### PR TITLE
Added new pair creation helper

### DIFF
--- a/util/plugins/eu.esdihumboldt.util/src/eu/esdihumboldt/util/Pair.java
+++ b/util/plugins/eu.esdihumboldt.util/src/eu/esdihumboldt/util/Pair.java
@@ -61,6 +61,18 @@ public class Pair<F, S> {
 	public S getSecond() {
 		return second;
 	}
+	
+	/**
+	 * Pair creation helper.
+	 * @param <F> the type of the first element in the pair
+	 * @param <S> the type of the second element
+	 * @param first the first object
+	 * @param second the second object
+	 * @return a new pair
+	 */
+	public static <F, S> Pair<F, S> make(F first, S second) {
+		return new Pair<F, S>(first, second);
+	}
 
 	/**
 	 * @see Object#hashCode()


### PR DESCRIPTION
Now you can type `Pair.make(a, b)` which is a lot shorter than `new Pair<Map<String, Object>, LazyDuplicatingTransformer>(a, b)`

I wanted to be first to make a pull request! I hope you're already prepared for this! :-)
