### PR TITLE
Make SNAPSHOT dependencies resolvable in master build

### DIFF
--- a/build/gradle/deployArtifacts.gradle
+++ b/build/gradle/deployArtifacts.gradle
@@ -227,6 +227,9 @@ repositories {
 	maven { // wetransform artifactory
 		url 'http://artifactory.wetransform.to/artifactory/libs-release/'
 	}
+	maven { // wetransform artifactory (snapshots)
+		url 'http://artifactory.wetransform.to/artifactory/libs-snapshot/'
+	}
 	jcenter()
 	maven {
 		url 'http://download.osgeo.org/webdav/geotools/'


### PR DESCRIPTION
With SNAPSHOT dependencies the `:uploadEclipse` stage fails because those dependencies cannot be resolved.