### PR TITLE
allow null values in InstanceAccessor

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessorTest.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessorTest.groovy
@@ -88,6 +88,71 @@ class InstanceAccessorTest extends GroovyTestCase {
 		assertTrue instance.properties.relative.first() instanceof Instance
 	}
 
+	void testAccessNullProperties() {
+		// build instance (schema less)
+		Instance instance = new InstanceBuilder().instance { name null }
+
+		// test access of null property
+		assertNull new InstanceAccessor(instance, true).name.first()
+
+		// test access of null child property
+		assertNull new InstanceAccessor(instance, true).name.some.first()
+
+		def list = new InstanceAccessor(instance, true).name.list()
+		assertEquals(1, list.size())
+		assertNull(list[0])
+	}
+
+	void testNullProperties() {
+		// build instance (schema less)
+		Instance instance = new InstanceBuilder().instance { name null }
+
+		// test access of null property
+		assertNull new InstanceAccessor(instance).name.first()
+
+		// test access of null child property
+		assertNull new InstanceAccessor(instance).name.some.first()
+
+		def list = new InstanceAccessor(instance).name.list()
+		assertEquals(0, list.size())
+	}
+
+	void testNull() {
+		// test access on null object
+		assertNull new InstanceAccessor(null).name.first()
+
+		def list = new InstanceAccessor(null).name.list()
+		assertEquals(0, list.size())
+	}
+
+	void testNullMixed() {
+		// build instances (schema less)
+		Instance instance1 = new InstanceBuilder().instance { name 'Lisa' }
+		Instance instance2 = new InstanceBuilder().instance { name null }
+		Instance instance3 = new InstanceBuilder().instance { name 'Bart' }
+
+		def instances = [
+			instance1,
+			null,
+			instance2,
+			instance3,
+			null
+		]
+
+		// test access to first property
+		assertEquals 'Lisa', new InstanceAccessor(instances).name.first()
+
+		// list w/o null access
+		def list = new InstanceAccessor(instances).name.list()
+		assertEquals(2, list.size())
+		assertEquals('Lisa', list[0])
+		assertEquals('Bart', list[1])
+
+		// list w/ null access
+		def list2 = new InstanceAccessor(instances, true).name.list()
+		assertEquals(3, list2.size())
+	}
+
 	void testSchema() {
 		String defaultNs = "http://www.my.namespace"
 

--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/merge/PropertiesMergeHandler.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/merge/PropertiesMergeHandler.java
@@ -104,6 +104,7 @@ public class PropertiesMergeHandler
 
 		for (List<QName> propertyPath : mergeConfig.keyProperties) {
 			// retrieve values from instance
+			// XXX should nulls be listed?
 			InstanceAccessor accessor = new InstanceAccessor(instance);
 			for (QName name : propertyPath) {
 				accessor.findChildren(name.getLocalPart(),

--- a/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
@@ -47,14 +47,16 @@ public class PathWithNulls<C> implements Path<C> {
 	 * @param parent the parent element
 	 */
 	public PathWithNulls(C parent) {
-		this(Collections.singletonList(parent));
+		super();
+		this.path = Collections.singletonList(parent);
 	}
 
 	/**
 	 * Create an empty path.
 	 */
 	public PathWithNulls() {
-		this(ImmutableList.<C> of());
+		super();
+		this.path = ImmutableList.<C> of();
 	}
 
 	@Override

--- a/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Simon Templer
+ * Copyright (c) 2017 wetransform GmbH
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the GNU Lesser General Public License as
@@ -10,7 +10,7 @@
  * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
  * 
  * Contributors:
- *     Simon Templer - initial version
+ *     wetransform GmbH <http://www.wetransform.to>
  */
 
 package eu.esdihumboldt.util.groovy.paths;

--- a/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy/src/eu/esdihumboldt/util/groovy/paths/PathWithNulls.java
@@ -15,18 +15,19 @@
 
 package eu.esdihumboldt.util.groovy.paths;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
 /**
- * Path base implementation. This path implementation does not allow
- * <code>null</code> values as part of paths.
+ * Path implementation that supports .
  * 
  * @param <C> the child type
  * @author Simon Templer
  */
-public class PathImpl<C> implements Path<C> {
+public class PathWithNulls<C> implements Path<C> {
 
 	private final List<C> path;
 
@@ -35,9 +36,9 @@ public class PathImpl<C> implements Path<C> {
 	 * 
 	 * @param path the list of definitions defining the path
 	 */
-	public PathImpl(List<C> path) {
+	public PathWithNulls(List<C> path) {
 		super();
-		this.path = ImmutableList.copyOf(path);
+		this.path = Collections.unmodifiableList(new ArrayList<>(path));
 	}
 
 	/**
@@ -45,14 +46,14 @@ public class PathImpl<C> implements Path<C> {
 	 * 
 	 * @param parent the parent element
 	 */
-	public PathImpl(C parent) {
-		this(ImmutableList.<C> of(parent));
+	public PathWithNulls(C parent) {
+		this(Collections.singletonList(parent));
 	}
 
 	/**
 	 * Create an empty path.
 	 */
-	public PathImpl() {
+	public PathWithNulls() {
 		this(ImmutableList.<C> of());
 	}
 
@@ -63,13 +64,16 @@ public class PathImpl<C> implements Path<C> {
 
 	@Override
 	public Path<C> subPath(C child) {
-		return new PathImpl<C>(ImmutableList.<C> builder().addAll(path).add(child).build());
+		List<C> list = new ArrayList<>(path);
+		list.add(child);
+		return new PathWithNulls<C>(list);
 	}
 
 	@Override
 	public Path<C> subPath(Path<C> append) {
-		return new PathImpl<C>(
-				ImmutableList.<C> builder().addAll(path).addAll(append.getElements()).build());
+		List<C> list = new ArrayList<>(path);
+		list.addAll(append.getElements());
+		return new PathWithNulls<C>(list);
 	}
 
 }


### PR DESCRIPTION
Added two ways of dealing with nulls in InstanceAccessor:

- treat null values as non-existing values (default behavior)
- treat null values as they are and list them

There is no way though to discern no value and a null value even with the later setting, if the `first()` or `value()` access methods are used.