### PR TITLE
enhancements for rewriting GML files

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollection.java
@@ -252,7 +252,8 @@ public class GmlInstanceCollection implements InstanceCollection {
 			}
 
 			if (accept) {
-				return def.getConstraint(MappingRelevantFlag.class).isEnabled();
+				return ignoreMappingRelevant
+						|| def.getConstraint(MappingRelevantFlag.class).isEnabled();
 			}
 			else {
 				return false;
@@ -665,6 +666,8 @@ public class GmlInstanceCollection implements InstanceCollection {
 	private final boolean ignoreNamespaces;
 	private final IOProvider ioProvider;
 
+	private final boolean ignoreMappingRelevant;
+
 	/**
 	 * Create an XMl/GML instance collection based on the given source.
 	 * 
@@ -695,6 +698,13 @@ public class GmlInstanceCollection implements InstanceCollection {
 		this.ignoreNamespaces = ignoreNamespaces;
 		this.crsProvider = crsProvider;
 		this.ioProvider = provider;
+
+		// extract additional settings from I/O provider
+
+		this.ignoreMappingRelevant = provider
+				.getParameter(StreamGmlReader.PARAM_IGNORE_MAPPING_RELEVANT)
+				.as(Boolean.class, false);
+
 	}
 
 	/**

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
@@ -84,6 +84,12 @@ public class StreamGmlReader extends AbstractInstanceReader {
 	 */
 	public static final String PARAM_IGNORE_MAPPING_RELEVANT = "ignoreMappingRelevant";
 
+	/**
+	 * Name of the parameter that that specifies if parsing geometries should be
+	 * suppressed.
+	 */
+	public static final String PARAM_SUPPRESS_PARSE_GEOMETRY = "suppressParsingGeometry";
+
 	private InstanceCollection instances;
 
 	private final boolean restrictToFeatures;

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
@@ -75,6 +75,15 @@ public class StreamGmlReader extends AbstractInstanceReader {
 	 */
 	public static final String PARAM_FEATURES_PER_WFS_REQUEST = "featuresPerWfsRequest";
 
+	/**
+	 * The name of the parameter specifying if the selection of mapping relevant
+	 * types for instances that are processed should be ignored.
+	 * 
+	 * Essentially if this is enabled the behavior is like if any type in the
+	 * schema is classified as mapping relevant.
+	 */
+	public static final String PARAM_IGNORE_MAPPING_RELEVANT = "ignoreMappingRelevant";
+
 	private InstanceCollection instances;
 
 	private final boolean restrictToFeatures;

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/StreamGmlHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/StreamGmlHelper.java
@@ -56,6 +56,7 @@ import eu.esdihumboldt.hale.common.schema.model.constraint.type.AugmentedValueFl
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.HasValueFlag;
 import eu.esdihumboldt.hale.io.gml.geometry.constraint.GeometryFactory;
 import eu.esdihumboldt.hale.io.gml.internal.simpletype.SimpleTypeUtil;
+import eu.esdihumboldt.hale.io.gml.reader.internal.StreamGmlReader;
 import eu.esdihumboldt.hale.io.xsd.constraint.XmlAttributeFlag;
 import eu.esdihumboldt.hale.io.xsd.constraint.XmlMixedFlag;
 
@@ -109,6 +110,11 @@ public abstract class StreamGmlHelper {
 			if (dim != null)
 				srsDimension = Integer.parseInt(dim);
 		}
+
+		// extract additional settings from I/O provider
+		boolean suppressParsingGeometry = ioProvider
+				.getParameter(StreamGmlReader.PARAM_SUPPRESS_PARSE_GEOMETRY)
+				.as(Boolean.class, false);
 
 		MutableInstance instance;
 		if (indexInStream == null) {
@@ -179,7 +185,7 @@ public abstract class StreamGmlHelper {
 		}
 
 		// augmented value XXX should this be an else if?
-		if (type.getConstraint(AugmentedValueFlag.class).isEnabled()) {
+		if (!suppressParsingGeometry && type.getConstraint(AugmentedValueFlag.class).isEnabled()) {
 			// add geometry as a GeometryProperty value where applicable
 			GeometryFactory geomFactory = type.getConstraint(GeometryFactory.class);
 			Object geomValue = null;


### PR DESCRIPTION
Ignoring the mapping relevant types setting allows to read objects that are not by default classified as mapping relevant. Only makes sense though if used with the GML reader.

Suppressing the parsing of geometries allows rewriting the geometries in their original form.