### PR TITLE
support for extra dependencies defined in manifest

### DIFF
--- a/build/gradle/deployArtifacts.gradle
+++ b/build/gradle/deployArtifacts.gradle
@@ -91,6 +91,36 @@ def findOtherMergedParts(java.util.jar.Manifest manifest) {
 }
 
 /**
+ * Add additional dependencies defined in the manifest.
+ */
+void addMoreDependencies(def pom, java.util.jar.Manifest manifest) {
+	def deps = manifest?.attr?.getValue('Unpuzzle-AddDependencies')
+	if (deps) {
+		deps.split(',').each { depStr ->
+			def parts = depStr.split(';')
+			
+			if (parts.length >= 3) {
+				def group = parts[0]
+				def name = parts[1]
+				def version = parts[2]
+				
+				println "Adding additional dependency $group:$name:$version"
+				
+				// add custom dependency
+				pom.dependencyBundles << new org.akhikhl.unpuzzle.osgi2maven.DependencyBundle(
+					// add prefix to be able to identify the dependeny for configuration
+					group: '___more___' + group,
+					name: name,
+					version: version,
+					// not sure what this is for
+					// visibility: 'private',
+					resolution: 'mandatory')
+			}
+		}
+	}
+}
+
+/**
  * Find the artifact version to use from a version mapping part of
  * the bundle artifact map.
  */
@@ -291,12 +321,24 @@ unpuzzle {
 				// add "other parts" if bundle was merged with bnd-platform
 				otherParts.addAll(findOtherMergedParts(pom.manifest));
 			}
+			else if (group.startsWith('___more___')) {
+				// custom dependency defined via manifest
+				
+				// remove prefix
+				group = group.substring('___more___'.length())
+				
+				// do not deploy dependency (this should always be an existing Maven dependency)
+				deploy = false
+			}
 			else {
 				// Eclipse-provided or HALE-built bundle
 			
 				// for HALE-built bundles, adapt version number as SNAPSHOT/release
 				version = adaptHaleBundleVersion(version)
 			}
+			
+			// add custom dependencies defined in manifest
+			addMoreDependencies(pom, pom.manifest)
 		}
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.schematron/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.schematron/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Import-Package: eu.esdihumboldt.hale.common.instance.io,
  eu.esdihumboldt.hale.util.nonosgi.contenttype.describer,
  eu.esdihumboldt.util.io
 Export-Package: eu.esdihumboldt.hale.io.schematron.validator
+Unpuzzle-AddDependencies: org.opengis.cite;schema-utils;1.8
 Bundle-ClassPath: .,
  lib/saxon9-9.0.0.8.jar,
  lib/schema-utils-1.8.jar,


### PR DESCRIPTION
...to be able to have correct dependencies for Maven artifacts of bundles
that bundle libraries internally.

Added extra dependency for schematron bundle.

As a result it should be possible to remove the `org.opengis.cite:schema-utils:1.8` dependency in https://github.com/halestudio/hale-cli/pull/24.