### PR TITLE
Remove plugin e.e.h.ui.templates from UI feature

### DIFF
--- a/ui/features/eu.esdihumboldt.hale.ui.feature/feature.xml
+++ b/ui/features/eu.esdihumboldt.hale.ui.feature/feature.xml
@@ -64,13 +64,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="eu.esdihumboldt.hale.ui.templates"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="eu.esdihumboldt.hale.ui.schema.presets"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Remove `Load project from template...` funcionality in the course of
hale connect integration (see #293).