### PR TITLE
Replace "HALE" with "hale"/"hale studio" in GUI

### DIFF
--- a/app/plugins/eu.esdihumboldt.hale.app.transform/src/eu/esdihumboldt/hale/app/transform/ExecApplication.groovy
+++ b/app/plugins/eu.esdihumboldt.hale.app.transform/src/eu/esdihumboldt/hale/app/transform/ExecApplication.groovy
@@ -97,7 +97,7 @@ class ExecApplication extends AbstractApplication<ExecContext> {
 	protected boolean validate(ExecContext ec) {
 		// project is required
 		if (!ec.project) {
-			error('You need to provide a reference to a HALE project that defines the mapping for the transformation')
+			error('You need to provide a reference to a hale project that defines the mapping for the transformation')
 			return false
 		}
 
@@ -125,7 +125,7 @@ class ExecApplication extends AbstractApplication<ExecContext> {
 Usage:
 $baseCommand
      [-argsFile <file-with-arguments>]
-     -project <file-or-URI-to-HALE-project>
+     -project <file-or-URI-to-hale-project>
      -source <file-or-URI-to-source-data>
          [-include <file-pattern>]
          [-exclude <file-pattern>]

--- a/app/plugins/eu.esdihumboldt.hale.app.transform/src/eu/esdihumboldt/hale/app/transform/ExecTransformation.java
+++ b/app/plugins/eu.esdihumboldt.hale.app.transform/src/eu/esdihumboldt/hale/app/transform/ExecTransformation.java
@@ -292,7 +292,7 @@ public class ExecTransformation implements ConsoleConstants {
 	}
 
 	private void loadProject() throws IOException {
-		status("Loading HALE project...");
+		status("Loading hale project...");
 
 		env = new ProjectTransformationEnvironment(id,
 				new DefaultInputSupplier(context.getProject()), reportHandler);
@@ -444,7 +444,7 @@ public class ExecTransformation implements ConsoleConstants {
 	}
 
 	private void transform() throws InterruptedException, ExecutionException {
-		status("Running HALE transformation...");
+		status("Running hale transformation...");
 
 		// configure transformation environment
 

--- a/common/plugins/eu.esdihumboldt.hale.common.align/plugin.xml
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/plugin.xml
@@ -505,7 +505,7 @@
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="align,xml"
             id="eu.esdihumboldt.hale.io.align.26"
-            name="HALE alignment"
+            name="hale alignment"
             priority="normal">
          <describer
                class="eu.esdihumboldt.hale.util.nonosgi.contenttype.describer.XMLRootElementContentDescriber2">

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/AbstractAlignmentReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/AbstractAlignmentReader.java
@@ -193,7 +193,7 @@ public abstract class AbstractAlignmentReader extends AbstractImportProvider imp
 	 */
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE alignment";
+		return "hale alignment";
 	}
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/CastorAlignmentReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/CastorAlignmentReader.java
@@ -48,7 +48,7 @@ public class CastorAlignmentReader extends AbstractAlignmentReader {
 	@Override
 	protected MutableAlignment loadAlignment(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Load HALE alignment", ProgressIndicator.UNKNOWN);
+		progress.begin("Load hale alignment", ProgressIndicator.UNKNOWN);
 
 		InputStream in = getSource().getInput();
 		MutableAlignment alignment = null;

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/CastorAlignmentWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/CastorAlignmentWriter.java
@@ -49,7 +49,7 @@ public class CastorAlignmentWriter extends AbstractAlignmentWriter {
 	@Override
 	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Save HALE alignment", ProgressIndicator.UNKNOWN);
+		progress.begin("Save hale alignment", ProgressIndicator.UNKNOWN);
 
 		PathUpdate pathUpdate = new PathUpdate(getProjectLocation(), getTarget().getLocation());
 		OutputStream out = getTarget().getOutput();
@@ -73,7 +73,7 @@ public class CastorAlignmentWriter extends AbstractAlignmentWriter {
 	 */
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE alignment";
+		return "hale alignment";
 	}
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentReader.java
@@ -49,7 +49,7 @@ public class JaxbAlignmentReader extends AbstractAlignmentReader {
 	@Override
 	protected MutableAlignment loadAlignment(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Load HALE alignment", ProgressIndicator.UNKNOWN);
+		progress.begin("Load hale alignment", ProgressIndicator.UNKNOWN);
 
 		InputStream in = getSource().getInput();
 		MutableAlignment alignment = null;

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentWriter.java
@@ -50,7 +50,7 @@ public class JaxbAlignmentWriter extends AbstractAlignmentWriter {
 	@Override
 	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Save HALE alignment", ProgressIndicator.UNKNOWN);
+		progress.begin("Save hale alignment", ProgressIndicator.UNKNOWN);
 
 		PathUpdate pathUpdate = new PathUpdate(getProjectLocation(), getTarget().getLocation());
 		AlignmentType alignment;
@@ -83,7 +83,7 @@ public class JaxbAlignmentWriter extends AbstractAlignmentWriter {
 	 */
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE alignment";
+		return "hale alignment";
 	}
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbBaseAlignmentReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbBaseAlignmentReader.java
@@ -55,7 +55,7 @@ public class JaxbBaseAlignmentReader extends AbstractImportProvider implements B
 	@Override
 	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Load HALE alignment", ProgressIndicator.UNKNOWN);
+		progress.begin("Load hale alignment", ProgressIndicator.UNKNOWN);
 
 		try {
 			JaxbAlignmentIO.addBaseAlignment(getAlignment(), getSource().getUsedLocation(),
@@ -76,7 +76,7 @@ public class JaxbBaseAlignmentReader extends AbstractImportProvider implements B
 	 */
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE alignment";
+		return "hale alignment";
 	}
 
 	/**

--- a/common/plugins/eu.esdihumboldt.hale.common.core/plugin.xml
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/plugin.xml
@@ -14,14 +14,14 @@
       <content-type
             file-extensions="hale"
             id="eu.esdihumboldt.hale.io.project.hale25"
-            name="HALE project"
+            name="hale project"
             priority="normal">
       </content-type>
       <content-type
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="halex"
             id="eu.esdihumboldt.hale.io.project.hale25.xml"
-            name="HALE XML project"
+            name="hale XML project"
             priority="normal">
          <describer
                class="eu.esdihumboldt.hale.util.nonosgi.contenttype.describer.XMLRootElementContentDescriber2">
@@ -34,7 +34,7 @@
       <content-type
             file-extensions="halez,zip"
             id="eu.esdihumboldt.hale.io.project.hale25.zip"
-            name="HALE project archive"
+            name="hale project archive"
             priority="normal">
       </content-type>
       <content-type
@@ -52,7 +52,7 @@
       <provider
             class="eu.esdihumboldt.hale.common.core.io.project.impl.ZipProjectReader"
             id="eu.esdihumboldt.hale.io.project.hale25.reader"
-            name="HALE project">
+            name="hale project">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25">
          </contentType>
@@ -61,7 +61,7 @@
             class="eu.esdihumboldt.hale.common.core.io.project.impl.ZipProjectWriter"
             description="Single project file that includes alignment and styles"
             id="eu.esdihumboldt.hale.io.project.hale25.writer"
-            name="HALE project">
+            name="hale project">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25">
          </contentType>
@@ -69,7 +69,7 @@
       <provider
             class="eu.esdihumboldt.hale.common.core.io.project.impl.XMLProjectReader"
             id="eu.esdihumboldt.hale.io.project.hale25.xml.reader"
-            name="HALE XML project">
+            name="hale XML project">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25.xml">
          </contentType>
@@ -78,7 +78,7 @@
             class="eu.esdihumboldt.hale.common.core.io.project.impl.XMLProjectWriter"
             description="XML project file with separate alignment file (best choice for version controlled projects)"
             id="eu.esdihumboldt.hale.io.project.hale25.xml.writer"
-            name="HALE XML project">
+            name="hale XML project">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25.xml">
          </contentType>
@@ -87,7 +87,7 @@
             class="eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectWriter"
             description="ZIP project archive that also includes local resources (best choice for sharing projects)"
             id="eu.esdihumboldt.hale.io.project.hale25.zip.writer"
-            name="HALE project archive">
+            name="hale project archive">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25.zip">
          </contentType>
@@ -95,7 +95,7 @@
       <provider
             class="eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectImport"
             id="eu.esdihumboldt.hale.io.project.hale25.zip.import"
-            name="HALE project archive (import)">
+            name="hale project archive (import)">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25.zip">
          </contentType>
@@ -103,7 +103,7 @@
       <provider
             class="eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectReader"
             id="eu.esdihumboldt.hale.io.project.hale25.zip.reader"
-            name="HALE project archive">
+            name="hale project archive">
          <contentType
                ref="eu.esdihumboldt.hale.io.project.hale25.zip">
          </contentType>

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/HalePlatform.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/HalePlatform.java
@@ -127,7 +127,7 @@ public class HalePlatform {
 					coreVersion = Version.parseVersion(versionString);
 				}
 			} catch (Exception e) {
-				log.error("Failure determining HALE core version", e);
+				log.error("Failure determining hale core version", e);
 				coreVersion = Version.emptyVersion;
 			}
 		}

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/ProjectIO.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/ProjectIO.java
@@ -98,7 +98,7 @@ public abstract class ProjectIO {
 	/**
 	 * Project file default type name
 	 */
-	public static final String PROJECT_TYPE_NAME = "HALE project";
+	public static final String PROJECT_TYPE_NAME = "hale project";
 
 	/**
 	 * Name of the internal project file

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/impl/AbstractProjectReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/impl/AbstractProjectReader.java
@@ -103,7 +103,7 @@ public abstract class AbstractProjectReader extends AbstractImportProvider
 			if (compared < 0) {
 				// project is newer than HALE
 				String message = MessageFormat.format(
-						"The version of HALE the loaded project was created with ({1}) is newer than this version of HALE ({0}). Consider updating to avoid possible information loss or unexpected behavior.",
+						"The version of hale studio the loaded project was created with ({1}) is newer than this version of hale studio ({0}). Consider updating to avoid possible information loss or unexpected behavior.",
 						haleVersion, projectVersion);
 				// report
 				reporter.warn(new IOMessageImpl(message, null));
@@ -113,8 +113,8 @@ public abstract class AbstractProjectReader extends AbstractImportProvider
 			else if (compared == 0 && HalePlatform.isSnapshotVersion()) {
 				// same version, but used version is a SNAPSHOT version
 				reporter.warn(new IOMessageImpl(MessageFormat.format(
-						"You are using a SNAPSHOT version of HALE {0} to load a project of the same version. "
-								+ "Thus there is the possibility that in the loaded project there are HALE features used that are not yet supported by your SNAPSHOT.",
+						"You are using a SNAPSHOT version of hale studio {0} to load a project of the same version. "
+								+ "Thus there is the possibility that in the loaded project there are hale studio features used that are not yet supported by your SNAPSHOT.",
 						haleVersion), null));
 			}
 		}

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/plugin.xml
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/plugin.xml
@@ -5,9 +5,9 @@
          point="eu.esdihumboldt.hale.io.provider">
       <provider
             class="eu.esdihumboldt.hale.common.schema.persist.hsd.HaleSchemaWriter"
-            description="HALE native schema format"
+            description="hale native schema format"
             id="eu.esdihumboldt.hale.common.schema.persist.hsd.write"
-            name="HALE Schema Definition">
+            name="hale Schema Definition">
          <contentType
                ref="eu.esdihumboldt.hale.common.schema.hsd">
          </contentType>
@@ -18,7 +18,7 @@
       <provider
             class="eu.esdihumboldt.hale.common.schema.persist.hsd.HaleSchemaReader"
             id="eu.esdihumboldt.hale.common.schema.persist.hsd.read"
-            name="HALE Schema Definition">
+            name="hale Schema Definition">
          <contentType
                ref="eu.esdihumboldt.hale.common.schema.hsd">
          </contentType>
@@ -28,18 +28,18 @@
       </provider>
       <provider
             class="eu.esdihumboldt.hale.common.schema.persist.hsd.json.HaleSchemaWriterJson"
-            description="HALE native schema format as JSON"
+            description="hale native schema format as JSON"
             id="eu.esdihumboldt.hale.common.schema.persist.hsd.json.write"
-            name="HALE Schema Definition (JSON)">
+            name="hale Schema Definition (JSON)">
          <contentType
                ref="eu.esdihumboldt.hale.common.schema.hsd.json">
          </contentType>
       </provider>
       <provider
             class="eu.esdihumboldt.hale.common.schema.persist.hsd.json.HaleSchemaReaderJson"
-            description="HALE native schema format as JSON"
+            description="hale native schema format as JSON"
             id="eu.esdihumboldt.hale.common.schema.persist.hsd.json.read"
-            name="HALE Schema Definition (JSON)">
+            name="hale Schema Definition (JSON)">
          <contentType
                ref="eu.esdihumboldt.hale.common.schema.hsd.json">
          </contentType>
@@ -51,7 +51,7 @@
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="hsd,haleschema"
             id="eu.esdihumboldt.hale.common.schema.hsd"
-            name="HALE Schema Definition"
+            name="hale Schema Definition"
             priority="normal">
          <describer
                class="eu.esdihumboldt.hale.util.nonosgi.contenttype.describer.XMLRootElementContentDescriber2">
@@ -69,7 +69,7 @@
             base-type="eu.esdihumboldt.hale.common.core.gzip"
             file-extensions="hsd.gz,haleschema.gz"
             id="eu.esdihumboldt.hale.common.schema.hsd.gzip"
-            name="GZiped HALE Schema Definition"
+            name="GZiped hale Schema Definition"
             priority="normal">
          <describer
                class="eu.esdihumboldt.hale.common.core.io.util.GZipXMLRootElementContentDescriber">
@@ -87,7 +87,7 @@
             base-type="org.eclipse.core.runtime.text"
             file-extensions="hsd.json,json"
             id="eu.esdihumboldt.hale.common.schema.hsd.json"
-            name="HALE Schema Definition (JSON)"
+            name="hale Schema Definition (JSON)"
             priority="normal">
       </content-type>
    </extension>

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaReader.java
@@ -63,7 +63,7 @@ public class HaleSchemaReader extends AbstractSchemaReader {
 
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE Schema Definition";
+		return "hale Schema Definition";
 	}
 
 	@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaWriter.java
@@ -79,7 +79,7 @@ public class HaleSchemaWriter extends AbstractSchemaWriter {
 
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE Schema Definition";
+		return "hale Schema Definition";
 	}
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaReaderJson.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaReaderJson.java
@@ -77,7 +77,7 @@ public class HaleSchemaReaderJson extends AbstractSchemaReader {
 
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE Schema Definition (JSON)";
+		return "hale Schema Definition (JSON)";
 	}
 
 	@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaWriterJson.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaWriterJson.java
@@ -63,7 +63,7 @@ public class HaleSchemaWriterJson extends AbstractSchemaWriter {
 
 	@Override
 	protected String getDefaultTypeName() {
-		return "HALE Schema Definition (JSON)";
+		return "hale Schema Definition (JSON)";
 	}
 
 }

--- a/ext/styledmap/eu.esdihumboldt.hale.ui.views.styledmap/plugin.xml
+++ b/ext/styledmap/eu.esdihumboldt.hale.ui.views.styledmap/plugin.xml
@@ -6,7 +6,7 @@
          point="de.fhg.igd.mapviewer.view.MapViewExtension">
       <extra
             class="eu.esdihumboldt.hale.ui.views.styledmap.StyledMapExtra"
-            name="HALE Styled Map">
+            name="hale Styled Map">
       </extra>
    </extension>
    <extension

--- a/io/plugins/eu.esdihumboldt.hale.io.appschema/src/eu/esdihumboldt/hale/io/appschema/writer/AbstractAppSchemaConfigurator.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.appschema/src/eu/esdihumboldt/hale/io/appschema/writer/AbstractAppSchemaConfigurator.java
@@ -65,7 +65,7 @@ public abstract class AbstractAppSchemaConfigurator extends AbstractAlignmentWri
 	@Override
 	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		progress.begin("Translate HALE alignment to App-Schema Configuration",
+		progress.begin("Translate hale alignment to App-Schema Configuration",
 				ProgressIndicator.UNKNOWN);
 		if (getAlignment() == null) {
 			throw new IOProviderConfigurationException("No alignment was provided.");

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/internal/CSVAlignmentMappingWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/internal/CSVAlignmentMappingWriter.java
@@ -84,6 +84,6 @@ public class CSVAlignmentMappingWriter extends AbstractAlignmentMappingExport {
 	 */
 	@Override
 	protected String getDefaultTypeName() {
-		return "CSV HALE Alignment";
+		return "CSV hale Alignment";
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/internal/SpatiaLiteHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/internal/SpatiaLiteHelper.java
@@ -106,8 +106,8 @@ public class SpatiaLiteHelper {
 			if (!result) {
 				String msg = "The SpatiaLite extension for SQLite (mod_spatialite) could not be loaded. "
 						+ "This means that it is not possible to properly load or store geometries from/to SQLite.\n\n"
-						+ "Please check the HALE help on how to make it available:\n"
-						+ "HALE User Guide > Reference > Supported formats > Import > SQLite and SpatiaLite";
+						+ "Please check the hale studio help on how to make it available:\n"
+						+ "hale studio User Guide > Reference > Supported formats > Import > SQLite and SpatiaLite";
 				if (error) {
 					log.userError(msg);
 				}

--- a/io/plugins/eu.esdihumboldt.hale.io.oml/src/eu/esdihumboldt/hale/io/oml/helper/NotSupportedTranslator.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.oml/src/eu/esdihumboldt/hale/io/oml/helper/NotSupportedTranslator.java
@@ -66,8 +66,8 @@ public class NotSupportedTranslator implements FunctionTranslator {
 
 		}
 
-		reporter.error(new IOMessageImpl("The function '" + id
-				+ "' is not supported in this HALE version", null));
+		reporter.error(new IOMessageImpl(
+				"The function '" + id + "' is not supported in this hale studio version", null));
 
 		return params;
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSAlignmentMappingWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSAlignmentMappingWriter.java
@@ -177,7 +177,7 @@ public class XLSAlignmentMappingWriter extends AbstractAlignmentMappingExport {
 
 	@Override
 	protected String getDefaultTypeName() {
-		return "XLS HALE Alignment";
+		return "XLS hale Alignment";
 	}
 
 	private int calculateWidth(int maxColWidth) {

--- a/ui/plugins/eu.esdihumboldt.hale.ui.application/plugin.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.application/plugin.xml
@@ -84,7 +84,7 @@
          </property>
          <property
                name="aboutText"
-               value="hale studio&#x0A;&#x0A;Version ___version___&#x0A;&#x0A;Build ___build___&#x0A;Revision ___revision___&#x0A;&#x0A;Project page:&#x0A;http://www.wetransform.to/products/hale&#x0A;&#x0A;Forum:&#x0A;http://www.esdi-community.eu/projects/hale/boards&#x0A;&#x0A;News:&#x0A;http://www.wetransform.to/news&#x0A;&#x0A;Get professional support:&#x0A;http://www.wetransform.to/services/support">
+               value="hale studio&#x0A;&#x0A;Version ___version___&#x0A;&#x0A;Build ___build___&#x0A;Revision ___revision___&#x0A;&#x0A;Project page:&#x0A;https://www.wetransform.to/products/halestudio/&#x0A;&#x0A;Forum:&#x0A;https://discuss.wetransform.to/&#x0A;&#x0A;News:&#x0A;https://www.wetransform.to/category/news/&#x0A;&#x0A;Get professional support:&#x0A;https://www.wetransform.to/services/support/">
          </property>
          <property
                name="introTitle"

--- a/ui/plugins/eu.esdihumboldt.hale.ui.firststeps/plugin.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.firststeps/plugin.xml
@@ -79,7 +79,7 @@
       <example-project
             id="eu.esdihumboldt.hale.ui.firststeps.introexample"
             location="exampleschema/t1t2.halex"
-            summary="Basic example project used in the &apos;Get started with HALE&apos; guide.">
+            summary="Basic example project used in the &apos;Get started with hale studio&apos; guide.">
       </example-project>
    </extension>
 </plugin>

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util/plugin.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util/plugin.xml
@@ -11,7 +11,7 @@
    <extension
          point="org.eclipse.ui.commands">
       <command
-            description="Exit HALE"
+            description="Exit hale studio"
             id="eu.esdihumboldt.hale.ui.util.command.exit"
             name="exit">
       </command>

--- a/ui/plugins/eu.esdihumboldt.hale.ui/plugin.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/plugin.xml
@@ -851,7 +851,7 @@
          point="org.eclipse.ui.views">
       <category
             id="eu.esdihumboldt.hale.ui"
-            name="HALE">
+            name="hale studio">
       </category>
    </extension>
    <extension


### PR DESCRIPTION
Replace product name in the GUI, as outlined in #310.