### PR TITLE
Add warning in export wizard when upstream hale connect has changed

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/plugin.xml
@@ -122,7 +122,7 @@
          point="eu.esdihumboldt.hale.ui.io.source">
       <source
             class="eu.esdihumboldt.hale.io.haleconnect.ui.projects.HaleConnectSource"
-            contentType="eu.esdihumboldt.hale.io.project.hale25.zip"
+            contentType="eu.esdihumboldt.hale.io.haleconnect.zip"
             description="Load from hale connect"
             icon="images/hale-connect-icon.png"
             id="eu.esdihumboldt.hale.io.haleconnect.ui.source"

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.java
@@ -117,6 +117,7 @@ public class ChooseHaleConnectProjectWizardPage
 		configuration.setProjectId(pi.getId());
 		configuration.setProjectName(pi.getName());
 		configuration.setOwner(pi.getOwner());
+		configuration.setLastModified(pi.getLastModified());
 
 		return true;
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectProjectConfig.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectProjectConfig.groovy
@@ -26,4 +26,5 @@ class HaleConnectProjectConfig {
 	String projectId
 	String projectName
 	Owner owner
+	Long lastModified
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectProjectExportAdvisor.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectProjectExportAdvisor.java
@@ -39,8 +39,7 @@ public class HaleConnectProjectExportAdvisor extends DefaultIOAdvisor<HaleConnec
 
 		ProjectService projectService = getService(ProjectService.class);
 		Project project = (Project) projectService.getProjectInfo();
-		// set a copy of the project
-		provider.setProject(project.clone());
+		provider.setProject(project);
 	}
 
 	@Override

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -34,6 +34,8 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowLayout;
@@ -54,6 +56,7 @@ import eu.esdihumboldt.hale.io.haleconnect.HaleConnectService;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectUrnBuilder;
 import eu.esdihumboldt.hale.io.haleconnect.Owner;
 import eu.esdihumboldt.hale.io.haleconnect.OwnerType;
+import eu.esdihumboldt.hale.io.haleconnect.project.HaleConnectProjectReader;
 import eu.esdihumboldt.hale.io.haleconnect.project.HaleConnectProjectWriter;
 import eu.esdihumboldt.hale.io.haleconnect.ui.HaleConnectLoginDialog;
 import eu.esdihumboldt.hale.io.haleconnect.ui.HaleConnectLoginHandler;
@@ -90,6 +93,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 	private Composite updateProjectControls;
 	private StringFieldEditor projectName;
 	private Button selectProjectButton;
+	private Label upstreamModifiedWarning;
 
 	private boolean createNewProject;
 	private HaleConnectProjectConfig targetProject;
@@ -127,6 +131,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 				if (loginDialog.open() == Dialog.OK) {
 					HaleConnectLoginHandler.performLogin(loginDialog);
 					updateState();
+					prefillTargetProject();
 				}
 			}
 
@@ -261,6 +266,15 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 			}
 		});
 
+		FontData currentFont = loginStatusLabel.getFont().getFontData()[0];
+
+		upstreamModifiedWarning = new Label(updateProjectControls, SWT.WRAP);
+		upstreamModifiedWarning
+				.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, true, false, 3, 1));
+		upstreamModifiedWarning.setFont(new Font(upstreamModifiedWarning.getDisplay(),
+				new FontData(currentFont.getName(), currentFont.getHeight(), SWT.BOLD)));
+		upstreamModifiedWarning.setVisible(false);
+
 		Composite writerOptions = new Composite(parent, SWT.NONE);
 		writerOptions.setLayout(new RowLayout());
 		writerOptions.setLayoutData(new GridData(SWT.LEAD, SWT.LEAD, true, true, 3, 2));
@@ -277,33 +291,57 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 				"Use cached internal schema representation (required for big schema files)?");
 		excludeCachedResources.setSelection(true);
 
+		prefillTargetProject();
+
+		updateState();
+	}
+
+	/**
+	 * 
+	 */
+	private void prefillTargetProject() {
+		if (!haleConnect.isLoggedIn()) {
+			return;
+		}
+
 		ProjectInfoService pis = HaleUI.getServiceProvider().getService(ProjectInfoService.class);
-		URI loadLocation = pis.getLoadLocation();
-		if (loadLocation != null) {
+		String projectUrnProperty = pis
+				.getProperty(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY)
+				.getStringRepresentation();
+
+		if (projectUrnProperty != null) {
 			// If project was loaded from hale connect, prefill project name
-			try {
-				if (HaleConnectUrnBuilder.isValidProjectUrn(loadLocation)) {
-					String projectId = HaleConnectUrnBuilder.extractProjectId(loadLocation);
-					Owner owner = HaleConnectUrnBuilder.extractProjectOwner(loadLocation);
+
+			URI projectUrn = URI.create(projectUrnProperty);
+			if (HaleConnectUrnBuilder.isValidProjectUrn(projectUrn)) {
+				String projectId = HaleConnectUrnBuilder.extractProjectId(projectUrn);
+				Owner owner = HaleConnectUrnBuilder.extractProjectOwner(projectUrn);
+
+				try {
+					if (!haleConnect.testProjectPermission(HaleConnectService.PERMISSION_EDIT,
+							owner, projectId)) {
+						return;
+					}
+
 					HaleConnectProjectInfo projectInfo = haleConnect.getProject(owner, projectId);
 					if (projectInfo != null) {
 						targetProject = new HaleConnectProjectConfig();
 						targetProject.setOwner(owner);
 						targetProject.setProjectId(projectId);
 						targetProject.setProjectName(projectInfo.getName());
+						targetProject.setLastModified(projectInfo.getLastModified());
 						newProject.setSelection(false);
 						updateProject.setSelection(true);
 						projectName.setStringValue(projectInfo.getName());
 					}
+				} catch (Throwable t) {
+					// Non-fatal
+					log.warn(MessageFormat.format("Unable to prefill target project: {0}",
+							t.getMessage()), t);
 				}
-			} catch (Throwable t) {
-				// Non-fatal
-				log.warn(MessageFormat.format("Unable to prefill target project: {0}",
-						t.getMessage()), t);
 			}
 		}
 
-		updateState();
 	}
 
 	/**
@@ -311,6 +349,8 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 	 */
 	protected void updateState() {
 		updateLoginStatus();
+		updateOverwriteWarning();
+
 		setValid(haleConnect.isLoggedIn() && (ownerUser.isEnabled() || ownerOrg.isEnabled())
 				&& (newProject.getSelection() || targetProject != null));
 		if (newProject.getSelection()) {
@@ -449,9 +489,47 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 		targetProject = ChooseHaleConnectProjectWizard.openSelectProject();
 		if (targetProject != null) {
 			projectName.setStringValue(targetProject.getProjectName());
+			updateOverwriteWarning();
 		}
 		else {
 			projectName.setStringValue("");
 		}
+	}
+
+	private void updateOverwriteWarning() {
+		if (createNewProject || targetProject == null) {
+			upstreamModifiedWarning.setVisible(false);
+			return;
+		}
+
+		ProjectInfoService pis = HaleUI.getServiceProvider().getService(ProjectInfoService.class);
+
+		String lastModifiedProperty = pis
+				.getProperty(HaleConnectProjectReader.HALECONNECT_LAST_MODIFIED_PROPERTY)
+				.getStringRepresentation();
+		if (lastModifiedProperty != null && targetProject != null
+				&& targetProject.getLastModified() != null) {
+			Long lastModified = Long.parseLong(lastModifiedProperty);
+			boolean hasNewerVersion = lastModified < targetProject.getLastModified();
+			if (hasNewerVersion) {
+				upstreamModifiedWarning
+						.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED));
+				upstreamModifiedWarning.setText(
+						"The project hale connect has been updated since it was last imported.\nChanges may be lost if you continue with this export.");
+				upstreamModifiedWarning.setVisible(true);
+			}
+			else {
+				upstreamModifiedWarning.setVisible(false);
+			}
+		}
+		else {
+			upstreamModifiedWarning
+					.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED));
+			upstreamModifiedWarning.setText(
+					"The current project to be exported was not originally imported from hale connect.\nThe project to update on hale connect will be replaced by this project if you continue with this export.");
+			upstreamModifiedWarning.setVisible(true);
+		}
+
+		updateProjectControls.layout();
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/plugin.xml
@@ -30,6 +30,15 @@
                ref="eu.esdihumboldt.hale.io.haleconnect.zip">
          </contentType>
       </provider>
+      <provider
+            allowDuplicate="false"
+            class="eu.esdihumboldt.hale.io.haleconnect.project.HaleConnectProjectReader"
+            id="eu.esdihumboldt.hale.io.project.haleconnect.zip.reader"
+            name="hale connect project archive">
+         <contentType
+               ref="eu.esdihumboldt.hale.io.haleconnect.zip">
+         </contentType>
+      </provider>
    </extension>
    <extension
          point="org.eclipse.core.contenttype.contentTypes">

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectInputSupplier.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectInputSupplier.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.haleconnect;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import eu.esdihumboldt.hale.common.core.io.supplier.DefaultInputSupplier;
+
+/**
+ * I/O supplier for projects imported from hale connect
+ * 
+ * @author Florian Esser
+ */
+public class HaleConnectInputSupplier extends DefaultInputSupplier {
+
+	private final File projectArchive;
+	private final HaleConnectProjectInfo projectInfo;
+
+	/**
+	 * Create the input supplier based on the
+	 * 
+	 * @param location the location URI
+	 * @param projectArchive The downloaded project archive
+	 * @param projectInfo Details on the hale connect project
+	 */
+	public HaleConnectInputSupplier(URI location, File projectArchive,
+			HaleConnectProjectInfo projectInfo) {
+		super(location);
+
+		this.projectArchive = projectArchive;
+		this.projectInfo = projectInfo;
+	}
+
+	@Override
+	public InputStream getInput() throws IOException {
+		return new BufferedInputStream(new FileInputStream(projectArchive));
+	}
+
+	/**
+	 * @return details on the hale connect project
+	 */
+	public HaleConnectProjectInfo getProjectInfo() {
+		return this.projectInfo;
+	}
+
+	/**
+	 * @return the hale connect project archive
+	 */
+	public File getProjectArchive() {
+		return this.getProjectArchive();
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.java
@@ -27,6 +27,7 @@ public class HaleConnectProjectInfo {
 	private final HaleConnectOrganisationInfo organisation;
 	private final String name;
 	private final String author;
+	private final Long lastModified;
 
 	/**
 	 * Create the project info
@@ -38,14 +39,18 @@ public class HaleConnectProjectInfo {
 	 *            organisation, otherwise <code>null</code>)
 	 * @param name Project name
 	 * @param author Project author
+	 * @param lastModified The timestamp when the project was last modified on
+	 *            hale connect
 	 */
 	public HaleConnectProjectInfo(String id, HaleConnectUserInfo user,
-			HaleConnectOrganisationInfo organisation, String name, String author) {
+			HaleConnectOrganisationInfo organisation, String name, String author,
+			Long lastModified) {
 		this.id = id;
 		this.user = user;
 		this.organisation = organisation;
 		this.name = name;
 		this.author = author;
+		this.lastModified = lastModified;
 	}
 
 	/**
@@ -96,5 +101,9 @@ public class HaleConnectProjectInfo {
 		else {
 			throw new IllegalStateException("Unknown owner type");
 		}
+	}
+
+	public Long getLastModified() {
+		return lastModified;
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectService.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectService.java
@@ -267,10 +267,12 @@ public interface HaleConnectService {
 	 * @param permission the permission to test, usually one of the
 	 *            <code>PERMISSION_</code> constants defined in
 	 *            {@link HaleConnectService}.
+	 * @param owner Owner of the transformation project
 	 * @param projectId Transformation project ID
 	 * @return true if the user has the given permission
 	 * @throws HaleConnectException thrown on any API exception
 	 */
-	boolean testProjectPermission(String permission, String projectId) throws HaleConnectException;
+	boolean testProjectPermission(String permission, Owner owner, String projectId)
+			throws HaleConnectException;
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
@@ -628,12 +628,15 @@ public class HaleConnectServiceImpl implements HaleConnectService, BasePathManag
 	}
 
 	@Override
-	public boolean testProjectPermission(String permission, String projectId)
+	public boolean testProjectPermission(String permission, Owner owner, String projectId)
 			throws HaleConnectException {
 		PermissionsApi api = ProjectStoreHelper.getPermissionsApi(this,
 				this.getSession().getToken());
+
+		String combinedBucketId = MessageFormat.format("{0}.{1}.{2}",
+				owner.getType().getJsonValue(), owner.getId(), projectId);
 		try {
-			api.testBucketPermission(permission, projectId);
+			api.testBucketPermission(permission, combinedBucketId);
 		} catch (com.haleconnect.api.projectstore.v1.ApiException e) {
 			if (e.getCode() == 403) {
 				// not allowed

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.haleconnect.project;
+
+import java.io.IOException;
+
+import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
+import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
+import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectReader;
+import eu.esdihumboldt.hale.common.core.io.report.IOReport;
+import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
+import eu.esdihumboldt.hale.io.haleconnect.HaleConnectInputSupplier;
+
+/**
+ * Project reader that reads a project archive and adds additional information
+ * on the hale connect project to the project properties, if available.
+ * 
+ * @author Florian Esser
+ */
+public class HaleConnectProjectReader extends ArchiveProjectReader {
+
+	/**
+	 * The project property name for the hale connect project ID
+	 */
+	public static final String HALECONNECT_URN_PROPERTY = "haleconnect.urn";
+
+	/**
+	 * The project property name for the last modified timestamp on hale connect
+	 */
+	public static final String HALECONNECT_LAST_MODIFIED_PROPERTY = "haleconnect.lastModified";
+
+	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectReader#execute(eu.esdihumboldt.hale.common.core.io.ProgressIndicator,
+	 *      eu.esdihumboldt.hale.common.core.io.report.IOReporter)
+	 */
+	@Override
+	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
+			throws IOProviderConfigurationException, IOException {
+		IOReport result = super.execute(progress, reporter);
+
+		if (getSource() instanceof HaleConnectInputSupplier) {
+			HaleConnectInputSupplier source = (HaleConnectInputSupplier) getSource();
+			getProject().getProperties().put(HALECONNECT_LAST_MODIFIED_PROPERTY,
+					Value.of(source.getProjectInfo().getLastModified()));
+			getProject().getProperties().put(HALECONNECT_URN_PROPERTY,
+					Value.of(source.getLocation()));
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
The `lastModified` timestamp of the project bucket is now stored in the project properties when importing a project from hale connect. When a user wants to update the hale connect project later, that timestamp is checked against the current `lastModified` of the project bucket to check if the upstream project changed in the meantime. In case of a change, or if no timestamp is stored in the exported project, a warning is displayed. Refs #372 