### PR TITLE
Rename AssignReferencesFromCollector

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/functions/explanations/AssignExplanation.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/functions/explanations/AssignExplanation.java
@@ -16,10 +16,13 @@
 
 package eu.esdihumboldt.hale.common.align.model.functions.explanations;
 
+import java.util.Locale;
 import java.util.Map;
 
+import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.functions.AssignFunction;
 import eu.esdihumboldt.hale.common.align.model.impl.mdexpl.MarkdownCellExplanation;
+import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
 
 /**
  * Explanation for the assign function.
@@ -29,8 +32,9 @@ import eu.esdihumboldt.hale.common.align.model.impl.mdexpl.MarkdownCellExplanati
 public class AssignExplanation extends MarkdownCellExplanation implements AssignFunction {
 
 	@Override
-	protected void customizeBinding(Map<String, Object> binding) {
-		super.customizeBinding(binding);
+	protected void customizeBinding(Map<String, Object> binding, Cell cell, boolean html,
+			ServiceProvider provider, Locale locale) {
+		super.customizeBinding(binding, cell, html, provider, locale);
 
 		// to work with Assign and Bound assign both, add empty _source for
 		// Assign

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/mdexpl/MarkdownCellExplanation.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/mdexpl/MarkdownCellExplanation.java
@@ -178,7 +178,7 @@ public abstract class MarkdownCellExplanation extends AbstractCellExplanation {
 		addEntityBindings(binding, function.getTarget(), cell.getTarget(), "_target", html, locale);
 
 		// customization
-		customizeBinding(binding);
+		customizeBinding(binding, cell, html, provider, locale);
 
 		return binding;
 	}
@@ -201,7 +201,8 @@ public abstract class MarkdownCellExplanation extends AbstractCellExplanation {
 	 * 
 	 * @param binding the binding
 	 */
-	protected void customizeBinding(Map<String, Object> binding) {
+	protected void customizeBinding(Map<String, Object> binding, Cell cell, boolean html,
+			ServiceProvider provider, Locale locale) {
 		// override me
 	}
 

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/META-INF/MANIFEST.MF
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/META-INF/MANIFEST.MF
@@ -6,13 +6,17 @@ Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: wetransform GmbH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.google.common.collect;version="17.0.0",
+ de.fhg.igd.eclipse.util.extension,
  de.fhg.igd.slf4jplus,
  eu.esdihumboldt.cst,
  eu.esdihumboldt.cst.functions.core,
  eu.esdihumboldt.cst.functions.groovy.helpers,
  eu.esdihumboldt.cst.functions.groovy.helpers.util,
+ eu.esdihumboldt.hale.common.core,
  eu.esdihumboldt.hale.common.core.io,
+ eu.esdihumboldt.hale.common.core.parameter,
  eu.esdihumboldt.hale.common.core.report,
+ eu.esdihumboldt.hale.common.core.service,
  eu.esdihumboldt.hale.common.instance.groovy,
  eu.esdihumboldt.hale.common.instance.model,
  eu.esdihumboldt.hale.common.schema,
@@ -21,7 +25,8 @@ Import-Package: com.google.common.collect;version="17.0.0",
  eu.esdihumboldt.hale.common.schema.model.constraint.property,
  eu.esdihumboldt.hale.common.schema.model.constraint.property.factory,
  eu.esdihumboldt.hale.common.schema.model.constraint.type,
- eu.esdihumboldt.util.groovy.builder
+ eu.esdihumboldt.util.groovy.builder,
+ javax.annotation
 Require-Bundle: eu.esdihumboldt.hale.common.align;bundle-version="3.2.0",
  groovy;bundle-version="2.3.7"
 Export-Package: eu.esdihumboldt.cst.functions.collector

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/plugin.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="eu.esdihumboldt.hale.align.transformation">
       <propertyTransformation
-            class="eu.esdihumboldt.cst.functions.collector.AssignReferenceFromCollector"
+            class="eu.esdihumboldt.cst.functions.collector.AssignFromCollector"
             engine="eu.esdihumboldt.align.java"
             function="eu.esdihumboldt.cst.functions.collector.assign"
             id="eu.esdihumboldt.cst.functions.collector.assign">
@@ -16,9 +16,10 @@
             category="eu.esdihumboldt.hale.align.general"
             icon="icons/augmentation.gif"
             identifier="eu.esdihumboldt.cst.functions.collector.assign"
-            name="Assign collected references">
+            name="Assign collected values">
          <targetProperties>
             <property
+                  description="The property the collected values shall be assigned to"
                   eager="false"
                   maxOccurrence="1"
                   minOccurrence="1">
@@ -26,7 +27,7 @@
          </targetProperties>
          <functionParameter
                deprecated="false"
-               description="Name of the collector that contains the references"
+               description="Name of the collector that contains the values to be assigned"
                label="Collector name"
                maxOccurrence="1"
                minOccurrence="1"

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/plugin.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/plugin.xml
@@ -14,6 +14,7 @@
          point="eu.esdihumboldt.hale.align.function">
       <propertyFunction
             category="eu.esdihumboldt.hale.align.general"
+            cellExplanation="eu.esdihumboldt.cst.functions.collector.explanations.AssignFromCollectorExplanation"
             icon="icons/augmentation.gif"
             identifier="eu.esdihumboldt.cst.functions.collector.assign"
             name="Assign collected values">

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/AssignFromCollector.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/AssignFromCollector.java
@@ -43,15 +43,19 @@ import eu.esdihumboldt.hale.common.schema.model.constraint.property.Reference;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.HasValueFlag;
 
 /**
- * Function to assign references collected by a {@link Collector} to a
- * multi-valued target property. In case the target property cannot take the
- * values itself a child property is looked up to assign the references to.
+ * Function to assign values collected by a {@link Collector} to a multi-valued
+ * target property. In case the target property has the {@link Reference}
+ * constraint, the values are passed to {@link Reference#idToReference(Object)}
+ * before assignment.
+ * 
+ * If the target property cannot take the values itself, a child property with
+ * the {@link Reference} constraint is looked up to assign the values to.
  * 
  * @author Florian Esser
  */
-public class AssignReferenceFromCollector
+public class AssignFromCollector
 		extends AbstractSingleTargetPropertyTransformation<TransformationEngine>
-		implements AssignReferenceFromCollectorFunction {
+		implements AssignFromCollectorFunction {
 
 	private static final CollectorGroovyHelper helper = new CollectorGroovyHelper();
 

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/AssignFromCollectorFunction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/AssignFromCollectorFunction.java
@@ -20,7 +20,7 @@ package eu.esdihumboldt.cst.functions.collector;
  * 
  * @author Florian Esser
  */
-public interface AssignReferenceFromCollectorFunction {
+public interface AssignFromCollectorFunction {
 
 	/**
 	 * the function Id

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import eu.esdihumboldt.hale.common.align.model.Cell;
 import eu.esdihumboldt.hale.common.align.model.CellUtil;
-import eu.esdihumboldt.hale.common.align.model.ChildContext;
 import eu.esdihumboldt.hale.common.align.model.Entity;
 import eu.esdihumboldt.hale.common.align.model.impl.mdexpl.MarkdownCellExplanation;
 import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
@@ -46,9 +45,10 @@ public class AssignFromCollectorExplanation extends MarkdownCellExplanation {
 		binding.put("_isReference", false);
 
 		Entity entity = CellUtil.getFirstEntity(cell.getTarget());
-		if (entity != null) {
-			ChildContext childContext = entity.getDefinition().getPropertyPath().iterator().next();
-			PropertyDefinition resultProperty = childContext.getChild().asProperty();
+		if (entity != null
+				&& entity.getDefinition().getDefinition() instanceof PropertyDefinition) {
+			PropertyDefinition resultProperty = (PropertyDefinition) entity.getDefinition()
+					.getDefinition();
 			TypeDefinition resultPropertyType = resultProperty.getPropertyType();
 
 			boolean isReference = resultProperty.getConstraint(Reference.class).isReference();

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.cst.functions.collector.explanations;
+
+import java.util.Locale;
+import java.util.Map;
+
+import eu.esdihumboldt.hale.common.align.extension.function.FunctionDefinition;
+import eu.esdihumboldt.hale.common.align.extension.function.ParameterDefinition;
+import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ChildContext;
+import eu.esdihumboldt.hale.common.align.model.Entity;
+import eu.esdihumboldt.hale.common.align.model.impl.mdexpl.MarkdownCellExplanation;
+import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
+import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.Reference;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.HasValueFlag;
+
+/**
+ * Explanation for the Assign collected values function.
+ * 
+ * @author Florian Esser
+ */
+public class AssignFromCollectorExplanation extends MarkdownCellExplanation {
+
+	@Override
+	protected void customizeBinding(Map<String, Object> binding, Cell cell, boolean html,
+			ServiceProvider provider, Locale locale) {
+
+		FunctionDefinition<? extends ParameterDefinition> function = loadFunction(
+				cell.getTransformationIdentifier(), provider);
+
+		// Default values for all bindings
+		binding.put("_constraintsEvaluated", false);
+		binding.put("_hasValue", false);
+		binding.put("_isReference", false);
+
+		if (!function.getTarget().isEmpty() && !cell.getTarget().isEmpty()) {
+
+			ParameterDefinition parameterDefinition = function.getTarget().iterator().next();
+			Entity entity = cell.getTarget().get(parameterDefinition.getName()).iterator().next();
+			if (entity != null) {
+				ChildContext childContext = entity.getDefinition().getPropertyPath().iterator()
+						.next();
+				PropertyDefinition resultProperty = childContext.getChild().asProperty();
+				TypeDefinition resultPropertyType = resultProperty.getPropertyType();
+
+				boolean isReference = resultProperty.getConstraint(Reference.class).isReference();
+				binding.put("_isReference", isReference);
+
+				if (!isReference) {
+					boolean hasValue = resultPropertyType.getConstraint(HasValueFlag.class)
+							.isEnabled();
+					binding.put("_hasValue", hasValue);
+				}
+				else {
+					binding.put("_hasValue", true);
+				}
+
+				binding.put("_constraintsEvaluated", true);
+			}
+		}
+	}
+
+}

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.md
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation.md
@@ -1,0 +1,14 @@
+<%
+	if (!_constraintsEvaluated) {
+		out << "Assigns all values of the collector `$_params.collector` to the $_target property.\n\nIf the type of $_target is a reference type, the collected values will be converted to references before they are assigned.\n\nIn case the collected values cannot be assigned to $_target directly, a child attribute where references can be assigned is required. Then, for every collected value in the collector `$_params.collector` an instance of $_target is created and the value is assigned to the child attribute. If no such reference child attribute is found, the transformation will fail."
+	}
+	else if (_isReference) {
+		out << "Assigns all values of the collector `$_params.collector` to the $_target property as references.\n\nIf the collected values are valid XML Ids, they will be converted to local references by prepending the '#' character."
+	}
+	else if (_hasValue) {
+		out << "Assigns all values of the collector `$_params.collector` to the $_target property."
+	}
+	else {
+		out << "Assigns all values of the collector `$_params.collector` to a child property of $_target that can be assigned references (e.g. `href`).\n\nFor every collected value an instance of $_target is created and the value is assigned to the child property. If the collected values are valid XML Ids, they will be converted to local references by prepending the '#' character.\n\nIf there is no child property for references, the transformation will fail."
+	}
+%>

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation_de.md
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/src/eu/esdihumboldt/cst/functions/collector/explanations/AssignFromCollectorExplanation_de.md
@@ -1,0 +1,14 @@
+<%
+	if (!_constraintsEvaluated) {
+		out << "Weist dem Attribut $_target alle Werte des Collectors `$_params.collector` zu.\n\nFalls der Typ von $_target ein Referenztyp ist, werden die vom Collector gesammelten Werte vor ihrer Zuweisung in Referenzen umgewandelt.\n\nFalls das Attribut $_target die gesammelten Werte nicht selbst aufnehmen kann, muss ein Kind-Attribut existieren, das Referenzen aufnehmen kann. Es wird dann für jeden gesammelten Wert im Collectors `$_params.collector` eine Instanz von $_target erzeugt und der Wert dem Kind-Attribut zugewiesen. Gibt es kein passendes Kind-Attribut, schlägt die Transformation fehl."
+	}
+	else if (_isReference) {
+		out << "Weist dem Attribut $_target alle Werte des Collectors `$_params.collector` als Referenzen zu.\n\nWenn es sich bei den gesammelten Werten um gültige XML-Ids handelt, werden sie durch Voranstellen des Zeichens '#' in lokale Referenzen umgewandelt."
+	}
+	else if (_hasValue) {
+		out << "Weist dem Attribut $_target alle Werte des Collectors `$_params.collector` zu."
+	}
+	else {
+		out << "Weist einem Kind-Attribut von $_target, das Referenzen aufnehmen kann (z. B. falls vorhanden `href`), alle Werte des Collectors `$_params.collector` als Referenzen zu.\n\nEs wird für jeden gesammelten Wert im Collectors `$_params.collector` eine Instanz von $_target erzeugt und der Wert dem Kind-Attribut zugewiesen. Handelt es sich bei dem Wert um eine gültige XML-Id, wird er durch Voranstellen des Zeichens '#' in eine lokale Referenz umgewandelt.\n\nGibt es kein passendes Kind-Attribut, schlägt die Transformation fehl."
+	}
+%>


### PR DESCRIPTION
Rename to AssignFromCollector to better reflect what the function
actually does, as the function can assign collected values to any kind
of target property and is not limited to assigning references.