### PR TITLE
don't prefer default locale over root locale

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/AbstractCellExplanation.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/AbstractCellExplanation.java
@@ -273,7 +273,8 @@ public abstract class AbstractCellExplanation implements CellExplanation {
 	protected String getMessage(String key, Locale locale, Class<?> messageClass) {
 		return ResourceBundle
 				.getBundle(messageClass.getName(), locale, messageClass.getClassLoader(),
-						ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES))
+						ResourceBundle.Control
+								.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES))
 				.getString(key);
 	}
 
@@ -299,7 +300,8 @@ public abstract class AbstractCellExplanation implements CellExplanation {
 		return ResourceBundle
 				.getBundle(AbstractCellExplanation.class.getName(), locale,
 						AbstractCellExplanation.class.getClassLoader(),
-						ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES))
+						ResourceBundle.Control
+								.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES))
 				.getString(key);
 	}
 

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/mdexpl/MarkdownCellExplanation.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/mdexpl/MarkdownCellExplanation.java
@@ -118,7 +118,7 @@ public abstract class MarkdownCellExplanation extends AbstractCellExplanation {
 	private Optional<URL> findResource(Class<?> clazz, String baseName, String suffix,
 			Locale locale) {
 		ResourceBundle.Control control = ResourceBundle.Control
-				.getControl(ResourceBundle.Control.FORMAT_DEFAULT);
+				.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT);
 
 		List<Locale> candidateLocales = control.getCandidateLocales(baseName, locale);
 

--- a/cst/plugins/eu.esdihumboldt.cst.functions.custom/src/eu/esdihumboldt/hale/common/align/custom/DefaultCustomFunctionExplanation.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.custom/src/eu/esdihumboldt/hale/common/align/custom/DefaultCustomFunctionExplanation.java
@@ -109,7 +109,7 @@ public class DefaultCustomFunctionExplanation extends MarkdownCellExplanation
 
 	private Optional<Value> findTemplate(Locale locale) {
 		ResourceBundle.Control control = ResourceBundle.Control
-				.getControl(ResourceBundle.Control.FORMAT_DEFAULT);
+				.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT);
 
 		List<Locale> candidateLocales = control.getCandidateLocales("baseName", locale);
 


### PR DESCRIPTION
Fixes German content being used for English language if the default locale is German.