### PR TITLE
improve handling of loaded reports

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/writer/ReportReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/writer/ReportReader.java
@@ -243,7 +243,9 @@ public class ReportReader {
 		try {
 			id = Long.parseLong(result);
 		} catch (NumberFormatException e) {
-			_log.error("Could not determine ReportSession ID.");
+			_log.debug("Could not determine ReportSession ID, using current timestamp.");
+			// XXX improvement would be determining the session ID from the file
+			// content
 		}
 
 		return id;

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/writer/ReportReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/writer/ReportReader.java
@@ -41,6 +41,11 @@ import eu.esdihumboldt.hale.common.core.report.ReportSession;
  */
 public class ReportReader {
 
+	/**
+	 * Identifier for unknown report sessions.
+	 */
+	public static final long UNKNOWN_SESSION = 0;
+
 	private final ReportFactory rf = ReportFactory.getInstance();
 	private final MessageFactory mf = MessageFactory.getInstance();
 	private static final ALogger _log = ALoggerFactory.getLogger(ReportReader.class);
@@ -239,7 +244,7 @@ public class ReportReader {
 			result = name[0];
 		}
 
-		long id = 0;
+		long id = UNKNOWN_SESSION;
 		try {
 			id = Long.parseLong(result);
 		} catch (NumberFormatException e) {

--- a/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportListLabelProvider.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportListLabelProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 
 import eu.esdihumboldt.hale.common.core.report.Report;
 import eu.esdihumboldt.hale.common.core.report.ReportSession;
+import eu.esdihumboldt.hale.common.core.report.writer.ReportReader;
 
 /**
  * LabelProvider for {@link ReportList}.
@@ -94,7 +95,8 @@ public class ReportListLabelProvider extends LabelProvider {
 		}
 		else if (element instanceof ReportSession) {
 			long id = ((ReportSession) element).getId();
-			if (id == 0) {
+			if (id == ReportReader.UNKNOWN_SESSION) {
+				// session information is not present usually for imported logs
 				return "Import";
 			}
 			return df.format(new Date(id));

--- a/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportListLabelProvider.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportListLabelProvider.java
@@ -37,8 +37,8 @@ import eu.esdihumboldt.hale.common.core.report.ReportSession;
  */
 public class ReportListLabelProvider extends LabelProvider {
 
-	private Map<ImageDescriptor, Image> imageCache = new HashMap<ImageDescriptor, Image>();
-	private SimpleDateFormat df = new SimpleDateFormat("HH:mm yyyy-MM-dd");
+	private final Map<ImageDescriptor, Image> imageCache = new HashMap<ImageDescriptor, Image>();
+	private final SimpleDateFormat df = new SimpleDateFormat("HH:mm yyyy-MM-dd");
 
 	/**
 	 * @see org.eclipse.jface.viewers.IBaseLabelProvider#dispose()
@@ -93,7 +93,11 @@ public class ReportListLabelProvider extends LabelProvider {
 			return ((Report<?>) element).getTaskName();
 		}
 		else if (element instanceof ReportSession) {
-			return df.format(new Date(((ReportSession) element).getId()));
+			long id = ((ReportSession) element).getId();
+			if (id == 0) {
+				return "Import";
+			}
+			return df.format(new Date(id));
 		}
 
 		return "Unhandled type";
@@ -109,8 +113,8 @@ public class ReportListLabelProvider extends LabelProvider {
 	protected Image getImage(String img) {
 		ImageDescriptor descriptor = null;
 
-		descriptor = AbstractUIPlugin.imageDescriptorFromPlugin(
-				"eu.esdihumboldt.hale.ui.views.report", img);
+		descriptor = AbstractUIPlugin
+				.imageDescriptorFromPlugin("eu.esdihumboldt.hale.ui.views.report", img);
 		if (descriptor == null) {
 			return null;
 		}


### PR DESCRIPTION
- Being unable to determine a report session ID from a file name is not an error
- Don't use formatted date for report session with ID/timestamp 0