### PR TITLE
incremental merging of instances

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/InstanceResolver.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/InstanceResolver.java
@@ -16,6 +16,10 @@
 
 package eu.esdihumboldt.hale.common.instance.model;
 
+import java.util.Collection;
+
+import eu.esdihumboldt.hale.common.instance.model.impl.ReferenceInstanceCollection;
+
 /**
  * Interface for instance resolvers, that allow getting a reference for an
  * instance and vice versa.
@@ -42,14 +46,21 @@ public interface InstanceResolver {
 	 */
 	public Instance getInstance(InstanceReference reference);
 
-	/*
-	 * TODO add method to get instances for multiple references? would allow to
-	 * optimize retrieval e.g. for GmlInstanceCollection
+	/**
+	 * Get an instance collection based on the given instance references.
 	 * 
-	 * best would be a list with preserved order, as this would allow
-	 * determining which instance belongs to which reference, as such allowing
-	 * dereferencing instances for a larger number of references, e.g. for
-	 * several instance sets/partitions
+	 * This method allows implementors to optimize retrieval of multiple
+	 * references, and to do a lazy resolving.
+	 * 
+	 * The default implementation delegates to
+	 * {@link #getInstance(InstanceReference)} in the iterator.
+	 * 
+	 * @param references the references to resolve
+	 * @return the instances collection based on the references
 	 */
+	default public InstanceCollection getInstances(
+			Collection<? extends InstanceReference> references) {
+		return new ReferenceInstanceCollection(references, this);
+	}
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/impl/ReferenceInstanceCollection.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/impl/ReferenceInstanceCollection.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.instance.model.impl;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import eu.esdihumboldt.hale.common.instance.model.Filter;
+import eu.esdihumboldt.hale.common.instance.model.Instance;
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.InstanceReference;
+import eu.esdihumboldt.hale.common.instance.model.InstanceResolver;
+import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
+
+/**
+ * Instance collection based on references.
+ * 
+ * @author Simon Templer
+ */
+public class ReferenceInstanceCollection implements InstanceCollection {
+
+	/**
+	 * Instance iterator based on instance references.
+	 * 
+	 * @param <X> the instance reference type
+	 */
+	private class ReferenceIterator<X extends InstanceReference>
+			extends GenericResourceIteratorAdapter<X, Instance> {
+
+		/**
+		 * Constructor.
+		 * 
+		 * @param iterator iterator on instances references
+		 */
+		public ReferenceIterator(Iterator<X> iterator) {
+			super(iterator);
+		}
+
+		@Override
+		protected Instance convert(X next) {
+			return instanceResolver.getInstance(next);
+		}
+
+	}
+
+	private final Collection<? extends InstanceReference> references;
+	private final InstanceResolver instanceResolver;
+
+	/**
+	 * Create an instance collection based on the given references.
+	 * 
+	 * @param references the instance references
+	 * @param instanceResolver the instance resolver
+	 */
+	public ReferenceInstanceCollection(Collection<? extends InstanceReference> references,
+			InstanceResolver instanceResolver) {
+		this.references = references;
+		this.instanceResolver = instanceResolver;
+	}
+
+	@Override
+	public InstanceReference getReference(Instance instance) {
+		// TODO instead have references associated to instances and retrieve
+		// those?
+		return new PseudoInstanceReference(instance);
+	}
+
+	@Override
+	public Instance getInstance(InstanceReference reference) {
+		if (reference instanceof PseudoInstanceReference) {
+			return ((PseudoInstanceReference) reference).getInstance();
+		}
+
+		return instanceResolver.getInstance(reference);
+	}
+
+	@Override
+	public ResourceIterator<Instance> iterator() {
+		return new ReferenceIterator<>(references.iterator());
+	}
+
+	@Override
+	public boolean hasSize() {
+		return true;
+	}
+
+	@Override
+	public int size() {
+		return references.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return references.isEmpty();
+	}
+
+	@Override
+	public InstanceCollection select(Filter filter) {
+		return FilteredInstanceCollection.applyFilter(this, filter);
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollection.java
@@ -762,6 +762,10 @@ public class GmlInstanceCollection implements InstanceCollection {
 				"Reference can only be determined based on a StreamGmlInstance");
 	}
 
+	/*
+	 * TODO optimize retrieval of multiple references
+	 */
+
 	/**
 	 * @see InstanceResolver#getInstance(InstanceReference)
 	 */

--- a/ui/plugins/eu.esdihumboldt.hale.ui.views.mapping/src/eu/esdihumboldt/hale/ui/views/mapping/MappingView.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.views.mapping/src/eu/esdihumboldt/hale/ui/views/mapping/MappingView.java
@@ -35,6 +35,8 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.WorkbenchPart;
 import org.eclipse.zest.core.viewers.GraphViewer;
+import org.eclipse.zest.layouts.LayoutAlgorithm;
+import org.eclipse.zest.layouts.algorithms.TreeLayoutAlgorithm;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -72,6 +74,8 @@ public class MappingView extends AbstractMappingView {
 	private AlignmentServiceListener alignmentListener;
 	private final Action showCellsOnChildren;
 
+	private ResizingTreeLayoutAlgorithm treeLayout;
+
 	/**
 	 * Default constructor.
 	 */
@@ -101,9 +105,14 @@ public class MappingView extends AbstractMappingView {
 				.setImageDescriptor(MappingViewPlugin.getImageDescriptor("icons/sub_co.gif"));
 	}
 
-	/**
-	 * @see eu.esdihumboldt.hale.ui.views.mapping.AbstractMappingView#createViewControl(org.eclipse.swt.widgets.Composite)
-	 */
+	@Override
+	protected LayoutAlgorithm createLayout() {
+		treeLayout = new ResizingTreeLayoutAlgorithm(TreeLayoutAlgorithm.RIGHT_LEFT,
+				new AlignmentViewResizingStrategy());
+
+		return treeLayout;
+	}
+
 	@Override
 	public void createViewControl(Composite parent) {
 		super.createViewControl(parent);


### PR DESCRIPTION
refs #225

Improves the memory consumption for large merges, especially if much of the data of the individual instances does not end up in the merged source instance.
Performance is likely lower than before, because the check if a value is unique now has to be done for each instance against all values that have been added before.

Changes the behavior of "auto-detect" slightly, with auto detect now for all properties only unique values are retained. As with the other aspects if the merge this is still restricted to first level properties.