### PR TITLE
Replace "HALE" with "hale studio" or "hale" in documentation

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.groovy/help/common.xhtml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.groovy/help/common.xhtml
@@ -298,7 +298,7 @@
 	<!-- Helper functions -->
 	<div id="helper-functions">
 		<h2>Helper Functions</h2>
-		<p>HALE provides the possibility to extend it with helper
+		<p><i>hale studio</i> provides the possibility to extend it with helper
 			functions that can be conveniently called from Groovy scripts. An
 			overview on the available functions can be found in the functions
 			tray (see below). Select an individual function to get detailed

--- a/doc/plugins/eu.esdihumboldt.cst.doc.functions.dummy/html/functions.html
+++ b/doc/plugins/eu.esdihumboldt.cst.doc.functions.dummy/html/functions.html
@@ -10,7 +10,7 @@
 		<img src="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/images/warning.gif">
 		<strong>Sorry, but the Functions reference is not available in the online
 		documentation.</strong><br><br>Please have a look at the documentation
-		provided with your version of HALE to get detailed information about the
+		provided with your version of <i>hale studio</i> to get detailed information about the
 		available transformation functions.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/contact.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/contact.html
@@ -5,7 +5,7 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - Point of Contact</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - Point of Contact</title>
 </head>
 <body>
 	<h1>Point of Contact</h1> 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/future.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/future.html
@@ -5,17 +5,17 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - Future plans</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - Future plans</title>
 </head>
 <body>
 	<h1>Future plans</h1>
 
 	<p>
-	There are already plans to extend the HALE App-Schema plug-in in several respects:
+	There are already plans to extend the <i>hale studio</i> App-Schema plug-in in several respects:
 	</p>
 	
 	<ul>
-	<li>out of the box support for more HALE transformation functions</li>
+	<li>out of the box support for more <i>hale studio</i> transformation functions</li>
 	<li>support for conditional mappings via property filters</li>
 	<li>support for a greater number of datastore types</li>
 	<li>definition of configuration profiles to persist settings between exports</li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/introduction/intro.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/introduction/intro.html
@@ -26,7 +26,7 @@
 
 	<p>
 	The <strong>GeoServer App-Schema Plug-in for hale studio</strong> brings the possibility to convert 
-	a <i>hale studio</i> alignment to a GeoServer App-Schema mapping configuration. Once uploaded to a live 
+	a <i>hale</i> alignment to a GeoServer App-Schema mapping configuration. Once uploaded to a live 
 	GeoServer instance, this configuration will enable WMS / WFS access to the transformed GML data.
 	</p>
 
@@ -42,7 +42,7 @@
 	<h2>Known limitations</h2>
 
 	<p>
-	At this stage, not every single <i>hale studio</i> function can be automatically translated to App-Schema
+	At this stage, not every single <i>hale</i> function can be automatically translated to App-Schema
 	mapping directives.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/introduction/intro.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/introduction/intro.html
@@ -5,10 +5,10 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>Introduction to the GeoServer App-Schema Plug-in for HALE</title>
+<title>Introduction to the GeoServer App-Schema Plug-in for hale studio</title>
 </head>
 <body>
-	<h1>GeoServer App-Schema Plug-in for HALE</h1>
+	<h1>GeoServer App-Schema Plug-in for hale studio</h1>
 
 	<p>
 	<strong><a href="http://geoserver.org/" target="_blank">GeoServer</a></strong> is an open source
@@ -25,15 +25,15 @@
 	</p>
 
 	<p>
-	The <strong>GeoServer App-Schema Plug-in for HALE</strong> brings the possibility to convert 
-	a HALE alignment to a GeoServer App-Schema mapping configuration. Once uploaded to a live 
+	The <strong>GeoServer App-Schema Plug-in for hale studio</strong> brings the possibility to convert 
+	a <i>hale studio</i> alignment to a GeoServer App-Schema mapping configuration. Once uploaded to a live 
 	GeoServer instance, this configuration will enable WMS / WFS access to the transformed GML data.
 	</p>
 
 	<h2>Installation requirements</h2>
 
 	<p>
-	The plug-in is already bundled in the standard HALE distribution, starting from version 2.9.4.
+	The plug-in is already bundled in the standard <i>hale studio</i> distribution, starting from version 2.9.4.
 	A <a href="http://geoserver.org/release/stable/" target="_blank">recent GeoServer version</a>
 	(2.8.0+) is required. Note that the App-Schema extension is not part of the standard GeoServer 
 	distribution and must be <a href="http://sourceforge.net/projects/geoserver/files/GeoServer/2.8.0/extensions/geoserver-2.8.0-app-schema-plugin.zip" target="_blank">downloaded separately</a>.
@@ -42,7 +42,7 @@
 	<h2>Known limitations</h2>
 
 	<p>
-	At this stage, not every single HALE function can be automatically translated to App-Schema
+	At this stage, not every single <i>hale studio</i> function can be automatically translated to App-Schema
 	mapping directives.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/compatibility.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/compatibility.html
@@ -5,7 +5,7 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - GeoServer compatibility mode</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - GeoServer compatibility mode</title>
 </head>
 <body>
 	<h1>GeoServer compatibility mode</h1>
@@ -13,7 +13,7 @@
 	<div style="width: 60%; float: left;">
 		<p>
 		To help the user discern which functions are compatible with App-Schema and which are not, a 
-		GeoServer compatibility mode has been added to HALE. Once the mode is activated, the mapping 
+		GeoServer compatibility mode has been added to hale studio. Once the mode is activated, the mapping 
 		function selection menu in the schema explorer view will only list the functions which are 
 		compatible with the GeoServer App-Schema extension, and a red cross will appear at the bottom 
 		right corner of the window if the alignment cannot be automatically translated to an App-Schema 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/export.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/export.html
@@ -5,7 +5,7 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - Export the App-Schema Configuration</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - Export the App-Schema Configuration</title>
 </head>
 <body>
 	<h1>Export the App-Schema mapping configuration</h1>
@@ -109,7 +109,7 @@
 	</p>
 
 	<p>
-	The HALE Join relation does provide for 1., but not for 2. This is the reason why a additional configuration
+	The hale Join relation does provide for 1., but not for 2. This is the reason why a additional configuration
 	is required to make Feature Chaining function properly.
 	</p>
 
@@ -167,7 +167,7 @@
 	<p>
 	The App-Schema mapping file requires that data sources be specified in the <em>sourceDataStores</em> section.
 	Although the GeoServer App-Schema extension supports a variety of data store types and multiple data
-	store configurations, the HALE App-Schema plug-in only allows to configure a single PostGIS data store.
+	store configurations, the <i>hale studio</i> App-Schema plug-in only allows to configure a single PostGIS data store.
 	This limitation will likely be removed (or at least alleviated) in future releases of the plugin.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/hale_vs_appschema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/hale_vs_appschema.html
@@ -5,12 +5,12 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - HALE vs. App-Schema</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - hale vs. App-Schema</title>
 </head>
 <body>
-	<h1>HALE vs. App-Schema</h1>
+	<h1>hale vs. App-Schema</h1>
 
-	This section will go into more detail on points where the behavior of App-Schema differs from HALE's.
+	This section will go into more detail on points where the behavior of App-Schema differs from hale's.
 
 	<h2>Feature Type mappings</h2>
 
@@ -39,9 +39,9 @@
 
 	<a name="join"></a>
 	<p>
-	Note that a <strong>Join</strong> is handled differently in HALE and App-Schema:
+	Note that a <strong>Join</strong> is handled differently in hale and App-Schema:
 	<ul>
-	<li>In HALE, multiple source types are fused into a target type</li>
+	<li>In hale, multiple source types are fused into a target type</li>
 	<li>In App-Schema, each single source type is mapped to a different target type, then target types are
 	further composed to form more complex types via feature chaining. In this way, each target feature type
 	retains its identity and can be queried separately (via WFS, for example).</li>
@@ -49,7 +49,7 @@
 	</p>
 
 	<p>
-	It is also worth mentioning that, although in HALE multiple join conditions can be specified for each source type,
+	It is also worth mentioning that, although in hale multiple join conditions can be specified for each source type,
 	App-Schema only supports single-condition joins; thus, in order to be translateable to a GeoServer
 	App-Schema configuration, an alignment should not contain more than one join condition for the same source type.
 	<br>See the section on <a href="./export.html#chaining">Feature Chaining</a> for more details.
@@ -87,9 +87,9 @@
 	</p>
 
 	<p>
-	This is another important point where HALE and App-Schema differ:
+	This is another important point where hale and App-Schema differ:
 	<ul>
-	<li>In HALE, the number of target instances is a function of the relation between source and target
+	<li>In hale, the number of target instances is a function of the relation between source and target
 	types</li>
 	<li>In App-Schema, the number of target instances is a function of the gml:id mapping</li>
 	</ul>
@@ -97,8 +97,8 @@
 
 	<p>
 	This is particularly relevant when translating an alignment that contains one or more <strong><em>Merge</em></strong> relations.
-	To reproduce the same behavior in HALE and App-Schema, the user needs to construct the <strong>gml:id</strong> from
-	a combination of the source properties configured as the properties to merge on in HALE (e.g. using
+	To reproduce the same behavior in hale and App-Schema, the user needs to construct the <strong>gml:id</strong> from
+	a combination of the source properties configured as the properties to merge on in hale (e.g. using
 	a Formatted String transformation).
 	</p>
 
@@ -107,7 +107,7 @@
 	<p>
 	Special care should be taken when the target of a property relation is a geometry. For ordinary GML
 	geometry properties (i.e. whose type inherits from <em>gml:GeometryPropertyType</em>), the mapping
-	in both HALE and App-Schema is as simple as defining a <em>Rename</em> relation between the source
+	in both hale and App-Schema is as simple as defining a <em>Rename</em> relation between the source
 	property (be it a geometry column in a database, or a geometric attribute in a shapefile) and the
 	target property.
 	</p>
@@ -124,7 +124,7 @@
 	<p>
 	Another point that deserves attention is the generation of GML IDs for geometries.
 	In GML 3.x, all geometries must have a <strong>gml:id</strong> attribute, even though often its actual
-	value is of no interest to the user. HALE satisfies this requirement by automatically generating
+	value is of no interest to the user. hale satisfies this requirement by automatically generating
 	GML IDs on data export. However, the App-Schema plug-in requires an explicit mapping for the geometry's
 	<strong>gml:id</strong> attribute to generate a correct App-Schema configuration. This limitation
 	will likely be removed in a future release.
@@ -139,14 +139,14 @@
 	</p>
 
 	<p>
-	If no mapping is present in the alignment for a nillable mandatory element, upon data export HALE
+	If no mapping is present in the alignment for a nillable mandatory element, upon data export hale
 	automatically creates an empty element with an <em>xsi:nil="true"</em> attribute. On the contrary,
 	App-Schema does not handle this situation automatically, but requires the user to explicitly map
 	the <em>xsi:nil</em> attribute in the configuration file.
 	</p>
 
 	<p>
-	The App-Schema plug-in for HALE strives to alleviate this nuisance by tuning the generated Attribute
+	The App-Schema plug-in for hale strives to alleviate this nuisance by tuning the generated Attribute
 	Mappings of nillable elements for which a mapping has been defined in the alignment. The tuning
 	results in an <em>xsi:nil="true"</em> attribute being automatically added to the element when it has no value.
 	</p>
@@ -154,7 +154,7 @@
 	<p>
 	However, this only applies to mapped elements. For nillable elements that do not participate in the
 	alignment, the user is required to provide a mapping, to make the generation of the necessary
-	App-Schema configuration possible. HALE does not allow to map the <em>xsi:nil</em> attribute directly,
+	App-Schema configuration possible. hale does not allow to map the <em>xsi:nil</em> attribute directly,
 	so the plug-in relies on the <em>nilReason</em> attribute: if a mapping exists for the <em>nilReason</em>
 	attribute of a nillable element, the generated Attribute Mapping is altered so that an <em>xsi:nil="true"</em>
 	attribute will appear on the element when a value exists for the <em>nilReason</em> attribute.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/usage_intro.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/html/usage/usage_intro.html
@@ -5,25 +5,25 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>GeoServer App-Schema Plug-in for HALE - Usage</title>
+<title>GeoServer App-Schema Plug-in for <i>hale studio</i> - Usage</title>
 </head>
 <body>
 	<h1>Usage</h1>
 
 	<p>
-	The plug-in has been designed to have as little impact on the regular HALE user as possible, so
-	the basic workflow to produce a HALE alignment still applies.
+	The plug-in has been designed to have as little impact on the regular <i>hale studio</i> user as possible, so
+	the basic workflow to produce a <i>hale</i> alignment still applies.
 	</p>
 
 	<p>
-	This section does not aim to be a comprehensive tutorial on HALE or GeoServer; instead, it assumes
-	the user has at least some familiarity with both HALE and GeoServer App-Schema and focuses on
-	describing the core functionality of the plug-in, how it affects ordinary HALE usage, how a
-	mapping behaves differently for App-Schema than in HALE and what users should pay attention to.
+	This section does not aim to be a comprehensive tutorial on <i>hale studio</i> or GeoServer; instead, it assumes
+	the user has at least some familiarity with both <i>hale studio</i> and GeoServer App-Schema and focuses on
+	describing the core functionality of the plug-in, how it affects ordinary <i>hale studio</i> usage, how a
+	mapping behaves differently for App-Schema than in <i>hale</i> and what users should pay attention to.
 	</p>
 
 	<p>
-	For a more entry level tutorial, covering also the basics of setting up a HALE project and providing
+	For a more entry level tutorial, covering also the basics of setting up a <i>hale</i> project and providing
 	some real world mapping examples, please refer to the <a href="http://geoserver.geo-solutions.it/complexfeatures/index.html" target="_blank">Complex Features Training</a>
 	from <a href="http://www.geo-solutions.it/" target="_blank">GeoSolutions</a>. The training materials
 	can be downloaded <a href="http://geoserver.geo-solutions.it/downloads/training/windows/complexfeatures/Training-ComplexFeatures-2.8.X-32-V1.zip" target="_blank">here</a>.
@@ -32,7 +32,7 @@
 	<h2>Basic workflow</h2>
 
 	<ol>
-	<li>Create a new HALE project and <a class="command-link" href='javascript:liveAction("eu.esdihumboldt.hale.ui.firststeps",
+	<li>Create a new <i>hale</i> project and <a class="command-link" href='javascript:liveAction("eu.esdihumboldt.hale.ui.firststeps",
 			"eu.esdihumboldt.hale.ui.firststeps.ImportAction", "eu.esdihumboldt.hale.io.schema.read.source")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png" alt="command link">import source</a> and
 			<a class="command-link" href='javascript:liveAction("eu.esdihumboldt.hale.ui.firststeps",

--- a/doc/plugins/eu.esdihumboldt.hale.doc.appschema/toc.xml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.appschema/toc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<toc label="GeoServer App-Schema Plug-in for HALE">
+<toc label="GeoServer App-Schema Plug-in for hale">
    <topic href="html/introduction/intro.html" label="Introduction">
       <anchor id="introduction"/>
    </topic>
@@ -8,7 +8,7 @@
       </topic>
       <topic href="html/usage/export.html" label="Export the App-Schema Configuration">
       </topic>
-      <topic href="html/usage/hale_vs_appschema.html" label="HALE vs. App-Schema">
+      <topic href="html/usage/hale_vs_appschema.html" label="hale vs. App-Schema">
       </topic>
       <anchor id="usage"/>
    </topic>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.dev/toc.xml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.dev/toc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<toc label="HALE Developer Guide">
+<toc label="hale studio Developer Guide">
    <topic label="Getting Started">
-      <topic href="http://www.esdi-community.eu/projects/hale/wiki/How_to_access_the_HALE_sources" label="How to access the HALE sources">
+      <topic href="https://github.com/halestudio/hale/wiki/Set-up-your-development-environment" label="How to access the hale studio sources">
       </topic>
    </topic>
    <topic label="Concepts">

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user.examples/src/eu/esdihumboldt/hale/doc/user/examples/internal/content/overview.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user.examples/src/eu/esdihumboldt/hale/doc/user/examples/internal/content/overview.html
@@ -10,8 +10,8 @@
 
 	<p>
 		Following is a list of example projects that are shipped with your
-		version of HALE. You can load them in HALE and experiment with them.
-		To save your work based on an example project, save the project as a <i>HALE
+		version of <i>hale studio</i>. You can load them in <i>hale studio</i> and experiment with them.
+		To save your work based on an example project, save the project as a <i>hale
 			project archive</i>.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user.examples/src/eu/esdihumboldt/hale/doc/user/examples/internal/content/overview.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user.examples/src/eu/esdihumboldt/hale/doc/user/examples/internal/content/overview.html
@@ -42,9 +42,10 @@
 	</table>
 
 	<p class="Note">We are always looking for data we can include as
-		examples in HALE. If you know any suitable open data or are a data
-		provider that could provide sample data for this purpose, please
-		contact us - also concerning support for the mapping creation.</p>
+		examples in <i>hale studio</i>. If you know any suitable open data 
+		or are a data provider that could provide sample data for this 
+		purpose, please contact us - also concerning support for the mapping 
+		creation.</p>
 
 </body>
 </html>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user.ioproviders/src/eu/esdihumboldt/hale/doc/user/ioproviders/content/overview.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user.ioproviders/src/eu/esdihumboldt/hale/doc/user/ioproviders/content/overview.html
@@ -8,14 +8,14 @@
 	<h1>Reference on ${providerType}s</h1>
 	<p>
 		This is a reference documentation of I/O providers of type
-		$providerType in HALE. Usually you will not need this reference, as in
-		HALE the configuration of I/O providers is done via the respective
+		$providerType in hale studio. Usually you will not need this reference, as in
+		<i>hale studio</i> the configuration of I/O providers is done via the respective
 		wizards for import and export. Where this reference can come in handy
 		is if you want launch a <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html">transformation
 			via the command line</a>.
 	</p>
-	<h2>${providerType}s in this version of HALE (can be extended through plugins)</h2>
+	<h2>${providerType}s in this version of <i>hale studio</i> (can be extended through plugins)</h2>
 	<ul>
 		#foreach ($provider in $providers)
 			<li><a href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user.ioproviders/ioproviders/${provider.identifier}.html">$provider.displayName</a></li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user.ioproviders/src/eu/esdihumboldt/hale/doc/user/ioproviders/content/provider.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user.ioproviders/src/eu/esdihumboldt/hale/doc/user/ioproviders/content/provider.html
@@ -9,8 +9,8 @@
 	<h1>$descriptor.displayName</h1>
 	<p>
 		This is a reference documentation of the $descriptor.displayName
-		$providerType in HALE. Usually you will not need this reference, as in
-		HALE the configuration of I/O providers is done via the respective
+		$providerType in hale studio. Usually you will not need this reference, as in
+		<i>hale studio</i> the configuration of I/O providers is done via the respective
 		wizards for import and export. Where this reference can come in handy
 		is if you want launch a <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html">transformation

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/functions.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/functions.html
@@ -20,9 +20,9 @@
 		parameters.
 	</p>
 	<p class="Note">
-		<strong>Note:</strong> The functions available in HALE represent only
+		<strong>Note:</strong> The functions available in <i>hale studio</i> represent only
 		a small subset of possible relations - if you find that you are not
-		able to express a relation through the given functions, HALE offers an
+		able to express a relation through the given functions, <i>hale studio</i> offers an
 		extension point to integrate additional functions.
 	</p>
 	<p>There are two basic types of functions, functions that represent
@@ -32,7 +32,7 @@
 	<p>A type relation describes how types from the source schema are
 		to be translated to a type in the target schema.</p>
 	<p>
-		The most simple type relation in <i>HALE</i> is represented by the <a
+		The most simple type relation in <i>hale studio</i> is represented by the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.cst.doc.functions/functions/eu.esdihumboldt.hale.align.retype.html">Retype</a>
 		function, which expresses that a source and target type are
 		semantically equal. For the transformation this means that for each

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/what_is_instance.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/what_is_instance.html
@@ -21,7 +21,7 @@
 		<img src="images/instance.png" class="fit">
 	</div>
 	<p>
-		When loading a source data set in <i>HALE</i>, the data is partitioned
+		When loading a source data set in <i>hale studio</i>, the data is partitioned
 		into instances. Those instances can be inspected in the <a
 			href="../views/source_data.html">Source Data</a> view. When a
 		mapping/alignment is defined, the transformation is executed on the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/what_is_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/concepts/what_is_schema.html
@@ -21,10 +21,10 @@
 			</ul></li>
 	</ul>
 	<p>
-		In <i>HALE</i> we define the schema mapping on the conceptual level,
+		In <i>hale studio</i> we define the schema mapping on the conceptual level,
 		between classes/types and properties. For the complete transformation
 		process however, information about the data format is needed. The
-		approach used in <i>HALE</i> can deal with both kinds of schemas,
+		approach used in <i>hale studio</i> can deal with both kinds of schemas,
 		abstracting a conceptual view for logical schemas, while using the
 		information from the logical schema for the transformation process.
 		For conceptual schemas, no transformation can be applied, but the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/contributors.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/contributors.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Contributors</h1>
-	<p>Thanks to all who contributed to make HALE what it is!</p>
+	<p>Thanks to all who contributed to make <i>hale studio</i> what it is!</p>
 	<div>
 		<table class="contributors">
 			<tr>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/confWorkbench.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/confWorkbench.html
@@ -7,14 +7,14 @@
 <body>
 	<h1>Configuring your workbench</h1>
 	<p>
-		When you start <i>HALE</i> the first time, it will present you with
+		When you start <i>hale studio</i> the first time, it will present you with
 		the <i>First steps</i> welcome page. It offers you to load an existing
 		project or to continue with the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with HALE</a>
+			alt="command link">Get started with hale studio</a>
 		guide. After choosing either of those options the welcome page is
-		replaced with the <i>HALE</i> workbench. You can also close the
+		replaced with the <i>hale studio</i> workbench. You can also close the
 		welcome page manually.
 	</p>
 	<p>The workbench consists of</p>
@@ -41,7 +41,7 @@
 		perspective, and the <i>Schema Explorer</i> view is active.
 	</p>
 	<div>
-		<img src="workbench.png" title="HALE workbench"
+		<img src="workbench.png" title="hale studio workbench"
 			style="max-width: 100%">
 	</div>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/help.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/help.html
@@ -2,32 +2,32 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>How to use the HALE help</title>
+<title>How to use the <i>hale studio</i> help</title>
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
 </head>
 <body>
-	<h1>How to use the HALE help</h1>
-	<p>The HALE help is available both online and in your version of
-		HALE. The online help misses some information that is provided
-		on-the-fly in HALE, e.g. the transformation function reference and the
+	<h1>How to use the <i>hale studio</i> help</h1>
+	<p>The <i>hale studio</i> help is available both online and in your version of
+		hale studio. The online help misses some information that is provided
+		on-the-fly in hale studio, e.g. the transformation function reference and the
 		detailed reference for I/O providers for use with the command line
 		interface. In some help topics live actions are provided, that allow
 		you to directly perform a specific task in your currently running
-		version of HALE. Here is an example: <a class="command-link"
+		version of hale studio. Here is an example: <a class="command-link"
 			href='javascript:liveAction("eu.esdihumboldt.hale.ui.firststeps", "eu.esdihumboldt.hale.ui.firststeps.ImportAction",
 	"eu.esdihumboldt.hale.io.schema.read.source")'><img
 			src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
 			alt="command link">Import source schema</a></p>
-	<p>In HALE you have different means to access the help, you should
+	<p>In <i>hale studio</i> you have different means to access the help, you should
 		know how to use them to be able to find the right help topics quickly:</p>
 	<h2>Dynamic help</h2>
 	<p>
 		When you have selected a specific view (e.g. the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html">Schema
 			Explorer</a>) you can press <i>F1</i> to find out what help topics are
-		associated to it. HALE provides associated help topics for most of the
+		associated to it. <i>hale studio</i> provides associated help topics for most of the
 		views and even for specific objects. You can select a mapping cell or
 		function and will be presented a link to the corresponding help topic
 		in the function reference.
@@ -43,7 +43,7 @@
 	<h2>Help Browser</h2>
 	<p>Use the Help Browser if you want to get an overview on the help
 		and browse through tasks, views and the reference. The simplest way
-		to open the Help Browser is the HALE toolbar:</p>
+		to open the Help Browser is the <i>hale studio</i> toolbar:</p>
 	<div>
 		<img src="help_toolbar.png">
 	</div>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/main_workflow.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/main_workflow.html
@@ -5,20 +5,20 @@
 <script type="text/javascript"
 	src="PLUGINS_ROOT/org.eclipse.help/livehelp.js">
 </script>
-<title>First steps in HALE</title>
+<title>First steps in hale studio</title>
 </head>
 <body>
-	<h1>First steps in HALE</h1>
+	<h1>First steps in hale studio</h1>
 	<p>
-		<i>HALE</i> is an application that strives to assist you in creating
+		<i>hale studio</i> is an application that strives to assist you in creating
 		schema mappings, allowing the transformation of data that conforms to
-		the source schema to data that is compliant to the target schema. <i>HALE</i>
+		the source schema to data that is compliant to the target schema. <i>hale studio</i>
 		combines both the mapping creation and the transformation,
 		facilitating an interactive mapping by giving feedback on each change
 		to the mapping by transforming a given sample data set.
 	</p>
 	<p>
-		A schema in <i>HALE</i> is a collection of classes/types with
+		A schema in <i>hale studio</i> is a collection of classes/types with
 		well-defined properties/attributes. Schemas may be complex, i.e. the
 		properties may again have properties themselves. Before starting with
 		the mapping creation you should familiarize yourself with the source
@@ -37,7 +37,7 @@
 		online - or you can follow the instructions in the
 		<a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
-			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png" alt="command link">Get started with HALE</a> guide.
+			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png" alt="command link">Get started with hale studio</a> guide.
 			It will show you a simple example project and get you going on starting
 			your own alignment project.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/thorsten_perspective.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/getting_started/thorsten_perspective.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Thorsten perspective</h1>
 	<p>The Thorsten perspective is how Thorsten works most efficiently
-		with HALE. He likes to have schemas, data and the alignment in his
+		with hale studio. He likes to have schemas, data and the alignment in his
 		reach all the time. For creating the alignment he prefers an approach
 		driven by sample data, so the data views and the map view play an
 		important role in his favorite perspective.</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/introduction/introduction_HALE.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/introduction/introduction_HALE.html
@@ -2,16 +2,16 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>HALE - The HUMBOLDT Alignment Editor</title>
+<title>hale studio - The HUMBOLDT Alignment Editor</title>
 </head>
 <body>
-	<h1>HALE - The HUMBOLDT Alignment Editor</h1>
+	<h1>hale studio - The HUMBOLDT Alignment Editor</h1>
 
 	<p>The mapping of elements such as Feature Types and Attributes of
 		one conceptual schema (e.g. GML Application Schemas, Database Schemas
 		or UML models) to another is a cornerstone of data harmonisation. The
-		HUMBOLDT Alignment Editor (HALE) is a tool for defining and evaluating
-		conceptual schema mappings. HALE allows domain experts to create
+		HUMBOLDT Alignment Editor (hale studio) is a tool for defining and evaluating
+		conceptual schema mappings. <i>hale studio</i> allows domain experts to create
 		logically and semantically consistent mappings and to transform
 		geodata based on these mappings. Furthermore, a major focus is put on
 		the documentation of the schema transformation process and its
@@ -22,33 +22,33 @@
 		<img style="text-align: center; max-width: 95%" src="haleio.png">
 	</div>
 
-	<p>HALE uses a high-level language for expressing the mappings.
+	<p>hale studio uses a high-level language for expressing the mappings.
 		They can later be used by the Conceptual Schema Transformer processing
 		component to execute a data transformation, e.g. from a non-harmonised
 		data source to a INSPIRE-compliant data set.</p>
 
 	<p>To make this complex process more accessible to domain experts
-		and to increase the quality of the transformations, HALE allows
+		and to increase the quality of the transformations, <i>hale studio</i> allows
 		working with sample geodata (instances) for visualization and
 		validation.</p>
 
-	<p>The value that HALE provides to data custodians, i.e.
+	<p>The value that <i>hale studio</i> provides to data custodians, i.e.
 		maintainers of geographic datasets, is manifold:</p>
 	<ul>
-		<li>HALE provides a unique declarative approach to making
+		<li>hale studio provides a unique declarative approach to making
 			interactive schema mapping a less daunting task;</li>
-		<li>HALE is based on a powerful conceptual-level mapping paradigm
+		<li>hale studio is based on a powerful conceptual-level mapping paradigm
 			that makes mappings easier to understand and to maintain;</li>
-		<li>HALE makes use of both the information in different
+		<li>hale studio makes use of both the information in different
 			conceptual schemas and of geographic instances to ensure high-quality
 			mappings;</li>
-		<li>HALE provides a rich, textual and graphical interface
+		<li>hale studio provides a rich, textual and graphical interface
 			specifically adopted for GI Experts;</li>
-		<li>HALE gives instant feedback about the progress of mapping
+		<li>hale studio gives instant feedback about the progress of mapping
 			data from one schema to another, enabling throughout understanding of
 			the transformation process;</li>
-		<li>HALE enables collaborative creation of mappings;</li>
-		<li>With HALE, users can furthermore document known limitations
+		<li>hale studio enables collaborative creation of mappings;</li>
+		<li>With hale studio, users can furthermore document known limitations
 			of the mapping they are creating in the form of a unique Mismatch
 			Description Language.</li>
 	</ul>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/introduction/introduction_dhp.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/introduction/introduction_dhp.html
@@ -8,7 +8,7 @@
 	<h1>The data harmonisation panel</h1>
 
 	<p>From April 2011 on, after the end of the HUMBOLDT project, the
-		development of HALE has been coordinated under the auspices of the
+		development of <i>hale studio</i> has been coordinated under the auspices of the
 		data harmonisation panel. The data harmonisation panel has been
 		established with the goal of supporting the international community of
 		experts and organisations that have to deal with spatial data

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_0_0.xhtml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_0_0.xhtml
@@ -73,7 +73,7 @@
 			<tr id="new-groovy-features">
 				<td class="title">New Groovy Function Features</td>
 				<td class="content">Groovy Functions help when the functions we
-					ship with hale studio don't match specific requirements. To make
+					ship with <i>hale studio</i> don't match specific requirements. To make
 					them more powerful, we have added several new capabilities. The
 					first of these is to output multiple features from a single Groovy
 					Retype, Groovy Merge or Groovy Join function. You can use this

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_1_0.xhtml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_1_0.xhtml
@@ -95,7 +95,7 @@
 					value restrictions in a schema, but also bring less safety in
 					respect to validation. To check the data you create in respect to
 					values from code lists you can now simply associate a code list to
-					a property - hale studio compares your data against the loaded code
+					a property - <i>hale studio</i> compares your data against the loaded code
 					list and informs you in case different values are used.
 					<p>
 						<img src="3_1_0_images/codevalidation.png" />
@@ -110,7 +110,7 @@
 				<td class="content">On your source schema you can define
 					contexts for the mapping that are specified through a condition on
 					a type or property, or an index of a property. When you have source
-					data loaded in hale studio you can now see directly how many
+					data loaded in <i>hale studio</i> you can now see directly how many
 					instances and values there are, that match these contexts.
 					<p>
 						<img src="3_1_0_images/contexts.png" />

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_2_0.xhtml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/new/3_2_0.xhtml
@@ -75,7 +75,7 @@
 				<td class="title">WFS request pagination support</td>
 				<td class="content">
 					<p>
-						When loading from WFS sources, hale studio now supports request 
+						When loading from WFS sources, <i>hale studio</i> now supports request 
 						pagination, a capability that was introduced with the WFS 2.0 standard.
 						This allows loading larger datasets from a WFS where previously this
 						may have been limited by a server-side limit of retrievable features
@@ -92,7 +92,7 @@
 				<td class="content">
 					<p>
 						The use of project variables, a feature that was introduced with hale 
-						studio 3.0, is now easier as several wizards in hale studio have been
+						studio 3.0, is now easier as several wizards in <i>hale studio</i> have been
 						extended to provide content assistance. Simply press Ctrl+Space when
 						inside a text field and choose the desired variable from a list. The
 						content assistant will take care of the correct syntax.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/cql_filter.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/cql_filter.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>CQL Filter</h1>
 	<p>The Common Query Language (CQL) is used to define expressions
-		and filters in several parts of <i>HALE</i>. It can be used to define
+		and filters in several parts of <i>hale studio</i>. It can be used to define
 		conditions on schema elements or to filter instances.</p>
 
 	<h2>Property references</h2>
@@ -65,7 +65,7 @@
 		project provided in the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with HALE</a> guide, using the
+			alt="command link">Get started with hale studio</a> guide, using the
 		<a href="../views/transformed_data.html">Transformed Data view</a>.
 	</p>
 	<h3>Comparisons</h3>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/html_mapping.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/html_mapping.html
@@ -15,7 +15,7 @@
 		the example project from the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with HALE</a>
+			alt="command link">Get started with hale studio</a>
 		guide is provided as an <a href="sample_documentation.html">example</a>.
 	</p>
 	<p>To create the mapping documentation for your project, export the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/jdbc.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/jdbc.html
@@ -6,10 +6,10 @@
 </head>
 <body>
 	<h1>Database Export</h1>
-	<p>HALE writes to databases using JDBC. HALE
+	<p><i>hale studio</i> writes to databases using JDBC. hale studio
 		offers support for PostgreSQL and PostGIS databases out of the box,
 		support for other databases can be added through plug-ins.</p>
-	<p class="Note">The database export in this version of HALE is
+	<p class="Note">The database export in this version of <i>hale studio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a database export feature.
 		However, within its limits it is functional and may be useful to you.</p>
@@ -26,7 +26,7 @@
 			identifier assigned during transformation will be replaced by the
 			auto-generated value.</li>
 	</ul>
-	<p>When storing geometries in PostGIS, HALE will try to detect the
+	<p>When storing geometries in PostGIS, <i>hale studio</i> will try to detect the
 		spatial reference system associated to the target column and transform
 		them appropriately.</p>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/mssql.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/mssql.html
@@ -7,15 +7,15 @@
 <body>
 	<h1>MsSQL Server Export</h1>
 	<p>
-		Support for MsSQL Server in HALE is based on the generic <a
+		Support for MsSQL Server in <i>hale studio</i> is based on the generic <a
 			href="jdbc.html">Database export</a> based on JDBC, and thus has the
-		same limitations. For instance HALE needs the database schema to
+		same limitations. For instance <i>hale studio</i> needs the database schema to
 		already exist in SQL server, thus you can only write to database that have 
 		already been prepared and loaded as target schema.
 	</p>
 	
 	<p>
-		HALE supports writing both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
+		<i>hale studio</i> supports writing both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
 		of MsSQL Server but if any objects does not contain spatial reference system then 
 		<b>(EPSG:4326)</b> will be used as a default reference system. 
 		However, within this limit it is functional and may be useful to you.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/sqlite.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/sqlite.html
@@ -7,13 +7,13 @@
 <body>
 	<h1>SQLite and SpatiaLite Export</h1>
 	<p>
-		Support for SQLite and SpatiaLite in HALE is based on the generic <a
+		Support for SQLite and SpatiaLite in <i>hale studio</i> is based on the generic <a
 			href="jdbc.html">Database export</a> based on JDBC, and thus has the
-		same limitations. For instance HALE needs the database schema to
+		same limitations. For instance <i>hale studio</i> needs the database schema to
 		already exist, thus you can only write to files that have already been
 		prepared and loaded as target schema.
 	</p>
-	<p class="Note">The database export in this version of HALE is
+	<p class="Note">The database export in this version of <i>hale studio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a database export feature.
 		However, within its limits it is functional and may be useful to you.</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/wfs.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/wfs.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Transactional WFS</h1>
-	<p>HALE supports publishing your transformed GML data to a WFS with
+	<p><i>hale studio</i> supports publishing your transformed GML data to a WFS with
 		support for transactions. Currently supported are Transactional Web
 		Feature Services following the OGC WFS 1.1.0 or WFS 2.0.0
 		specifications. There are two different providers for publishing to
@@ -24,7 +24,7 @@
 			together so the WFS-T is able to retain those references.
 		</li>
 	</ul>
-	<p class="Note">The publishing to WFS in this version of HALE is
+	<p class="Note">The publishing to WFS in this version of <i>hale studio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a WFS publishing feature.
 		However, within its limits it is functional and may be useful to you.</p>
@@ -36,15 +36,15 @@
 			messages in the transformation and export reports. There is no
 			automatic recovery, features may have to be deleted manually if they
 			are not desired to be published.<br>
-		<br>HALE behaves like this because both transformation and GML
+		<br><i>hale studio</i> behaves like this because both transformation and GML
 			export aim to provide you a result even if there are small errors or
 			inconsistencies.<br><br>
 		</li>
-		<li>HALE will not check the WFS Capabilities if the WFS
+		<li><i>hale studio</i> will not check the WFS Capabilities if the WFS
 			supports any of the provided GML feature types.</li>
 	</ul>
 	<p>Target location for the WFS-T export is the POST URL for the
-		WFS Transaction operation. The HALE user interface provides a helper to
+		WFS Transaction operation. The <i>hale studio</i> user interface provides a helper to
 		determine that URL from the WFS capabilities.</p>
 	
 	<br>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/xml_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/xml_data.html
@@ -25,7 +25,7 @@
 		<img src="images/xml_export_root.png" title="Specify root element" class="fit">
 	</div>
 	<p>
-		When writing the transformed data, <i>HALE</i> will try to find a
+		When writing the transformed data, <i>hale studio</i> will try to find a
 		valid XML path to write each of the transformed instances. If there
 		are geometry objects contained in an instance, they are written as a
 		GML geometry if possible.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/csv.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/csv.html
@@ -7,12 +7,12 @@
 <body>
 	<h1>CSV Import</h1>
 	<p>
-		Comma separated value (CSV) files can be used as a data source in <i>HALE</i>,
+		Comma separated value (CSV) files can be used as a data source in <i>hale studio</i>,
 		with the schema definition also being derived from the CSV file.
 	</p>
 	<h2>General CSV Import Options</h2>
 	<p>
-		When loading a CSV file, <i>HALE</i> will try to auto-detect the
+		When loading a CSV file, <i>hale studio</i> will try to auto-detect the
 		settings for reading the file, i.e. which character is used to
 		separate the values and what the quote and escape characters should
 		be. You can correct the settings manually by choosing other characters

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_data.html
@@ -21,7 +21,7 @@
 
 	<h2>Load data from a WFS</h2>
 	<p>
-		<i>HALE</i> offers the possibility to load data based on a WFS <i>GetFeature</i>
+		<i>hale studio</i> offers the possibility to load data based on a WFS <i>GetFeature</i>
 		KVP request. You can specify the request URL manually or use the <i>...</i>
 		button to launch a wizard assisting you in building the URL from the service capabilities.
 	</p>
@@ -35,7 +35,7 @@
 	<div>
 		<img src="images/wfs_data_bb.png" class="fit"></img>
 	</div>
-	<p>When loading from WFS sources, HALE supports request pagination, a capability that
+	<p>When loading from WFS sources, <i>hale studio</i> supports request pagination, a capability that
 	    was introduced with the WFS 2.0 standard. You can activate or deactivate request
 	    pagination on the <i>XML/GML settings</i> page. If activated, the number of features 
 	    that will be retrieved per request can also be set.
@@ -43,7 +43,7 @@
 		<p>Even though pagination was introduced in the WFS 2.0 standard, there are
 		WFS server implementations available that support this feature for WFS 1.1.0 
 		requests as well. If you know that the queried WFS supports this and activate 
-		pagination, HALE will paginate the requests also for WFS 1.1.0 requests. 
+		pagination, <i>hale studio</i> will paginate the requests also for WFS 1.1.0 requests. 
 		</p>
 	<div>
 		<img src="images/wfs_data_settings.png" class="fit"></img>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_schema.html
@@ -17,7 +17,7 @@
 	</div>
 	<h2>Load a schema from a WFS</h2>
 	<p>
-		<i>HALE</i> offers the possibility to load a schema based on a WFS <i>DescribeFeatureType</i>
+		<i>hale studio</i> offers the possibility to load a schema based on a WFS <i>DescribeFeatureType</i>
 		KVP request. You can specify the request URL manually or use the <i>...</i>
 		button to launch a wizard assisting you in building the URL based on the service capabilities.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/jdbc.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/jdbc.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Database Import</h1>
-	<p>Database schemas and data are imported in HALE using JDBC. HALE
+	<p>Database schemas and data are imported in <i>hale studio</i> using JDBC. hale studio
 		offers support for Microsoft SQL Server, PostgreSQL and PostGIS databases out of the box,
 		support for other databases can be added through plug-ins.</p>
 	<p>The database import currently has the following known limitations:</p>
@@ -53,7 +53,7 @@
 		those types that are marked as mapping relevant. <br>Before
 		loading the data it is recommended to enable the selection of a
 		sub-set as sample data (<i>First n instances per type</i>), so a
-		potentially big database is not loaded completely into HALE just for
+		potentially big database is not loaded completely into <i>hale studio</i> just for
 		the analysis and mapping. This can be enabled in the tool bar or the
 		project's source data settings.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/mssql.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/mssql.html
@@ -7,12 +7,12 @@
 <body>
 	<h1>MsSQL Server Import</h1>
 	<p>
-		HALE supports MsSQL Server database (tested version 2012 and 2014) import like generic 
+		<i>hale studio</i> supports MsSQL Server database (tested version 2012 and 2014) import like generic 
 		<a href="jdbc.html">Database import</a> based on JDBC. Thus has the same limitations.
 	</p>
 	
 	<p>
-		HALE supports both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
+		<i>hale studio</i> supports both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
 		of MsSQL Server but there are some limitations on curved <a href="https://msdn.microsoft.com/en-us/library/bb964711(v=sql.110).aspx#Anchor_1"> spatial data objects</a>. 
 	</p>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/shapefile.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/shapefile.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Shapefile (SHP) Import</h1>
 	<p>
-		Shapefiles can be used as a data source in <i>HALE</i>, with the
+		Shapefiles can be used as a data source in <i>hale studio</i>, with the
 		schema definition also being derived from the Shapefile. Before
 		importing a Shapefile as source data, you have to import it as source
 		schema.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/sqlite.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/sqlite.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>SQLite and SpatiaLite Import</h1>
 	<p>
-		Support for SQLite and SpatiaLite in HALE is based on the generic <a
+		Support for SQLite and SpatiaLite in <i>hale studio</i> is based on the generic <a
 			href="jdbc.html">Database import</a> based on JDBC, and thus has the
 		same limitations. For convenience,
 		you can simply select a

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xls.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xls.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Excel File (XLS, XLSX) Import</h1>
 	<p>
-		Excel files can be used as a data source in <i>HALE</i>. The 
+		Excel files can be used as a data source in <i>hale studio</i>. The 
 		schema definition can/should also be derived from this excel file, 
 		by using a headline or user input to define attribute names.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xml_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xml_schema.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>XML Schema Import</h1>
 	<p>
-		<i>HALE</i> supports loading schemas from XML Schema Definition (XSD)
+		<i>hale studio</i> supports loading schemas from XML Schema Definition (XSD)
 		files. XML elements and types will be analyzed in a given schema file,
 		as well as in the included and imported additional schemas. Complex
 		properties are supported, as well as cycles, substitutions, groups and

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/spatialite_common.xhtml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/spatialite_common.xhtml
@@ -11,18 +11,18 @@
 			To support SpatiaLite the
 			<code>mod_spatialite</code>
 			extension for SQLite must be available. For Windows users the
-			extension is provided together with HALE, for other
+			extension is provided together with hale studio, for other
 			operating systems you may find it in your package manager or can
 			compile it yourself.
 		</p>
-		<p>HALE specifically supports version 3 and 4 of SpatiaLite, but
+		<p><i>hale studio</i> specifically supports version 3 and 4 of SpatiaLite, but
 			should also work with previous versions. Please let us know if you
 			experience any problems working with your files.</p>
 			
 		<h3>SpatiaLite on Windows</h3>
 		<p>
-			HALE ships with the SQLite extension <code>mod_spatialite</code> (Version 4.2.0),
-			which is available as DLLs in the main HALE directory. You can
+			<i>hale studio</i> ships with the SQLite extension <code>mod_spatialite</code> (Version 4.2.0),
+			which is available as DLLs in the main <i>hale studio</i> directory. You can
 			replace the library and its dependencies with different versions, e.g. as provided on
 			the <a href="http://www.gaia-gis.it/gaia-sins/" target="_blank">project
 				page</a>.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/define_custom_function.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/define_custom_function.html
@@ -6,9 +6,9 @@
 </head>
 <body>
 	<h1>Define a custom function</h1>
-	<p>HALE comes with a set of pre-defined transformation functions
+	<p><i>hale studio</i> comes with a set of pre-defined transformation functions
 		that cover most basic mapping cases. If you need other functionality
-		the easiest way is to define a custom function directly in HALE. In a
+		the easiest way is to define a custom function directly in hale studio. In a
 		custom function you can use Groovy to determine the output, based on
 		input and parameters, similar to the Groovy script function. The main
 		difference to the Groovy script function is, that with a custom
@@ -93,7 +93,7 @@
 	</p>
 	
 	<h3>Function explanation</h3>
-	<p>HALE generates an explanation for mapping cells that reference specific
+	<p><i>hale studio</i> generates an explanation for mapping cells that reference specific
 		transformation functions. As a last step you have the opportunity to
 		specify how this explanation is created for your custom function.</p>
 	<p>The explanation can be a fixed text, or it can be a template
@@ -104,12 +104,12 @@
 	</div>
 	<p>
 		To support both text and HTML explanations with a single template,
-		HALE provides Markdown support using the <a
+		<i>hale studio</i> provides Markdown support using the <a
 			href="https://github.com/sirthias/pegdown" target="_blank">pegdown</a>
 		Markdown processor.
 	</p>
 	<p>
-		To render the template HALE uses the <a
+		To render the template <i>hale studio</i> uses the <a
 			href="http://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_gstringtemplateengine"
 			target="_blank">GStringTemplateEngine</a>. The variables available to
 		you in the template are the following:

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/mapping_schema_elem.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/mapping_schema_elem.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Mapping schema elements</h1>
 	<p>
-		The main purpose of <i>HALE</i> is of course not to just inspect
+		The main purpose of <i>hale studio</i> is of course not to just inspect
 		schemas, but to map the elements of these schemas with the goal of
 		transforming corresponding (geo)data sets.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/type_relations.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/type_relations.html
@@ -90,13 +90,13 @@
 
 	<h2>Identify each type relation</h2>
 	<p>For the type correspondences as the next step you need to
-		identify how they can be expressed as relations in HALE.</p>
+		identify how they can be expressed as relations in <i>hale</i>.</p>
 	<p>
 		The most simple kind of relation is a 1:1 relation - a correspondence
 		between a single source and a single target type, where all
 		information needed to populate a target instance is present in a
 		single source instance - like in our <i>River/Watercourse</i> example.
-		This kind of relation is represented in HALE by the <a
+		This kind of relation is represented in <i>hale</i> by the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.cst.doc.functions/functions/eu.esdihumboldt.hale.align.retype.html">Retype</a>
 		function.<br />
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/save_transformation.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/save_transformation.html
@@ -8,7 +8,7 @@
 	<h1>Save the transformation result</h1>
 	<p>
 		If you have defined a mapping and loaded source data in the
-		application, <i>HALE</i> performs the transformation derived from the
+		application, <i>hale studio</i> performs the transformation derived from the
 		mapping on the source data. This happens on every change to the
 		mapping, to instantly show the user what consequences his changes
 		have.
@@ -31,7 +31,7 @@
 		work based on a XML target schema.
 	</p>
 	<p>
-		Supported data export formats in <i>HALE</i> are:
+		Supported data export formats in <i>hale studio</i> are:
 	</p>
 	<ul>
 		<li><a href="../../reference/export/xml_data.html">XML</a></li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/transform_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/transform_data.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Transform external data</h1>
 	<p>To transform your data you don't need to load all of it into
-		HALE. Usually it's a better practice to only load a representative
+		hale studio. Usually it's a better practice to only load a representative
 		sample of your data, to help you verify the mapping and quickly get
 		feedback on its transformation. Once you have defined the mapping you
 		have the possibility to transform your data without loading it into

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/validate_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/validate_data.html
@@ -10,11 +10,11 @@
 		transformation result to not only follow the schema's structure, but
 		to also meet the other constraints defined by the schema, like
 		mandatory properties or restrictions on property values.</p>
-	<p>Validation of instances in HALE currently is supported for XML
+	<p>Validation of instances in <i>hale studio</i> currently is supported for XML
 		based schemas. Validation can be done on the exported transformation
 		result or on the transformed instances currently available in the
 		application.</p>
-	<p>In addition to schema-based checks, HALE supports validation of the
+	<p>In addition to schema-based checks, <i>hale studio</i> supports validation of the
 		exported transformation result with Schematron. To perform Schematron
 		validation, you can add the Schematron validator to the list of
 		validators and configure it when exporting the transformed instances.
@@ -35,7 +35,7 @@
 		produces a report about errors found during the validation and 
 		informs you whether the file is valid or not.</p>
 
-	<h2>Validation inside HALE</h2>
+	<h2>Validation inside hale studio</h2>
 	<p>If a mapping exists and source data is loaded, each mapping change will 
 		trigger the live transformation (if activated).
 		When the transformed data changes, schema-based validation is started
@@ -44,7 +44,7 @@
 	<div>
 		<img src="images/validation_activate.png" class="fit">
 	</div>
-	<p>A status item in the lower right corner of the HALE window shows
+	<p>A status item in the lower right corner of the <i>hale studio</i> window shows
 		the status of the validation. If there is a small warning sign in the
 		icon, it informs us about validation errors:</p>
 	<div>
@@ -79,10 +79,10 @@
 	<div>
 		<img src="images/validation_properties.png">
 	</div>
-	<p>This kind of validation inside HALE is very convenient, but may
+	<p>This kind of validation inside <i>hale studio</i> is very convenient, but may
 		not be as accurate as the validation on export for some cases. This is
 		due to the fact that the export itself may change the result slightly
-		from what is available in HALE. This could for instance be encodings
+		from what is available in hale studio. This could for instance be encodings
 		that are only replied when writing certain properties, or values like
 		identifiers that are generated when missing.</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/working_source_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/working_source_data.html
@@ -8,12 +8,12 @@
 	<h1>Working with a source data set</h1>
 	<p>
 		The term <i>source data</i> refers to data according to the <i>source
-			schema</i> loaded in <i>HALE</i>. Loading source data therefore always
+			schema</i> loaded in <i>hale studio</i>. Loading source data therefore always
 		requires that the corresponding source schema has already been
 		imported.
 	</p>
 	<p>
-		Loading source data in <i>HALE</i> serves to provide feedback on the
+		Loading source data in <i>hale studio</i> serves to provide feedback on the
 		current mapping by transforming this data in the application. The <a
 			href="../../views/source_data.xhtml">Source Data view</a> can be used
 		to inspect the source data, while the <a
@@ -25,7 +25,7 @@
 	
 	<h2>Configuring a sample data set</h2>
 	<p>You have the possibility to load only a sub-set of your data in
-		HALE, to use it as a sample for the data analysis and transformation
+		hale studio, to use it as a sample for the data analysis and transformation
 		debugging. You can enable it in the tool bar or the project's source
 		data settings. To open the settings use tool bar button highlighted
 		below:</p>
@@ -61,7 +61,7 @@
 		easily transform and export the complete data. Select <i>Transformation</i>&#8594;<i>Transform
 			project data...</i> from the menu to launch a wizard that will guide you
 		through the export configuration and launch the transformation. While
-		the transformation runs you can continue working in HALE, as the
+		the transformation runs you can continue working in hale studio, as the
 		transformation works on a copy of your current mapping.
 	</p>
 
@@ -79,7 +79,7 @@
 		choose the one that applies.
 	</p>
 	<p>
-		Supported data import formats in <i>HALE</i> are:
+		Supported data import formats in <i>hale studio</i> are:
 	</p>
 	<ul>
 		<li><a href="../../reference/import/xml_data.html">XML</a></li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/save_project.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/save_project.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Saving your work</h1>
 	<p>
-		<i>HALE</i> allows you to save your mapping, together with the
+		<i>hale studio</i> allows you to save your mapping, together with the
 		configuration which schemas and source data sets are used in an
 		alignment project. The project also includes additional settings, e.g.
 		the list of mapping relevant types and the map styles. You can
@@ -25,17 +25,17 @@
 	<p>There are three different formats for projects currently supported:
 	</p>
 	<ul>
-		<li>A <b>HALE project</b> (.hale) contains the project
+		<li>A <b>hale project</b> (.hale) contains the project
 			configuration and the alignment in a single file.
 		</li>
-		<li>A <b>HALE XML project</b> (.halex) saves the project as an
+		<li>A <b>hale XML project</b> (.halex) saves the project as an
 			XML file, with the alignment as a separate file. This is the best
 			choice if you use your projects with any kind of version control.
 		</li>
-		<li>A <b>HALE project archive</b> (.halez) is a ZIP archive
+		<li>A <b>hale project archive</b> (.halez) is a ZIP archive
 			including the project file, alignment and all local resources. Online
 			resources can be included as well. The project archive is the best
-			choice for sharing a project. It can be turned into a HALE XML
+			choice for sharing a project. It can be turned into a hale XML
 			project by simply extracting the archive.
 		</li>
 	</ul>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/inspire_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/inspire_schema.html
@@ -12,13 +12,13 @@
 		exchange formats for INSPIRE. One application of those exchange
 		formats is the provision of data through INSPIRE Download services.</p>
 	<p>
-		To use an INSPIRE GML data model in <i>HALE</i> all you have to do is
+		To use an INSPIRE GML data model in <i>hale studio</i> all you have to do is
 		loading the corresponding GML Application Schema as source or target
 		schema (see <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html">Loading
 			and browsing schemas</a>).<br> The GML Application Schemas are
 		provided by the European Commission. You can either use the schema
-		presets defined in HALE (choose &quot;From preset&quot; when importing
+		presets defined in <i>hale studio</i> (choose &quot;From preset&quot; when importing
 		a schema) or the <a href="http://inspire.ec.europa.eu/schemas/"
 			target="_blank">schema repository</a> maintained by the JRC.
 	</p>
@@ -27,7 +27,7 @@
 			href="http://inspire.jrc.ec.europa.eu/index.cfm/pageid/2/list/datamodels"
 			target="_blank">http://inspire.jrc.ec.europa.eu/index.cfm/pageid/2/list/datamodels</a>
 	</p>
-	<p>HALE provides some pre-defined schema locations you can choose
+	<p><i>hale studio</i> provides some pre-defined schema locations you can choose
 		from - currently the INSPIRE schemas for Annex I, II and III in
 		versions 3.0 and 4.0 are listed:</p>
 	<div>
@@ -57,7 +57,7 @@
 			target="_blank">http://inspire.ec.europa.eu/draft-schemas/</a> (Draft
 		schemas)<br> <br> The schemas available there are not meant
 		for download - instead their URLs should be used to load them into
-		HALE (e.g. by browsing the repository and using &quot;Copy Link
+		<i>hale studio</i> (e.g. by browsing the repository and using &quot;Copy Link
 		Location&quot; for a schema file to copy its URL to the clipboard and
 		further providing it in &quot;From URL&quot; when importing a schema).
 	</p>
@@ -66,7 +66,7 @@
 		The INSPIRE data models make heavy use of code lists. A lot of these
 		code lists are provided through the <a
 			href="http://inspire.ec.europa.eu/codelist/" target="_blank">INSPIRE
-			code list register</a>. With HALE you can easily load them to use them
+			code list register</a>. With <i>hale studio</i> you can easily load them to use them
 		for a convenient selection from the available values. In the code list
 		import, select &quot;From INSPIRE registry&quot; to download the
 		current list of code lists and select a code list to load into the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html
@@ -10,7 +10,7 @@
 		start with the creation of a mapping you have to determine what the
 		source and target schemas are.</p>
 	<p>
-		Loading a schema in <i>HALE</i> provides you with the possibility to
+		Loading a schema in <i>hale studio</i> provides you with the possibility to
 		browse the schema in the <a href="../../views/schema_explorer.html">Schema
 			Explorer</a> and to get detailed information on the defined types and
 		their properties.
@@ -50,7 +50,7 @@
 
 	<h2>Supported schema formats</h2>
 	<p>
-		<i>HALE</i> supports the following formats for schema import:
+		<i>hale studio</i> supports the following formats for schema import:
 	</p>
 	<ul>
 		<li><a href="../../reference/import/xml_schema.html">XML

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html
@@ -7,67 +7,67 @@
 <body>
 	<h1>Transformation via the command line</h1>
 	<p>This help topic is about performing transformation of source
-		data using the command line interface provided by HALE. It allows you
-		to execute transformations based on mappings defined in HALE, without
-		having to use HALE as desktop application, for instance to run the
+		data using the command line interface provided by <i>hale studio</i>. It allows you
+		to execute transformations based on mappings defined in <i>hale studio</i>, without
+		having to use <i>hale studio</i> as desktop application, for instance to run the
 		transformation automatically on a regular basis or to integrate it
 		with existing infrastructure.</p>
 	<p>The following are the basic things you need to use the command
 		line interface:</p>
 	<ol>
-		<li>An existing <b>HALE project file</b>, e.g. a project archive (.halez).</li>
+		<li>An existing <b>hale project file</b>, e.g. a project archive (.halez).</li>
 		<li>The location of the <b>source data to transform</b>, either an URL or a file name. The data has to match the source schema of the project.</li>
 		<li>Configuration on <b>how and where to write the transformed data</b>.</li>
 	</ol>
 	
 	<h2>General usage</h2>
-	<p>You can run HALE on the command line either using the HALE
-		executable (e.g. HALE.exe) or using Java directly. Depending on the
+	<p>You can run <i>hale studio</i> on the command line either using the <i>hale studio</i>
+		executable (i.e. HALE.exe) or using Java directly. Depending on the
 		operating system, behavior may be different, but in general it is
 		better to use Java directly (either use locally installed compatible
-		version of Java or the version shipped with HALE), especially if you
+		version of Java or the version shipped with <i>hale studio</i>), especially if you
 		include the task in an automated process. The advantage of using the
-		HALE executable is that it uses the Java version that is shipped with
-		HALE automatically and sets some important system properties for you.
+		<i>hale studio</i> executable is that it uses the Java version that is shipped with
+		<i>hale studio</i> automatically and sets some important system properties for you.
 		The following are the commands to show the usage information of the
 		command line interface, with the executable or via Java, assuming your
-		working directory is the HALE installation folder:</p>
-	<p>Running the HALE executable:</p>
+		working directory is the <i>hale studio</i> installation folder:</p>
+	<p>Running the <i>hale studio</i> executable:</p>
 	<pre class="cli"><code><b>&gt;</b> <i>HALE -nosplash</i> -application hale.transform</code></pre>
 	<p>Running Java:</p>
 	<pre class="cli"><code><b>&gt;</b> <i>java -Xmx1024m -Dcache.level1.enabled=false -Dcache.level1.size=0 -Dcache.level2.enabled=false -Dcache.level2.size=0 -jar plugins\org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar</i> -application hale.transform</code></pre>
 	<p>Running the command above will show the usage information of the
 		transformation application. Please note that for the Java call, the
-		version of the launcher JAR file may change with new HALE versions and
+		version of the launcher JAR file may change with new <i>hale studio</i> versions and
 		you should use a path delimiter appropriate for your system.</p>
 	<p>Additionally, the Java call specifies settings and system
 		properties for the Java VM. You cannot provide these settings to a
-		call to the HALE executable - in that case you have to adapt the file
+		call to the <i>hale studio</i> executable - in that case you have to adapt the file
 		<code>HALE.ini</code>. Following is a short description of the most important
 		VM arguments:</p>
 	<ul>
 		<li style="padding-bottom: 16px;"><code>-Xmx1024m</code><br><br>This setting specifies the
-			<b>maximum heap memory</b> provided as working memory for HALE. If you are
+			<b>maximum heap memory</b> provided as working memory for <i>hale studio</i>. If you are
 			with very large individual instances you may need to increase the
 			value. The example specifies a maximum heap space of 1024 MB.</li>
 		<li style="padding-bottom: 16px;"><code>-Dcache.level1.enabled=false
 				-Dcache.level1.size=0 -Dcache.level2.enabled=false
 				-Dcache.level2.size=0</code><br><br>These settings are important for the
-			temporary database used within HALE. If you do not use them you may
+			temporary database used within <i>hale studio</i>. If you do not use them you may
 			run into memory issues.</li>
 		<li style="padding-bottom: 16px;"><code>-Dlog.hale.level=INFO -Dlog.root.level=WARN</code><br><br>These
 			settings allow you to <b>configure the log level</b> for log events emitted
-			by HALE. These log events may overlap with messages from the reports,
+			by <i>hale studio</i>. These log events may overlap with messages from the reports,
 			but are generally independent. <code>log.hale.level</code> controls
-			the log level for components of HALE, while <code>log.root.level</code>
+			the log level for components of <i>hale studio</i>, while <code>log.root.level</code>
 			controls the log level for other code, such as third party libraries.
 			See the <a href="http://logback.qos.ch/manual/configuration.html"
 			target="_blank">logback documentation</a> for more information on
 			logging levels and other details about the logging configuration.</li>
-		<li style="padding-bottom: 16px;">If you need HALE to <b>connect to the internet via a
+		<li style="padding-bottom: 16px;">If you need <i>hale studio</i> to <b>connect to the internet via a
 				proxy server</b>, you need to provide that information as system
 			properties as well. The command line interface will not read the
-			proxy settings you configured in the HALE user interface.<br><br>
+			proxy settings you configured in the <i>hale studio</i> user interface.<br><br>
 			The following system properties can be provided to configure the proxy:
 			<ul>
 				<li><code>http.proxyHost</code> - the proxy host name or IP address</li>
@@ -85,7 +85,7 @@
 	<p>
 		For simplicity, the following examples will use the
 		<code>HALE</code>
-		executable, you can substitute HALE by the call to Java as above.
+		executable, you can substitute <code>HALE</code> by the call to Java as above.
 	</p>
 	<p>
 		Please note that every argument before
@@ -96,7 +96,7 @@
 		is an <b>application argument</b>.
 	</p>
 	<p class="Note">
-		<b>Note:</b> As an alternative to using the HALE studio application to
+		<b>Note:</b> As an alternative to using the <i>hale studio</i> application to
 		launch the CLI, you can use the dedicated <a
 			href="https://github.com/halestudio/hale-cli" target="_blank">hale-cli</a>.
 		With <i>hale-cli</i> a transformation is called like this:<br>
@@ -106,13 +106,13 @@
 	</p>
 	<p class="Note">
 		<b>Note:</b>
-		If using the HALE executable on Windows you will probably want to add the <code>-console</code> launcher argument as well:
+		If using the <i>hale studio</i> executable on Windows you will probably want to add the <code>-console</code> launcher argument as well:
 		<code>HALE -nosplash -console -application hale.transform</code><br>
 		Otherwise you may get no feedback from the application (if you still get no feedback, launch via Java).
 	</p>
 	<p class="Note">
-		<b>Note:</b> If using a version of HALE installed with the Windows
-		installer (or generally a version of HALE that has no write access to
+		<b>Note:</b> If using a version of <i>hale studio</i> installed with the Windows
+		installer (or generally a version of <i>hale studio</i> that has no write access to
 		its directory) it is needed to specify a data location with the
 		additional launcher argument
 		<code>-data</code>
@@ -150,10 +150,10 @@
      -stacktrace
      -trustGroovy
      -overallFilterContext</code></pre>
-	<h4>HALE project file</h4>
-	<pre class="cli"><code>-project &lt;file-or-URI-to-HALE-project&gt;</code></pre>
+	<h4>hale project file</h4>
+	<pre class="cli"><code>-project &lt;file-or-URI-to-hale-project&gt;</code></pre>
 	<p>
-		A HALE project contains all the necessary information to perform the
+		A hale project contains all the necessary information to perform the
 		transformation from one data model into another. It references the
 		source and target schemas and describes the transformation rules in
 		the aligment.<br> Use the
@@ -179,7 +179,7 @@
 	<p>The source data you can as well provide as path to a file or a
 		URI. For instance you can provide a URI to a Web Feature Service
 		GetFeature request. Specifying a source data location is mandatory,
-		any source data configured in the HALE project will be ignored for the
+		any source data configured in the hale project will be ignored for the
 		transformation.</p>
 	<p>
 		If the source is a directory, you can specify multiple
@@ -200,22 +200,22 @@
 		<code>-source</code>
 		argument for each.
 	</p>
-	<p>HALE will try to guess the file format and how to read it, so in
+	<p><i>hale studio</i> will try to guess the file format and how to read it, so in
 		most cases it will be enough to specify the location of the source
 		data. But you also have the possibility to control in detail which
-		HALE data reader to use and how to configure it.</p>
+		hale data reader to use and how to configure it.</p>
 	<p>
 		Please take a look at the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user.ioproviders/overview/InstanceReader.html">InstanceReader
 			reference</a> to see what kind of providers are available for you and what
 		kind of configuration options they offer. <i>Please note that this
 			reference documentation is generated from the I/O providers present
-			in your local HALE installation (including eventual additional
+			in your local <i>hale studio</i> installation (including eventual additional
 			plugins and custom implementations), so it is <b>only available in the
-			local HALE help and not in the online version on the web</b>.</i>
+			local <i>hale studio</i> help and not in the online version on the web</b>.</i>
 	</p>
 	<h4>Filtering source data</h4>
-	<p>By default HALE uses all data passed in as sources for the
+	<p>By default <i>hale studio</i> uses all data passed in as sources for the
 		transformation. The filter options allow you to filter the source data
 		before it is passed to the transformation. This can be helpful for
 		selecting only objects actually needed for the transformation (e.g. to
@@ -282,13 +282,13 @@
 	<p>
 		Also you need to specify where to write the transformation result to.
 		Usually this is a file.<br>In addition you need to provide either
-		an export preset or a HALE data writer ID and configuration.
+		an export preset or a hale data writer ID and configuration.
 	</p>
 	<p>
 		The recommended approach is to use an export preset. You can easily
-		define it in HALE with support through the UI, and save it as part of
+		define it in <i>hale studio</i> with support through the UI, and save it as part of
 		the project. An export preset essentially stores the configuration
-		information on how to save the data. Create it in HALE via <i>File</i>&#8594;<i>Export</i>&#8594;<i>Create
+		information on how to save the data. Create it in <i>hale studio</i> via <i>File</i>&#8594;<i>Export</i>&#8594;<i>Create
 			custom data export...</i> in the main menu. Configure the export and
 		specify a name for the preset - this name is what you specify to use
 		the preset on the command line.
@@ -304,14 +304,14 @@
 			reference</a> to see what kind of providers are available for you and what
 		kind of configuration options they offer. <i>Please note that this
 			reference documentation is generated from the I/O providers present
-			in your local HALE installation (including eventual additional
+			in your local <i>hale studio</i> installation (including eventual additional
 			plugins and custom implementations), so it is <b>only available in the
-			local HALE help and not in the online version on the web</b>.</i>
+			local <i>hale studio</i> help and not in the online version on the web</b>.</i>
 	</p>
 	<h4>Validation</h4>
 	<pre class="cli"><code>-validate &lt;ID-of-target-validator&gt; [&lt;setting&gt;...]</code></pre>
 	<p>The transformation result can optionally also be validated. To
-		do so, specify a validator to use by its ID in HALE. For example to
+		do so, specify a validator to use by its ID in hale. For example to
 		validate a created XML/GML file against it's XML Schema Definition use:</p>
 	<pre><code>-validate eu.esdihumboldt.hale.io.xml.validator</code></pre>
 	<p>
@@ -322,9 +322,9 @@
 		validator will by default be configured with the content type of the
 		transformation result writer. <i>Please note that this reference
 			documentation is generated from the I/O providers present in your
-			local HALE installation (including eventual additional plugins and
+			local <i>hale studio</i> installation (including eventual additional plugins and
 			custom implementations), so it is <b>only available in the local
-				HALE help and not in the online version on the web</b>.
+				<i>hale studio</i> help and not in the online version on the web</b>.
 		</i>
 	</p>
 	<h4>Other options</h4>
@@ -337,7 +337,7 @@
 			the validation. Use this option if you want to know in detail what
 			kind of warnings or errors may have occurred during the execution of
 			these tasks. If you find the file format hard to read, import the
-			report log into the <i>Report List</i> view in HALE.
+			report log into the <i>Report List</i> view in <i>hale studio</i>.
 		</dd>
 		<dt><code>-stacktrace</code></dt>
 		<dd>Provide this flag to enable printing the stacktrace if
@@ -352,7 +352,7 @@
 	</dl>
 	<h2>Examples</h2>
 	<p>Here is an example on how to use the command line interface. There is a 
-	HALE project named <code>toInspire.halez</code> which contains a source schema 
+	hale project named <code>toInspire.halez</code> which contains a source schema 
 	and a mapping one of the INSPIRE application schemas. The source data is contained 
 	in the <code>geographicData.shp</code> file, which is encoded in <code>UTF-8</code>. The transformed 
 	data should be stored in <code>inspireData.gml</code> and as GML with an INSPIRE SpatialDataSet as container.</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/alignment.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/alignment.html
@@ -25,7 +25,7 @@
 		mapping of the example project provided in the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with HALE</a>
+			alt="command link">Get started with hale studio</a>
 		guide. The mapping cells displayed are those that are associated with
 		the selected relation. This is always the corresponding cell, defining
 		the type relation, but also the mappings on properties that are

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/properties.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/properties.html
@@ -10,7 +10,7 @@
 		The properties view displays detailed information about the currently
 		selected object. Depending on the type of object, a different set of
 		properties is displayed. The object types for which this information
-		is available in <i>HALE</i> are the following:
+		is available in <i>hale studio</i> are the following:
 	</p>
 	<ul>
 		<li>Schema elements (e.g. selection from the <a

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html
@@ -19,7 +19,7 @@
 	<p>
 		The top level elements in the schema explorer are the classes/types
 		defined in the schema, which may be used in the mapping. When loading
-		a schema <i>HALE</i> tries to determine this automatically, but you
+		a schema <i>hale studio</i> tries to determine this automatically, but you
 		can also define manually, which types are relevant for your mapping.
 	</p>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/toc.xml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/toc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<toc label="HALE User Guide">
+<toc label="hale studio User Guide">
    <topic label="Introduction">
-      <topic href="html/introduction/introduction_HALE.html" label="HALE - The HUMBOLDT Alignment Editor">
+      <topic href="html/introduction/introduction_HALE.html" label="hale studio - The HUMBOLDT Alignment Editor">
       </topic>
       <topic href="html/introduction/introduction_project.html" label="The HUMBOLDT project">
       </topic>
@@ -36,9 +36,9 @@
       </topic>
    </topic>
    <topic label="Getting Started">
-      <topic href="html/getting_started/help.html" label="How to use the HALE help">
+      <topic href="html/getting_started/help.html" label="How to use the hale studio help">
       </topic>
-      <topic href="html/getting_started/main_workflow.html" label="First steps in HALE">
+      <topic href="html/getting_started/main_workflow.html" label="First steps in hale studio">
       </topic>
       <topic href="html/getting_started/confWorkbench.html" label="Configuring your workbench">
       </topic>

--- a/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/customtile_detail.html
+++ b/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/customtile_detail.html
@@ -8,7 +8,7 @@
 	<h1>Custom Tile Server Configuration</h1>
 	<p>
 		By configuring custom tile map servers, you can use any map based on
-		the web tiling scheme in <i>HALE</i>'s map view.
+		the web tiling scheme in <i>hale studio</i>'s map view.
 	</p>
 	<p>
 		To work with <i>Custom Tile</i> maps, first open the Map view, go to
@@ -23,7 +23,7 @@
 			style="margin-left: 20px">
 	</div>
 
-	<p>By default, hale studio uses the Stamen Terrain map in the Map
+	<p>By default, <i>hale studio</i> uses the Stamen Terrain map in the Map
 		view. Map tiles by <a href="http://stamen.com">Stamen Design</a>, 
 		under <a href="http://creativecommons.org/licenses/by/3.0">
 		CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">
@@ -33,7 +33,7 @@
 
 	<div>
 		<img src="../images/custom_default.png"
-			title="Custom Tile map(Stamen Terrain) as a default in HALE"
+			title="Custom Tile map(Stamen Terrain) as a default in hale studio"
 			class="fit"> <img src="../images/custom_default_menu.png"
 			title="Stamen Terrain in view menu of map" class="fit"
 			style="margin-left: 20px">
@@ -56,7 +56,7 @@
 	<p>
 		Please note, name should be unique in <i>Custom Tile</i> maps. The URL
 		Pattern has to include {z}, {x} and {y} literals which will be
-		replaced by the HALE as Zoom level, x-coordinate and y-coordinate
+		replaced by the <i>hale studio</i> as Zoom level, x-coordinate and y-coordinate
 		respectively while fetching the tiles. To go to the next configuration
 		page, click on <i>Next</i> button in the dialog or click <i>Finish</i>
 		directly to skip next configuration pages.

--- a/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/map_view.html
+++ b/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/map_view.html
@@ -17,7 +17,7 @@
 		reference system. For source data, this depends on the support
 		provided for geometries for the respective import format. The map will
 		display the geometries contained in the <i>default geometry
-			property</i>. <i>HALE</i> will try to determine the property
+			property</i>. <i>hale studio</i> will try to determine the property
 		automatically based on the schema, but you can also assign it manually
 		for each schema type using the context menu in the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html">Schema

--- a/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/wms_detail.html
+++ b/ext/styledmap/eu.esdihumboldt.hale.doc.user.views.styledmap/html/wms_detail.html
@@ -87,7 +87,7 @@
 	
 	
 	<p>
-		After finishing configuration, hale studio displays the <i>WMS map</i> 
+		After finishing configuration, <i>hale studio</i> displays the <i>WMS map</i> 
 		in the <i>Map</i> view. 
 	</p>
 	<div>

--- a/ui/plugins/eu.esdihumboldt.hale.ui.firststeps/intro/firststeps_part2.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.firststeps/intro/firststeps_part2.xml
@@ -2,7 +2,7 @@
 <introContent>
    <extensionContent id="euesdihumboldthaleuifirststeps-introExtension_part2" style="css/sample.css" name="Firststeps Cheatsheets" path="firststeps/@">
       <group style-id="content-group" id="euesdihumboldthaleuifirststeps-introLink-group">
-         <link label="Get started with HALE" url="http://org.eclipse.ui.intro/showStandby?partId=org.eclipse.platform.cheatsheet&amp;input=eu.esdihumboldt.hale.ui.firststeps.firststepsCS" style-id="content-link header-link">
+         <link label="Get started with hale studio" url="http://org.eclipse.ui.intro/showStandby?partId=org.eclipse.platform.cheatsheet&amp;input=eu.esdihumboldt.hale.ui.firststeps.firststepsCS" style-id="content-link header-link">
             <text>Get a guide along your way to see how the Humboldt Alignment Editor works and to create a new project.</text>
          </link>
          <group id="sub-content-group" label="Or only choose one of the parts of that guide:">


### PR DESCRIPTION
Replace product name in documentation, as outlined in #310.