### PR TITLE
Add support for partitioning GML to multiple files

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/supplier/MultiLocationOutputSupplier.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/supplier/MultiLocationOutputSupplier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.core.io.supplier;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Output supplier that supports multiple target locations.
+ * 
+ * @author Florian Esser
+ */
+public class MultiLocationOutputSupplier extends NoStreamOutputSupplier {
+
+	private final List<URI> locations = new ArrayList<>();
+
+	/**
+	 * Create a MultiOutputSupplier for the given locations
+	 * 
+	 * @param locations the collection of location URIs
+	 */
+	public MultiLocationOutputSupplier(Collection<URI> locations) {
+		super(null);
+
+		this.locations.addAll(locations);
+	}
+
+	/**
+	 * @return the list of location URIs
+	 */
+	public List<URI> getLocations() {
+		return locations;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/plugin.xml
@@ -70,6 +70,22 @@
                ref="eu.esdihumboldt.hale.io.gml.reader">
          </provider>
       </configPage>
+      <configPage
+            class="eu.esdihumboldt.hale.io.gml.ui.PartitionConfigurationPage"
+            order="11">
+         <provider
+               ref="eu.esdihumboldt.hale.io.gml.writer">
+         </provider>
+         <provider
+               ref="eu.esdihumboldt.hale.io.inspiregml.writer">
+         </provider>
+         <provider
+               ref="eu.esdihumboldt.hale.io.wfs.fc.write-1.1.0">
+         </provider>
+         <provider
+               ref="eu.esdihumboldt.hale.io.wfs.fc.write-2.0">
+         </provider>
+      </configPage>
    </extension>
 
 </plugin>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015 Data Harmonisation Panel
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     Data Harmonisation Panel <http://www.dhpanel.eu>
+ */
+
+package eu.esdihumboldt.hale.io.gml.ui;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
+
+import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.io.gml.writer.internal.StreamGmlWriter;
+import eu.esdihumboldt.hale.ui.io.IOWizard;
+import eu.esdihumboldt.hale.ui.io.config.AbstractConfigurationPage;
+
+/**
+ * Configuration page for GML file partitioning.
+ * 
+ * @author Simon Templer
+ * @author Florian Esser
+ */
+@SuppressWarnings("restriction")
+public class PartitionConfigurationPage
+		extends AbstractConfigurationPage<StreamGmlWriter, IOWizard<StreamGmlWriter>> {
+
+	private Button activatePartitioning;
+	private Spinner instances;
+
+	/**
+	 * Default constructor.
+	 */
+	public PartitionConfigurationPage() {
+		super("gmlPartition");
+
+		setTitle("XML/GML settings");
+		setDescription("Settings for splitting to multiple output files");
+	}
+
+	@Override
+	public void enable() {
+		// do nothing
+	}
+
+	@Override
+	public void disable() {
+		// do nothing
+	}
+
+	@Override
+	public boolean updateConfiguration(StreamGmlWriter provider) {
+		int threshold = activatePartitioning.getSelection() ? instances.getSelection()
+				: StreamGmlWriter.NO_PARTITIONING;
+		provider.setParameter(StreamGmlWriter.PARAM_INSTANCES_THRESHOLD, Value.of(threshold));
+		return true;
+	}
+
+	@Override
+	protected void createContent(Composite page) {
+		page.setLayout(new GridLayout(1, false));
+		GridDataFactory groupData = GridDataFactory.fillDefaults().grab(true, false);
+
+		Group part = new Group(page, SWT.NONE);
+		part.setLayout(new GridLayout(3, false));
+		part.setText("Partitioning");
+		groupData.applyTo(part);
+
+		activatePartitioning = new Button(part, SWT.CHECK);
+		activatePartitioning.setSelection(false);
+		activatePartitioning.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				update();
+			}
+		});
+
+		instances = new Spinner(part, SWT.BORDER);
+		instances.setMinimum(1);
+		instances.setMaximum(100000);
+		instances.setSelection(1);
+		instances.setIncrement(100);
+		instances.setPageIncrement(1000);
+
+		Label ext = new Label(part, SWT.NONE);
+		ext.setText("instances per file");
+
+		Label desc = new Label(part, SWT.WRAP);
+		GridDataFactory.swtDefaults().hint(400, SWT.DEFAULT).align(SWT.FILL, SWT.BEGINNING)
+				.span(3, 1).grab(true, false).applyTo(desc);
+		desc.setText(
+				"Number of instances that will be tried to fit into a single file. This number will only be exceeded if there are more objects that are all interconnected (e.g. a network).");
+
+		update();
+		setPageComplete(true);
+	}
+
+	private void update() {
+		instances.setEnabled(activatePartitioning.getSelection());
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.geotools;bundle-version="2.6.4",
  org.eclipse.core.contenttype;bundle-version="3.4.100",
  org.opengis;bundle-version="8.0.0",
  groovy;bundle-version="2.1.5",
- eu.esdihumboldt.hale.common.instance;bundle-version="3.2.0"
+ eu.esdihumboldt.hale.common.instance;bundle-version="3.2.0",
+ eu.esdihumboldt.hale.common.instance.graph;bundle-version="3.4.0"
 Import-Package: com.google.common.base,
  com.google.common.collect;version="11.0.1",
  com.google.common.io,

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
@@ -462,6 +462,20 @@
                   sampleDescription="Format must be given with digit 0 and decimal separator &apos;.&apos;. It states number of digits before and after decimal separator.">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Guiding value for instances per file. The number will be exceeded only in cases where there are too many inter-related instances that cannot be separated."
+               label="Instances per file"
+               name="instancesPerFile"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Integer">
+            </parameterBinding>
+            <valueDescriptor
+                  default="0"
+                  defaultDescription="By default, no partitioning will take place and all instances will be written to a single file."
+                  sample="1000">
+            </valueDescriptor>
+         </providerParameter>
       </provider>
       <provider
             class="eu.esdihumboldt.hale.io.gml.writer.XmlInstanceWriter"
@@ -717,6 +731,20 @@
                   sampleDescription="Format must be given with digit 0 and decimal separator &apos;.&apos;. It states number of digits before and after decimal separator.">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Guiding value for instances per file. The number will be exceeded only in cases where there are too many inter-related instances that cannot be separated."
+               label="Instances per file"
+               name="instancesPerFile"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Integer">
+            </parameterBinding>
+            <valueDescriptor
+                  default="0"
+                  defaultDescription="By default, no partitioning will take place and all instances will be written to a single file."
+                  sample="1000">
+            </valueDescriptor>
+         </providerParameter>
       </provider>
       <provider
             class="eu.esdihumboldt.hale.io.gml.writer.InspireInstanceWriter"
@@ -941,6 +969,20 @@
                   defaultDescription="By default no format is used, geometry coordiantes are written in the standard format only."
                   sample="000000.000"
                   sampleDescription="Format must be given with digit 0 and decimal separator &apos;.&apos;. It states number of digits before and after decimal separator.">
+            </valueDescriptor>
+         </providerParameter>
+         <providerParameter
+               description="Guiding value for instances per file. The number will be exceeded only in cases where there are too many inter-related instances that cannot be separated."
+               label="Instances per file"
+               name="instancesPerFile"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Integer">
+            </parameterBinding>
+            <valueDescriptor
+                  default="0"
+                  defaultDescription="By default, no partitioning will take place and all instances will be written to a single file."
+                  sample="1000">
             </valueDescriptor>
          </providerParameter>
       </provider>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriter.java
@@ -16,10 +16,14 @@
 
 package eu.esdihumboldt.hale.io.gml.writer.internal;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +45,7 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.geotools.gml3.GML;
 
+import com.google.common.io.Files;
 import com.vividsolutions.jts.geom.Geometry;
 
 import de.fhg.igd.slf4jplus.ALogger;
@@ -56,6 +61,10 @@ import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
 import eu.esdihumboldt.hale.common.core.io.supplier.DefaultInputSupplier;
 import eu.esdihumboldt.hale.common.core.io.supplier.Locatable;
+import eu.esdihumboldt.hale.common.core.io.supplier.LocatableOutputSupplier;
+import eu.esdihumboldt.hale.common.core.io.supplier.MultiLocationOutputSupplier;
+import eu.esdihumboldt.hale.common.instance.graph.reference.ReferenceGraph;
+import eu.esdihumboldt.hale.common.instance.graph.reference.impl.XMLInspector;
 import eu.esdihumboldt.hale.common.instance.io.impl.AbstractGeoInstanceWriter;
 import eu.esdihumboldt.hale.common.instance.io.impl.AbstractInstanceWriter;
 import eu.esdihumboldt.hale.common.instance.io.util.EnumWindingOrderTypes;
@@ -140,6 +149,16 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	 * coordinates should be formatted.
 	 */
 	public static final String PARAM_GEOMETRY_FORMAT = "geometry.write.decimalFormat";
+
+	/**
+	 * Name of the parameter defining the instance threshold.
+	 */
+	public static final String PARAM_INSTANCES_THRESHOLD = "instancesPerFile";
+
+	/**
+	 * Value for threshold parameter to deactivate partitioning.
+	 */
+	public static final int NO_PARTITIONING = 0;
 
 	/**
 	 * The XML stream writer
@@ -242,25 +261,119 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	@Override
 	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
 			throws IOProviderConfigurationException, IOException {
-		OutputStream out;
-		try {
-			out = init(reporter);
-		} catch (XMLStreamException e) {
-			throw new IOException("Creating the XML stream writer failed", e);
-		}
+		init();
 
-		try {
-			write(getInstances(), progress, reporter);
-			reporter.setSuccess(reporter.getErrors().isEmpty());
-		} catch (Exception e) {
-			reporter.error(new IOMessageImpl(e.getLocalizedMessage(), e));
-			reporter.setSuccess(false);
-		} finally {
-			progress.end();
-			out.close();
+		if (isThresholdConfigured()) {
+			int threshold = getParameter(PARAM_INSTANCES_THRESHOLD).as(Integer.class,
+					NO_PARTITIONING);
+			Iterator<InstanceCollection> parts = partition(getInstances(), threshold, progress);
+			writeParts(parts, progress, reporter);
+		}
+		else {
+			write(getInstances(), getTarget().getOutput(), progress, reporter);
 		}
 
 		return reporter;
+	}
+
+	/**
+	 * Write the given {@link InstanceCollection}s to multiple files using the
+	 * configured target as a base file name.<br>
+	 * <br>
+	 * Parts can only be written if the configured target is a URI to a local
+	 * file. The output files will be named after the target file, amended by a
+	 * counter. If, for example, the configured target file name is
+	 * <code>output.gml</code>, the files created by this method will be called
+	 * <code>output.0001.gml</code>, <code>output.0002.gml</code>, etc.
+	 * 
+	 * @param instanceCollections the parts to write
+	 * @param progress Progress indicator
+	 * @param reporter the reporter to use for the execution report
+	 * @throws IOException if an I/O operation fails
+	 * @see #setTarget(LocatableOutputSupplier)
+	 */
+	protected void writeParts(Iterator<InstanceCollection> instanceCollections,
+			ProgressIndicator progress, IOReporter reporter) throws IOException {
+		final URI location = getTarget().getLocation();
+
+		if (location == null) {
+			reporter.error("Cannot write multiple GML files: Output location unknown");
+			return;
+		}
+
+		// Can only write multiple instance collection if target is a local file
+		if (!"file".equals(location.getScheme())) {
+			reporter.error("Cannot write multiple GML files: Target must be a local file");
+			return;
+		}
+
+		Path origPath = Paths.get(location).normalize();
+		String filename;
+		String extension;
+		Path targetFolder;
+		if (origPath.toFile().isDirectory()) {
+			reporter.error("Cannot write to a directory: Target must a file");
+			return;
+			// TODO Support writing to a directory; use parameter to specify
+			// file name prefix.
+		}
+		else {
+			targetFolder = origPath.getParent();
+			filename = Files.getNameWithoutExtension(origPath.toString());
+			extension = Files.getFileExtension(origPath.toString());
+		}
+
+		List<URI> filesWritten = new ArrayList<>();
+		int i = 1;
+		while (instanceCollections.hasNext()) {
+			String targetFilename = String.format("%s%s%s.%04d.%s", targetFolder.toString(),
+					File.separator, filename, i++, extension);
+			File targetFile = new File(targetFilename);
+			FileOutputStream out = new FileOutputStream(targetFile);
+			InstanceCollection instances = instanceCollections.next();
+			write(instances, out, progress, reporter);
+			filesWritten.add(targetFile.toURI());
+		}
+
+		if (filesWritten.size() > 1) {
+			setTarget(new MultiLocationOutputSupplier(filesWritten));
+		}
+		else if (!filesWritten.isEmpty()) {
+			setTarget(new LocatableOutputSupplier<OutputStream>() {
+
+				@Override
+				public OutputStream getOutput() throws IOException {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public URI getLocation() {
+					return filesWritten.get(0);
+				}
+			});
+		}
+	}
+
+	/**
+	 * Partition instances in parts that respectively contain all referenced
+	 * instances.
+	 * 
+	 * @param instances instances to partition
+	 * @param threshold the guiding value for the maximum number of objects in a
+	 *            part
+	 * @param progress Progress indicator
+	 * @return an iterator of instance collections, each instance collection
+	 *         represents a part
+	 */
+	protected Iterator<InstanceCollection> partition(InstanceCollection instances, int threshold,
+			ProgressIndicator progress) {
+		progress.setCurrentTask("Partitioning data");
+
+		// create a reference graph
+		ReferenceGraph<String> rg = new ReferenceGraph<String>(new XMLInspector(), getInstances());
+
+		// partition the graph
+		return rg.partition(threshold);
 	}
 
 	// FIXME
@@ -274,9 +387,14 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 //		return result;
 //	}
 
+	private boolean isThresholdConfigured() {
+		int threshold = getParameter(PARAM_INSTANCES_THRESHOLD).as(Integer.class, NO_PARTITIONING);
+		return threshold != NO_PARTITIONING && threshold > 0;
+	}
+
 	@Override
 	public boolean isPassthrough() {
-		return true;
+		return !isThresholdConfigured();
 	}
 
 	/**
@@ -358,37 +476,26 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	}
 
 	/**
-	 * Create and setup the stream writer, the type index and the GML namespace
-	 * (Initializes {@link #writer}, {@link #gmlNs} and {@link #targetIndex},
-	 * resets {@link #geometryWriter} and {@link #additionalSchemas}).
+	 * Create and configure an <code>XMLStreamWriter</code> that writes to the
+	 * given <code>OutputStream</code>
 	 * 
-	 * @param reporter the reporter for any errors
-	 * 
-	 * @return the opened output stream
-	 * 
-	 * @throws XMLStreamException if creating the {@link XMLStreamWriter} fails
-	 * @throws IOException if creating the output stream fails
+	 * @param outStream <code>OutputStream</code> to write to
+	 * @param reporter the reporter
+	 * @return the configured <code>XMLStreamWriter</code>
+	 * @throws XMLStreamException if creating or configuring the
+	 *             <code>XMLStreamWriter</code> fails
 	 */
-	private OutputStream init(IOReporter reporter) throws XMLStreamException, IOException {
-		// reset target index
-		targetIndex = null;
-		// reset geometry writer
-		geometryWriter = null;
-		// reset additional schemas
-		additionalSchemas.clear();
-		additionalSchemaPrefixes.clear();
-
+	protected XMLStreamWriter createWriter(OutputStream outStream, IOReporter reporter)
+			throws XMLStreamException {
 		// create and set-up a writer
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
 		// will set namespaces if these not set explicitly
 		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", //$NON-NLS-1$
 				Boolean.valueOf(true));
+
 		// create XML stream writer with UTF-8 encoding
-		OutputStream outStream = getTarget().getOutput();
 		XMLStreamWriter tmpWriter = outputFactory.createXMLStreamWriter(outStream,
 				getCharset().name()); // $NON-NLS-1$
-
-		String defNamespace = null;
 
 		XmlIndex index = getXMLIndex();
 		// read the namespaces from the map containing namespaces
@@ -407,6 +514,8 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 
 		GmlWriterUtil.addNamespace(tmpWriter, SCHEMA_INSTANCE_NS, "xsi"); //$NON-NLS-1$
 
+		String defNamespace = null;
+
 		// determine default namespace
 //		if (defNamespace == null) {
 		// XXX don't use a default namespace, as this results in problems
@@ -424,14 +533,30 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 
 		// prettyPrint if enabled
 		if (isPrettyPrint()) {
-			writer = new IndentingXMLStreamWriter(tmpWriter);
+			return new IndentingXMLStreamWriter(tmpWriter);
 		}
 		else {
-			writer = tmpWriter;
+			return tmpWriter;
 		}
+	}
+
+	/**
+	 * Create and setup the type index and the GML namespace (Initializes
+	 * {@link #gmlNs} and {@link #targetIndex}, resets {@link #geometryWriter}
+	 * and {@link #additionalSchemas}).
+	 */
+	private void init() {
+		// reset target index
+		targetIndex = null;
+		// reset geometry writer
+		geometryWriter = null;
+		// reset additional schemas
+		additionalSchemas.clear();
+		additionalSchemaPrefixes.clear();
 
 		// determine GML namespace from target schema
 		String gml = null;
+		XmlIndex index = getXMLIndex();
 		if (index.getPrefixes() != null) {
 			Set<String> candidates = new TreeSet<>();
 			for (String ns : index.getPrefixes().keySet()) {
@@ -471,8 +596,6 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 		if (log.isDebugEnabled()) {
 			log.debug("GML namespace is " + gmlNs); //$NON-NLS-1$
 		}
-
-		return outStream;
 	}
 
 	/**
@@ -525,173 +648,212 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	}
 
 	/**
-	 * Write the given instances.
+	 * Write the given instances to an {@link OutputStream}.
 	 * 
 	 * @param instances the instance collection
+	 * @param out The <code>OutputStream</code> to write to
 	 * @param reporter the reporter
 	 * @param progress the progress
-	 * @throws XMLStreamException if writing the feature collection fails
+	 * @throws IOException if creating an XML stream writer fails
 	 */
-	public void write(InstanceCollection instances, ProgressIndicator progress, IOReporter reporter)
-			throws XMLStreamException {
-		final SubtaskProgressIndicator sub = new SubtaskProgressIndicator(progress) {
-
-			@Override
-			protected String getCombinedTaskName(String taskName, String subtaskName) {
-				return taskName + " (" + subtaskName + ")";
-			}
-
-		};
-		progress = sub;
-
-		progress.begin(getTaskName(), instances.size());
-
-		XmlElement container = findDefaultContainter(targetIndex, reporter);
-
-		TypeDefinition containerDefinition = (container == null) ? (null) : (container.getType());
-		QName containerName = (container == null) ? (null) : (container.getName());
-
-		if (containerDefinition == null) {
-			XmlElement containerElement = getConfiguredContainerElement(this, getXMLIndex());
-			containerDefinition = containerElement.getType();
-			containerName = containerElement.getName();
-		}
-
-		if (containerDefinition == null || containerName == null) {
-			throw new IllegalStateException("No root element/container found");
-		}
-
-		/*
-		 * Add schema for container to validation schemas, if the namespace
-		 * differs from the main namespace or additional schemas.
-		 * 
-		 * Needed for validation based on schemaLocation attribute.
-		 */
-		if (!containerName.getNamespaceURI().equals(targetIndex.getNamespace())
-				&& !additionalSchemas.containsKey(containerName.getNamespaceURI())) {
-			try {
-				@SuppressWarnings("null")
-				final URI containerSchemaLoc = stripFragment(container.getLocation());
-				if (containerSchemaLoc != null) {
-					addValidationSchema(containerName.getNamespaceURI(), new Locatable() {
-
-						@Override
-						public URI getLocation() {
-							return containerSchemaLoc;
-						}
-					}, null);
-				}
-			} catch (Exception e) {
-				reporter.error(new IOMessageImpl(
-						"Could not determine location of container definition", e));
-			}
-
-		}
-
-		// additional schema namespace prefixes
-		for (Entry<String, String> schemaNs : additionalSchemaPrefixes.entrySet()) {
-			GmlWriterUtil.addNamespace(writer, schemaNs.getKey(), schemaNs.getValue());
-		}
-
-		writer.writeStartDocument();
-		if (documentWrapper != null) {
-			documentWrapper.startWrap(writer, reporter);
-		}
-		GmlWriterUtil.writeStartElement(writer, containerName);
-
-		// generate mandatory id attribute (for feature collection)
-		String containerId = getParameter(PARAM_CONTAINER_ID).as(String.class);
-		GmlWriterUtil.writeID(writer, containerDefinition, null, false, containerId);
-
-		// write schema locations
-		StringBuffer locations = new StringBuffer();
-		locations.append(targetIndex.getNamespace());
-		locations.append(" "); //$NON-NLS-1$
-		locations.append(targetIndex.getLocation().toString());
-		for (Entry<String, Locatable> schema : additionalSchemas.entrySet()) {
-			locations.append(" "); //$NON-NLS-1$
-			locations.append(schema.getKey());
-			locations.append(" "); //$NON-NLS-1$
-			locations.append(schema.getValue().getLocation().toString());
-		}
-		writer.writeAttribute(SCHEMA_INSTANCE_NS, "schemaLocation", locations.toString()); //$NON-NLS-1$
-
-		writeAdditionalElements(writer, containerDefinition, reporter);
-
-		// write the instances
-		ResourceIterator<Instance> itInstance = instances.iterator();
+	protected void write(InstanceCollection instances, OutputStream out, ProgressIndicator progress,
+			IOReporter reporter) throws IOException {
+		XMLStreamWriter writer;
 		try {
-			Map<TypeDefinition, DefinitionPath> paths = new HashMap<TypeDefinition, DefinitionPath>();
+			writer = createWriter(out, reporter);
+		} catch (XMLStreamException e) {
+			throw new IOException("Creating the XML stream writer failed", e);
+		}
 
-			long lastUpdate = 0;
-			int count = 0;
-			Descent lastDescent = null;
-			while (itInstance.hasNext() && !progress.isCanceled()) {
-				Instance instance = itInstance.next();
-
-				TypeDefinition type = instance.getDefinition();
-
-				/*
-				 * Skip all objects that are no features when writing to a GML
-				 * feature collection.
-				 */
-				boolean skip = useFeatureCollection && !GmlWriterUtil.isFeatureType(type);
-				if (skip) {
-					progress.advance(1);
-					continue;
-				}
-
-				// get stored definition path for the type
-				DefinitionPath defPath;
-				if (paths.containsKey(type)) {
-					// get the stored path, may be null
-					defPath = paths.get(type);
-				}
-				else {
-					// determine a valid definition path in the container
-					defPath = findMemberAttribute(containerDefinition, containerName, type);
-					// store path (may be null)
-					paths.put(type, defPath);
-				}
-				if (defPath != null) {
-					// write the feature
-					lastDescent = Descent.descend(writer, defPath, lastDescent, false);
-					writeMember(instance, type, reporter);
-				}
-				else {
-					reporter.warn(
-							new IOMessageImpl(
-									MessageFormat.format(
-											"No compatible member attribute for type {0} found in root element {1}, one instance was skipped",
-											type.getDisplayName(), containerName.getLocalPart()),
-							null));
-				}
-
-				progress.advance(1);
-				count++;
-
-				long now = System.currentTimeMillis();
-				// only update every 100 milliseconds
-				if (now - lastUpdate > 100 || !itInstance.hasNext()) {
-					lastUpdate = now;
-					sub.subTask(String.valueOf(count) + " instances");
-				}
-			}
-			if (lastDescent != null) {
-				lastDescent.close();
-			}
+		try {
+			write(instances, writer, progress, reporter);
 		} finally {
-			itInstance.close();
+			out.close();
 		}
+	}
 
-		writer.writeEndElement(); // FeatureCollection
+	/**
+	 * Write the given instances to an {@link XMLStreamWriter}.<br>
+	 * <br>
+	 * Use {@link #createWriter(OutputStream, IOReporter)} to create a properly
+	 * configured writer for this method.
+	 * 
+	 * @param instances the instance collection
+	 * @param writer the writer to write the instances to
+	 * @param reporter the reporter
+	 * @param progress the progress
+	 * @see #createWriter(OutputStream, IOReporter)
+	 */
+	protected void write(InstanceCollection instances, XMLStreamWriter writer,
+			ProgressIndicator progress, IOReporter reporter) {
 
-		if (documentWrapper != null) {
-			documentWrapper.endWrap(writer, reporter);
+		this.writer = writer;
+
+		try {
+			final SubtaskProgressIndicator sub = new SubtaskProgressIndicator(progress) {
+
+				@Override
+				protected String getCombinedTaskName(String taskName, String subtaskName) {
+					return taskName + " (" + subtaskName + ")";
+				}
+
+			};
+			progress = sub;
+
+			progress.begin(getTaskName(), instances.size());
+
+			XmlElement container = findDefaultContainter(targetIndex, reporter);
+
+			TypeDefinition containerDefinition = (container == null) ? (null)
+					: (container.getType());
+			QName containerName = (container == null) ? (null) : (container.getName());
+
+			if (containerDefinition == null) {
+				XmlElement containerElement = getConfiguredContainerElement(this, getXMLIndex());
+				containerDefinition = containerElement.getType();
+				containerName = containerElement.getName();
+			}
+
+			if (containerDefinition == null || containerName == null) {
+				throw new IllegalStateException("No root element/container found");
+			}
+
+			/*
+			 * Add schema for container to validation schemas, if the namespace
+			 * differs from the main namespace or additional schemas.
+			 * 
+			 * Needed for validation based on schemaLocation attribute.
+			 */
+			if (!containerName.getNamespaceURI().equals(targetIndex.getNamespace())
+					&& !additionalSchemas.containsKey(containerName.getNamespaceURI())) {
+				try {
+					@SuppressWarnings("null")
+					final URI containerSchemaLoc = stripFragment(container.getLocation());
+					if (containerSchemaLoc != null) {
+						addValidationSchema(containerName.getNamespaceURI(), new Locatable() {
+
+							@Override
+							public URI getLocation() {
+								return containerSchemaLoc;
+							}
+						}, null);
+					}
+				} catch (Exception e) {
+					reporter.error(new IOMessageImpl(
+							"Could not determine location of container definition", e));
+				}
+
+			}
+
+			// additional schema namespace prefixes
+			for (Entry<String, String> schemaNs : additionalSchemaPrefixes.entrySet()) {
+				GmlWriterUtil.addNamespace(writer, schemaNs.getKey(), schemaNs.getValue());
+			}
+
+			writer.writeStartDocument();
+			if (documentWrapper != null) {
+				documentWrapper.startWrap(writer, reporter);
+			}
+			GmlWriterUtil.writeStartElement(writer, containerName);
+
+			// generate mandatory id attribute (for feature collection)
+			String containerId = getParameter(PARAM_CONTAINER_ID).as(String.class);
+			GmlWriterUtil.writeID(writer, containerDefinition, null, false, containerId);
+
+			// write schema locations
+			StringBuffer locations = new StringBuffer();
+			locations.append(targetIndex.getNamespace());
+			locations.append(" "); //$NON-NLS-1$
+			locations.append(targetIndex.getLocation().toString());
+			for (Entry<String, Locatable> schema : additionalSchemas.entrySet()) {
+				locations.append(" "); //$NON-NLS-1$
+				locations.append(schema.getKey());
+				locations.append(" "); //$NON-NLS-1$
+				locations.append(schema.getValue().getLocation().toString());
+			}
+			writer.writeAttribute(SCHEMA_INSTANCE_NS, "schemaLocation", locations.toString()); //$NON-NLS-1$
+
+			writeAdditionalElements(writer, containerDefinition, reporter);
+
+			// write the instances
+			ResourceIterator<Instance> itInstance = instances.iterator();
+			try {
+				Map<TypeDefinition, DefinitionPath> paths = new HashMap<TypeDefinition, DefinitionPath>();
+
+				long lastUpdate = 0;
+				int count = 0;
+				Descent lastDescent = null;
+				while (itInstance.hasNext() && !progress.isCanceled()) {
+					Instance instance = itInstance.next();
+
+					TypeDefinition type = instance.getDefinition();
+
+					/*
+					 * Skip all objects that are no features when writing to a
+					 * GML feature collection.
+					 */
+					boolean skip = useFeatureCollection && !GmlWriterUtil.isFeatureType(type);
+					if (skip) {
+						progress.advance(1);
+						continue;
+					}
+
+					// get stored definition path for the type
+					DefinitionPath defPath;
+					if (paths.containsKey(type)) {
+						// get the stored path, may be null
+						defPath = paths.get(type);
+					}
+					else {
+						// determine a valid definition path in the container
+						defPath = findMemberAttribute(containerDefinition, containerName, type);
+						// store path (may be null)
+						paths.put(type, defPath);
+					}
+					if (defPath != null) {
+						// write the feature
+						lastDescent = Descent.descend(writer, defPath, lastDescent, false);
+						writeMember(instance, type, reporter);
+					}
+					else {
+						reporter.warn(new IOMessageImpl(MessageFormat.format(
+								"No compatible member attribute for type {0} found in root element {1}, one instance was skipped",
+								type.getDisplayName(), containerName.getLocalPart()), null));
+					}
+
+					progress.advance(1);
+					count++;
+
+					long now = System.currentTimeMillis();
+					// only update every 100 milliseconds
+					if (now - lastUpdate > 100 || !itInstance.hasNext()) {
+						lastUpdate = now;
+						sub.subTask(String.valueOf(count) + " instances");
+					}
+				}
+				if (lastDescent != null) {
+					lastDescent.close();
+				}
+			} finally {
+				itInstance.close();
+			}
+
+			writer.writeEndElement(); // FeatureCollection
+
+			if (documentWrapper != null) {
+				documentWrapper.endWrap(writer, reporter);
+			}
+			writer.writeEndDocument();
+
+			writer.close();
+
+			reporter.setSuccess(reporter.getErrors().isEmpty());
+		} catch (Exception e) {
+			reporter.error(new IOMessageImpl(e.getLocalizedMessage(), e));
+			reporter.setSuccess(false);
+		} finally {
+			progress.end();
 		}
-		writer.writeEndDocument();
-
-		writer.close();
 	}
 
 	/**

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs/plugin.xml
@@ -283,6 +283,20 @@
                   default="false">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Guiding value for instances per file. The number will be exceeded only in cases where there are too many inter-related instances that cannot be separated."
+               label="Instances per file"
+               name="instancesPerFile"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Integer">
+            </parameterBinding>
+            <valueDescriptor
+                  default="0"
+                  defaultDescription="By default, no partitioning will take place and all instances will be written to a single file."
+                  sample="1000">
+            </valueDescriptor>
+         </providerParameter>
       </provider>
       <provider
             class="eu.esdihumboldt.hale.io.wfs.file.WFS11FCWriter"
@@ -382,6 +396,20 @@
                   default="true"
                   defaultDescription="By default, nilReason attributes are omitted for elements that are not nil."
                   sample="false">
+            </valueDescriptor>
+         </providerParameter>
+         <providerParameter
+               description="Guiding value for instances per file. The number will be exceeded only in cases where there are too many inter-related instances that cannot be separated."
+               label="Instances per file"
+               name="instancesPerFile"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Integer">
+            </parameterBinding>
+            <valueDescriptor
+                  default="0"
+                  defaultDescription="By default, no partitioning will take place and all instances will be written to a single file."
+                  sample="1000">
             </valueDescriptor>
          </providerParameter>
       </provider>

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs/src/eu/esdihumboldt/hale/io/wfs/file/WFSFeatureCollectionWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs/src/eu/esdihumboldt/hale/io/wfs/file/WFSFeatureCollectionWriter.java
@@ -206,6 +206,10 @@ public class WFSFeatureCollectionWriter extends GmlInstanceWriter
 
 	@Override
 	public boolean isPassthrough() {
+		if (!super.isPassthrough()) {
+			return false;
+		}
+
 		boolean requiresCount = requiresCount();
 		boolean skipCount = getParameter(PARAM_SKIP_COUNT).as(Boolean.class, false);
 


### PR DESCRIPTION
Add basic support for partitioning GML to multiple output files. This covers the basic requirements laid out in #331 which keeps all inter-related objects together in one part, regardless of the given number of maximum features per file.

Support for validating all generated output files is also added by replacing the original `LocatableOutputSupplier` object on-the-fly with a `MultiLocationOutputSupplier` as a hint for the validation mechanism that multiple files need to be validated.