### PR TITLE
make decorated properties public accessible

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/impl/AbstractGroupPropertyDecorator.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/impl/AbstractGroupPropertyDecorator.java
@@ -201,4 +201,11 @@ public abstract class AbstractGroupPropertyDecorator implements GroupPropertyDef
 		return propertyGroup.toString();
 	}
 
+	/**
+	 * @return internal property group definition
+	 */
+	public GroupPropertyDefinition getDecorated() {
+		return propertyGroup;
+	}
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/internal/SubstitutionProperty.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/internal/SubstitutionProperty.java
@@ -28,7 +28,10 @@ import eu.esdihumboldt.hale.io.xsd.model.XmlElement;
  */
 public class SubstitutionProperty extends DefaultPropertyDefinition {
 
-	private final DefaultPropertyDefinition originialProperty;
+	/**
+	 * original property that is substituted
+	 */
+	public final DefaultPropertyDefinition originialProperty;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
when using hale-api for analysis of the data schema, access to the origin properties is required.