### PR TITLE
Prevent static compile errors

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/GeometryHelperFunctions.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/GeometryHelperFunctions.groovy
@@ -90,7 +90,7 @@ class GeometryHelperFunctions {
 			return null;
 		}
 
-		if (!result.geometry || result.geometry.isEmpty()) {
+		if (!result.geometry || ((Geometry)result.geometry).isEmpty()) { // Explicit cast to circumvent type inferring problems of Groovy 2.3.11
 			return null;
 		}
 
@@ -117,7 +117,7 @@ class GeometryHelperFunctions {
 	static GeometryProperty<? extends Geometry> _interiorPoint(def geometryHolder) {
 		GeometryProperty<?> result = InteriorPoint.calculateInteriorPoint(geometryHolder);
 
-		if (!result.geometry || result.geometry.isEmpty()) {
+		if (!result.geometry || ((Geometry)result.geometry).isEmpty()) { // Explicit cast to circumvent type inferring problems of Groovy 2.3.11
 			return null;
 		}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriterTest2.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriterTest2.groovy
@@ -182,7 +182,7 @@ class StreamGmlWriterTest2 {
 		Collection<GeometryProperty<?>> geomsOther = GeometryUtil.getAllGeometries(other);
 		assertEquals(1, geomsOther.size())
 
-		StreamGmlWriterTest.matchGeometries(expected, geomsOther[0].geometry)
+		StreamGmlWriterTest.matchGeometries(expected, geomsOther[0].getGeometry()) // using getter instead of property circumvents type inferring problems of Groovy 2.3.11
 	}
 
 	@CompileStatic


### PR DESCRIPTION
Groovy compiler complains about accessing methods of  the `geometry`property of
methods returning `GeometryProperty<?>`.

An alternative solution where we would be able to keep the `@CompileStatic`s would 
be to let all relevant methods return `GeometryProperty<? extends Geometry>`
instead.