### PR TITLE
Add global switch to activate baked-in defaults for hale connect base paths

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/HaleConnectExtendedPreferencePage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/HaleConnectExtendedPreferencePage.java
@@ -15,11 +15,19 @@
 
 package eu.esdihumboldt.hale.io.haleconnect.ui.preferences;
 
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectService;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices;
 import eu.esdihumboldt.hale.io.haleconnect.ui.internal.HaleConnectImages;
@@ -33,6 +41,15 @@ import eu.esdihumboldt.hale.ui.HaleUI;
  */
 public class HaleConnectExtendedPreferencePage extends FieldEditorPreferencePage
 		implements IWorkbenchPreferencePage {
+
+	private static final ALogger log = ALoggerFactory
+			.getLogger(HaleConnectExtendedPreferencePage.class);
+
+	private BooleanFieldEditor defaults;
+	private StringFieldEditor clientBasepath;
+	private StringFieldEditor usersBasepath;
+	private StringFieldEditor dataBasepath;
+	private StringFieldEditor projectsBasepath;
 
 	/**
 	 * Creates new extended preferences page
@@ -51,17 +68,50 @@ public class HaleConnectExtendedPreferencePage extends FieldEditorPreferencePage
 	 */
 	@Override
 	protected void performApply() {
+		updateBasepaths();
 		super.performApply();
+	}
 
+	/**
+	 * @see org.eclipse.jface.preference.FieldEditorPreferencePage#performOk()
+	 */
+	@Override
+	public boolean performOk() {
+		updateBasepaths();
+		return super.performOk();
+	}
+
+	private void updateBasepaths() {
 		HaleConnectService hcs = HaleUI.getServiceProvider().getService(HaleConnectService.class);
-		hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
-				HaleConnectUIPlugin.getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_USERS));
-		hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
-				HaleConnectUIPlugin.getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA));
-		hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE, HaleConnectUIPlugin
-				.getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_PROJECTS));
-		hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT, HaleConnectUIPlugin
-				.getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_CLIENT));
+
+		if (defaults.getBooleanValue()) {
+			// Force default values
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
+					PreferenceInitializer.HALE_CONNECT_BASEPATH_USERS_DEFAULT);
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
+					PreferenceInitializer.HALE_CONNECT_BASEPATH_DATA_DEFAULT);
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
+					PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT);
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
+					PreferenceInitializer.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT);
+		}
+		else {
+			// Use individually configured values
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
+					usersBasepath.getStringValue());
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
+					dataBasepath.getStringValue());
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
+					projectsBasepath.getStringValue());
+			hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
+					clientBasepath.getStringValue());
+		}
+
+		if (hcs.isLoggedIn()) {
+			hcs.clearSession();
+			MessageDialog.openInformation(getShell(), "hale connect preferences",
+					"You have been logged out from hale connect.");
+		}
 	}
 
 	/**
@@ -69,14 +119,61 @@ public class HaleConnectExtendedPreferencePage extends FieldEditorPreferencePage
 	 */
 	@Override
 	protected void createFieldEditors() {
-		addField(new StringFieldEditor(PreferenceConstants.HALE_CONNECT_BASEPATH_CLIENT,
-				"Web client base path (URL):", getFieldEditorParent()));
-		addField(new StringFieldEditor(PreferenceConstants.HALE_CONNECT_BASEPATH_USERS,
-				"User service base path (URL):", getFieldEditorParent()));
-		addField(new StringFieldEditor(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA,
-				"Bucket service base path (URL):", getFieldEditorParent()));
-		addField(new StringFieldEditor(PreferenceConstants.HALE_CONNECT_BASEPATH_PROJECTS,
+		addField(defaults = new BooleanFieldEditor(
+				PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS,
+				"Use defaults for haleconnect.com?", getFieldEditorParent()) {
+
+			/**
+			 * @see org.eclipse.jface.preference.FieldEditor#createControl(org.eclipse.swt.widgets.Composite)
+			 */
+			@Override
+			protected void createControl(Composite parent) {
+				super.createControl(parent);
+
+				getChangeControl(parent).addSelectionListener(new SelectionAdapter() {
+
+					/**
+					 * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
+					 */
+					@Override
+					public void widgetSelected(SelectionEvent e) {
+						boolean enable = !getChangeControl(getFieldEditorParent()).getSelection();
+						updateBasepathControls(enable);
+					}
+
+				});
+			}
+
+		});
+
+		addField(clientBasepath = new StringFieldEditor(
+				PreferenceConstants.HALE_CONNECT_BASEPATH_CLIENT, "Web client base path (URL):",
+				getFieldEditorParent()));
+		addField(usersBasepath = new StringFieldEditor(
+				PreferenceConstants.HALE_CONNECT_BASEPATH_USERS, "User service base path (URL):",
+				getFieldEditorParent()));
+		addField(
+				dataBasepath = new StringFieldEditor(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA,
+						"Bucket service base path (URL):", getFieldEditorParent()));
+		addField(projectsBasepath = new StringFieldEditor(
+				PreferenceConstants.HALE_CONNECT_BASEPATH_PROJECTS,
 				"Project store base path (URL):", getFieldEditorParent()));
+
+		updateBasepathControls(!HaleConnectUIPlugin.getDefault().getPreferenceStore()
+				.getBoolean(PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS));
+	}
+
+	private void enableIfExists(FieldEditor control, Composite parent, boolean enabled) {
+		if (control != null) {
+			control.setEnabled(enabled, parent);
+		}
+	}
+
+	private void updateBasepathControls(boolean enabled) {
+		enableIfExists(clientBasepath, getFieldEditorParent(), enabled);
+		enableIfExists(usersBasepath, getFieldEditorParent(), enabled);
+		enableIfExists(dataBasepath, getFieldEditorParent(), enabled);
+		enableIfExists(projectsBasepath, getFieldEditorParent(), enabled);
 	}
 
 	/**

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceConstants.java
@@ -31,6 +31,8 @@ public interface PreferenceConstants {
 	 */
 	static final String SECURE_NODE_NAME = "eu.esdihumboldt.hale"; //$NON-NLS-1$
 
+	static final String HALE_CONNECT_BASEPATH_USE_DEFAULTS = "eu.esdihumboldt.hale.io.haleconnect.ui.endpoints.usedefaults";
+
 	static final String HALE_CONNECT_BASEPATH_USERS = "eu.esdihumboldt.hale.io.haleconnect.ui.login.endpoint";
 	static final String HALE_CONNECT_BASEPATH_DATA = "eu.esdihumboldt.hale.io.haleconnect.ui.endpoints.data";
 	static final String HALE_CONNECT_BASEPATH_PROJECTS = "eu.esdihumboldt.hale.io.haleconnect.ui.endpoints.projects";

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
@@ -40,6 +40,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	public void initializeDefaultPreferences() {
 		IPreferenceStore store = HaleConnectUIPlugin.getDefault().getPreferenceStore();
 
+		store.setDefault(PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS, true);
 		store.setDefault(PreferenceConstants.HALE_CONNECT_BASEPATH_USERS,
 				HALE_CONNECT_BASEPATH_USERS_DEFAULT);
 		store.setDefault(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA,


### PR DESCRIPTION
Allow activating the default base paths for hale connect via a checkbox in the extended preferences page. This will allow easier migration in the future in case the DNS names of the endpoints change.