### PR TITLE
Fix master build / Prevent NPE in HeadlessIO

### DIFF
--- a/build/gradle/deployArtifacts.gradle
+++ b/build/gradle/deployArtifacts.gradle
@@ -194,6 +194,9 @@ repositories {
 	maven { // HALE artifactory
 		url 'http://artifactory.esdi-humboldt.eu/artifactory/libs-release/'
 	}
+	maven { // wetransform artifactory
+		url 'http://artifactory.wetransform.to/artifactory/libs-release/'
+	}
 	jcenter()
 	maven {
 		url 'http://download.osgeo.org/webdav/geotools/'

--- a/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/HeadlessIO.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/HeadlessIO.java
@@ -127,11 +127,11 @@ public abstract class HeadlessIO {
 
 		// ... and provider
 		IOProvider provider = loadProvider(conf);
-		if (serviceProvider != null) {
-			// set service provider, just in case the advisor does not do it
-			provider.setServiceProvider(serviceProvider);
-		}
 		if (provider != null) {
+			if (serviceProvider != null) {
+				// set service provider, just in case the advisor does not do it
+				provider.setServiceProvider(serviceProvider);
+			}
 			// execute provider
 			executeProvider(provider, advisor, null, reportHandler);
 			// XXX progress?!!


### PR DESCRIPTION
Add wetransform artifactory for dependency resolution. Also prevents NullPointerException in case `loadProvider` returns null.