### PR TITLE
Skip Geoserver tests

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.appschema.test/src/eu/esdihumboldt/hale/io/geoserver/rest/ResourceManagerIT.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.appschema.test/src/eu/esdihumboldt/hale/io/geoserver/rest/ResourceManagerIT.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -46,6 +47,7 @@ import eu.esdihumboldt.hale.io.geoserver.FeatureType;
 import eu.esdihumboldt.hale.io.geoserver.Namespace;
 import eu.esdihumboldt.hale.io.geoserver.ResourceBuilder;
 
+@Ignore
 @SuppressWarnings("javadoc")
 public class ResourceManagerIT extends AbstractDockerTest {
 


### PR DESCRIPTION
Tests fail since INSPIRE schema URLs were moved to HTTPS