### PR TITLE
Do not rely on numberOfFeatures/numberMatched attributes

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/storage/StoreInstancesJob.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/storage/StoreInstancesJob.java
@@ -125,6 +125,7 @@ public abstract class StoreInstancesJob extends Job {
 			long lastUpdate = 0; // last count update
 
 			ResourceIterator<Instance> it = instances.iterator();
+			int size = instances.size();
 			try {
 				while (it.hasNext() && !monitor.isCanceled()) {
 					Instance instance = it.next();
@@ -161,7 +162,9 @@ public abstract class StoreInstancesJob extends Job {
 					long now = System.currentTimeMillis();
 					if (now - lastUpdate > 100) { // only update every 100
 													// milliseconds
-						monitor.subTask(String.valueOf(count) + " instances processed");
+						monitor.subTask(MessageFormat.format("{0}{1} instances processed",
+								String.valueOf(count), size != InstanceCollection.UNKNOWN_SIZE
+										? "/" + String.valueOf(size) : ""));
 						lastUpdate = now;
 					}
 				}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
@@ -25,6 +25,7 @@ import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
 import eu.esdihumboldt.hale.common.core.io.impl.AbstractIOProvider;
 import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
+import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier;
 import eu.esdihumboldt.hale.common.instance.io.InstanceReader;
 import eu.esdihumboldt.hale.common.instance.io.impl.AbstractInstanceReader;
@@ -132,6 +133,7 @@ public class StreamGmlReader extends AbstractInstanceReader {
 			// also give feedback to the user if the file can be loaded
 			reporter.setSuccess(true);
 		} catch (Throwable e) {
+			reporter.error(new IOMessageImpl(e.getMessage(), e));
 			reporter.setSuccess(false);
 		}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WFSException.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WFSException.groovy
@@ -15,13 +15,31 @@
 
 package eu.esdihumboldt.hale.io.gml.reader.internal.wfs
 
-import groovy.transform.InheritConstructors
-
 /**
  * Exception for exceptions during WFS communication
  * 
  * @author Florian Esser
  */
-@InheritConstructors
 class WFSException extends Exception {
+
+	public WFSException() {
+		super();
+	}
+
+	public WFSException(String message, Throwable cause, boolean enableSuppression,
+	boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public WFSException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WFSException(String message) {
+		super(message);
+	}
+
+	public WFSException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
@@ -274,11 +274,17 @@ public class WfsBackedGmlInstanceCollection implements InstanceCollection {
 		}
 	}
 
-	private int requestHits(URI requestUri) throws IOException, WFSException, URISyntaxException {
+	private int requestHits(URI requestUri) throws WFSException {
 		URIBuilder builder = new URIBuilder(requestUri);
 		builder.addParameter("RESULTTYPE", "hits");
 
-		InputStream in = builder.build().toURL().openStream();
+		InputStream in;
+		try {
+			in = builder.build().toURL().openStream();
+		} catch (IOException | URISyntaxException e) {
+			throw new WFSException(
+					MessageFormat.format("Unable to execute WFS request: {0}", e.getMessage()), e);
+		}
 
 		return FeatureCollectionHelper.getNumberOfFeatures(in);
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
@@ -252,7 +252,7 @@ public class WfsBackedGmlInstanceCollection implements InstanceCollection {
 	 */
 	@Override
 	public boolean isEmpty() {
-		return size > 0;
+		return size == 0;
 	}
 
 	/**


### PR DESCRIPTION
refs #188

- Use RESULTTYPE=hits query to determine total number of features but do not fail if WFS server does not include a numberOfFeatures/numberMatched attribute in its response
- While storing instances, use InstanceCollection.size() to display total number of features to the user if hasSize() is true
- In case of a communication/processing failure, report exception message

