### PR TITLE
Save projects to hale connect

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/HaleIO.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/HaleIO.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -144,6 +145,44 @@ public abstract class HaleIO {
 					result.add(factory);
 					break;
 				}
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Find all content types that are of the same kind as the given content
+	 * type.
+	 * 
+	 * @param candidates Content types to search
+	 * @param kind Parent content type
+	 * @return List of matches, including at least <code>kind</code>
+	 */
+	public static List<IContentType> findContentTypesOfKind(IContentType[] candidates,
+			IContentType kind) {
+
+		return findContentTypesOfKind(Arrays.asList(candidates), kind);
+	}
+
+	/**
+	 * Find all content types that are of the same kind as the given content
+	 * type.
+	 * 
+	 * @param candidates Content types to search
+	 * @param kind Parent content type
+	 * @return List of matches, including at least <code>kind</code>
+	 */
+	public static List<IContentType> findContentTypesOfKind(Collection<IContentType> candidates,
+			IContentType kind) {
+		List<IContentType> result = new ArrayList<>();
+		if (candidates == null || kind == null) {
+			return result;
+		}
+
+		for (IContentType candidate : candidates) {
+			if (candidate.isKindOf(kind)) {
+				result.add(candidate);
 			}
 		}
 

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/ProjectWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/ProjectWriter.java
@@ -31,6 +31,25 @@ import eu.esdihumboldt.hale.common.core.io.project.model.ProjectFile;
 public interface ProjectWriter extends ExportProvider {
 
 	/**
+	 * Mode a {@link ProjectWriter} operates in
+	 * 
+	 * @author Florian Esser
+	 */
+	public enum ProjectWriterMode {
+		/**
+		 * The project is saved to a target location and the save configuration
+		 * is updated accordingly
+		 */
+		SAVE,
+
+		/**
+		 * The project is exported to a target location but the save
+		 * configuration is not updated
+		 */
+		EXPORT
+	}
+
+	/**
 	 * Set the additional project files to write.
 	 * 
 	 * @param projectFiles the project files to write (file name mapped to
@@ -58,5 +77,10 @@ public interface ProjectWriter extends ExportProvider {
 	 * @param previousTarget the previous target
 	 */
 	public void setPreviousTarget(URI previousTarget);
+
+	/**
+	 * @return the {@link ProjectWriterMode} that was used in the last operation
+	 */
+	public ProjectWriterMode getLastWriterMode();
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/impl/AbstractProjectWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/project/impl/AbstractProjectWriter.java
@@ -118,4 +118,21 @@ public abstract class AbstractProjectWriter extends AbstractExportProvider
 		return previousTarget;
 	}
 
+	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.project.ProjectWriter#getLastWriterMode()
+	 */
+	@Override
+	public ProjectWriterMode getLastWriterMode() {
+		// Default method to determine if a project is saved or exported. This
+		// method can be overwritten by derived if another handling is required.
+
+		URI targetLocation = this.getTarget().getLocation();
+		if (targetLocation == null || !"file".equals(targetLocation.getScheme())) {
+			return ProjectWriterMode.EXPORT;
+		}
+		else {
+			return ProjectWriterMode.SAVE;
+		}
+	}
+
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/report/MutableTargetIOReport.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/report/MutableTargetIOReport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.core.io.report;
+
+import eu.esdihumboldt.hale.common.core.io.supplier.Locatable;
+
+/**
+ * Report for I/O tasks that supports changing the target
+ * 
+ * @author Florian Esser
+ */
+public interface MutableTargetIOReport extends IOReport {
+
+	/**
+	 * Change the target of this {@link IOReport}
+	 * 
+	 * @param target new target
+	 */
+	void setTarget(Locatable target);
+}

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/report/impl/DefaultIOReporter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/report/impl/DefaultIOReporter.java
@@ -20,6 +20,7 @@ import de.fhg.igd.slf4jplus.ALogger;
 import eu.esdihumboldt.hale.common.core.io.report.IOMessage;
 import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
+import eu.esdihumboldt.hale.common.core.io.report.MutableTargetIOReport;
 import eu.esdihumboldt.hale.common.core.io.supplier.Locatable;
 import eu.esdihumboldt.hale.common.core.report.impl.DefaultReporter;
 
@@ -30,9 +31,10 @@ import eu.esdihumboldt.hale.common.core.report.impl.DefaultReporter;
  * @partner 01 / Fraunhofer Institute for Computer Graphics Research
  * @since 2.5
  */
-public class DefaultIOReporter extends DefaultReporter<IOMessage> implements IOReporter {
+public class DefaultIOReporter extends DefaultReporter<IOMessage>
+		implements IOReporter, MutableTargetIOReport {
 
-	private final Locatable target;
+	private Locatable target;
 
 	/**
 	 * Create an empty I/O report. It is set to not successful by default. But
@@ -57,5 +59,16 @@ public class DefaultIOReporter extends DefaultReporter<IOMessage> implements IOR
 	@Override
 	public Locatable getTarget() {
 		return target;
+	}
+
+	/**
+	 * Update the target, e.g. if the target URL is not known at the time the
+	 * IOReporter is created.
+	 * 
+	 * @param target Updated target
+	 */
+	@Override
+	public void setTarget(Locatable target) {
+		this.target = target;
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -515,7 +515,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 				upstreamModifiedWarning
 						.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED));
 				upstreamModifiedWarning.setText(
-						"The project hale connect has been updated since it was last imported.\nChanges may be lost if you continue with this export.");
+						"The project on hale connect has been updated since it was last imported.\nChanges may be lost if you continue with this export.");
 				upstreamModifiedWarning.setVisible(true);
 			}
 			else {

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/plugin.xml
@@ -43,6 +43,7 @@
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
+            base-type="eu.esdihumboldt.hale.io.project.hale25.zip"
             file-extensions="hcp"
             id="eu.esdihumboldt.hale.io.haleconnect.zip"
             name="hale connect project"

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectInputSupplier.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectInputSupplier.java
@@ -43,11 +43,11 @@ public class HaleConnectInputSupplier extends DefaultInputSupplier {
 	private final BasePathResolver basePathResolver;
 
 	/**
-	 * Create the input supplier based on the
+	 * Create the hale connect input supplier
 	 * 
 	 * @param location the location URI
-	 * @param projectArchive The downloaded project archive
-	 * @param projectInfo Details on the hale connect project
+	 * @param apiKey API key to access the hale connect
+	 * @param resolver {@link BasePathResolver} for building hale connect URLs
 	 */
 	public HaleConnectInputSupplier(URI location, String apiKey, BasePathResolver resolver) {
 		super(location);
@@ -61,8 +61,6 @@ public class HaleConnectInputSupplier extends DefaultInputSupplier {
 	public InputStream getInput() throws IOException {
 		Owner owner = HaleConnectUrnBuilder.extractProjectOwner(getLocation());
 		String projectId = HaleConnectUrnBuilder.extractProjectId(getLocation());
-
-		URI location = HaleConnectUrnBuilder.buildProjectUrn(owner, projectId);
 
 		FilesApi api = ProjectStoreHelper.getFilesApi(basePathResolver, apiKey);
 		final ApiResponse<File> response;
@@ -100,6 +98,9 @@ public class HaleConnectInputSupplier extends DefaultInputSupplier {
 		return lastModified;
 	}
 
+	/**
+	 * @return The {@link BasePathResolver} used by this input supplier
+	 */
 	public BasePathResolver getBasePathResolver() {
 		return this.basePathResolver;
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.java
@@ -103,6 +103,9 @@ public class HaleConnectProjectInfo {
 		}
 	}
 
+	/**
+	 * @return The last modified timestamp of this hale connect project
+	 */
 	public Long getLastModified() {
 		return lastModified;
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang.StringUtils;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.haleconnect.api.projectstore.v1.ApiCallback;
-import com.haleconnect.api.projectstore.v1.ApiResponse;
 import com.haleconnect.api.projectstore.v1.api.BucketsApi;
 import com.haleconnect.api.projectstore.v1.api.FilesApi;
 import com.haleconnect.api.projectstore.v1.api.PermissionsApi;
@@ -306,16 +305,8 @@ public class HaleConnectServiceImpl implements HaleConnectService, BasePathManag
 					MessageFormat.format("Project does not exist: {0}", location.toString()));
 		}
 
-		FilesApi api = ProjectStoreHelper.getFilesApi(this, this.getSession().getToken());
-		final ApiResponse<File> response;
-		try {
-			response = api.getProjectFilesAsZipWithHttpInfo(owner.getType().getJsonValue(),
-					owner.getId(), projectId);
-		} catch (com.haleconnect.api.projectstore.v1.ApiException e) {
-			throw new HaleConnectException(e.getMessage(), e);
-		}
+		return new HaleConnectInputSupplier(location, this.getSession().getToken(), this);
 
-		return new HaleConnectInputSupplier(location, response.getData(), projectInfo);
 	}
 
 	/**

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.java
@@ -436,9 +436,19 @@ public class HaleConnectServiceImpl implements HaleConnectService, BasePathManag
 					apiCallback);
 
 			return future.get();
-		} catch (com.haleconnect.api.projectstore.v1.ApiException | InterruptedException
-				| ExecutionException e) {
-			throw new HaleConnectException(e.getMessage(), e);
+		} catch (com.haleconnect.api.projectstore.v1.ApiException e1) {
+			throw new HaleConnectException(e1.getMessage(), e1, e1.getCode(),
+					e1.getResponseHeaders());
+		} catch (ExecutionException e2) {
+			Throwable t = e2.getCause();
+			if (t instanceof HaleConnectException) {
+				throw (HaleConnectException) t;
+			}
+			else {
+				throw new HaleConnectException(t.getMessage(), t);
+			}
+		} catch (InterruptedException e3) {
+			throw new HaleConnectException(e3.getMessage(), e3);
 		}
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
@@ -17,10 +17,12 @@ package eu.esdihumboldt.hale.io.haleconnect.project;
 
 import java.io.IOException;
 
+import eu.esdihumboldt.hale.common.core.io.ExportProvider;
 import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
 import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectReader;
+import eu.esdihumboldt.hale.common.core.io.project.model.IOConfiguration;
 import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectInputSupplier;
@@ -58,6 +60,15 @@ public class HaleConnectProjectReader extends ArchiveProjectReader {
 					Value.of(source.getLastModified()));
 			getProject().getProperties().put(HALECONNECT_URN_PROPERTY,
 					Value.of(source.getLocation()));
+
+			IOConfiguration saveConfig = getProject().getSaveConfiguration();
+			saveConfig.setProviderId(HaleConnectProjectWriter.ID);
+			saveConfig.getProviderConfiguration().put(ExportProvider.PARAM_CONTENT_TYPE,
+					Value.of(HaleConnectProjectWriter.HALECONNECT_CONTENT_TYPE_ID));
+			saveConfig.getProviderConfiguration().put(ExportProvider.PARAM_TARGET,
+					Value.of(source.getLocation()));
+
+			getProject().setSaveConfiguration(saveConfig);
 		}
 
 		return result;

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
@@ -55,7 +55,7 @@ public class HaleConnectProjectReader extends ArchiveProjectReader {
 		if (getSource() instanceof HaleConnectInputSupplier) {
 			HaleConnectInputSupplier source = (HaleConnectInputSupplier) getSource();
 			getProject().getProperties().put(HALECONNECT_LAST_MODIFIED_PROPERTY,
-					Value.of(source.getProjectInfo().getLastModified()));
+					Value.of(source.getLastModified()));
 			getProject().getProperties().put(HALECONNECT_URN_PROPERTY,
 					Value.of(source.getLocation()));
 		}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -52,6 +52,11 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	private static final ALogger log = ALoggerFactory.getLogger(HaleConnectProjectWriter.class);
 
 	/**
+	 * The provider ID
+	 */
+	public static final String ID = "eu.esdihumboldt.hale.io.haleconnect.uploader";
+
+	/**
 	 * Owner of the uploaded project
 	 */
 	public static final String OWNER_TYPE = "ownerType";
@@ -65,6 +70,12 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	 * Enable versioning for uploaded project
 	 */
 	public static final String ENABLE_VERSIONING = "enableVersioning";
+
+	/**
+	 * Identifier of the hale connect project content type
+	 */
+	public static final String HALECONNECT_CONTENT_TYPE_ID = "eu.esdihumboldt.hale.io.haleconnect.zip";
+
 
 	private final HaleConnectService haleConnect;
 	private URI projectUri;

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.text.MessageFormat;
 
@@ -113,15 +112,6 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		URI location = null;
 		if (getTarget().getLocation() != null) {
 			location = getTarget().getLocation();
-		}
-		else if (getProject().getProperties().containsKey(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY)) {
-			// Use cached hale connect location as default target
-			try {
-				location = new URI(
-						getProject().getProperties().get(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY).toString());
-			} catch (URISyntaxException e) {
-				// Ignore
-			}
 		}
 
 		progress.begin("Saving project to hale connect", ProgressIndicator.UNKNOWN);

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -203,7 +203,15 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		try {
 			result = haleConnect.uploadProjectFile(projectId, owner, projectArchive, progress);
 		} catch (HaleConnectException e) {
-			reporter.error("Error uploading hale connect project", e);
+			switch (e.getStatusCode()) {
+			case 403: /* Forbidden */
+				reporter.error(MessageFormat.format("You are not authorized to access project {0}",
+						projectId), e);
+				break;
+			default:
+				reporter.error(MessageFormat.format("Error uploading hale connect project: {0}",
+						e.getMessage()), e);
+			}
 			reporter.setSuccess(false);
 			return reporter;
 		}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -81,11 +81,10 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	 */
 	public static final String HALECONNECT_CONTENT_TYPE_ID = "eu.esdihumboldt.hale.io.haleconnect.zip";
 
-
 	private final HaleConnectService haleConnect;
 	private URI projectUri;
 	private URI clientAccessUrl;
-	private ProjectWriterMode writerMode = ProjectWriterMode.EXPORT;
+	private ProjectWriterMode writerMode = ProjectWriterMode.SAVE;
 
 	/**
 	 * Creates a hale connect project writer

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -63,6 +63,11 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	public static final String ID = "eu.esdihumboldt.hale.io.haleconnect.uploader";
 
 	/**
+	 * Type name for hale connect projects
+	 */
+	public static final String PROJECT_TYPE_NAME = "hale connect project";
+
+	/**
 	 * Owner of the uploaded project
 	 */
 	public static final String OWNER_TYPE = "ownerType";

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -37,6 +37,7 @@ import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.common.core.io.report.impl.DefaultIOReporter;
 import eu.esdihumboldt.hale.common.core.io.supplier.Locatable;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableURI;
+import eu.esdihumboldt.hale.common.core.io.supplier.NoStreamOutputSupplier;
 import eu.esdihumboldt.hale.io.haleconnect.BasePathResolver;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectException;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectProjectInfo;
@@ -179,6 +180,8 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 			projectUrn = location;
 			writerMode = ProjectWriterMode.SAVE;
 		}
+
+		this.setTarget(new NoStreamOutputSupplier(projectUrn));
 
 		// save the hale connect project URN in the project properties
 		getProject().getProperties().put(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY, Value.of(projectUrn.toString()));

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -69,6 +69,7 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	private final HaleConnectService haleConnect;
 	private URI projectUri;
 	private URI clientAccessUrl;
+	private ProjectWriterMode writerMode = ProjectWriterMode.EXPORT;
 
 	/**
 	 * Creates a hale connect project writer
@@ -153,6 +154,7 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		}
 		else {
 			projectUrn = location;
+			writerMode = ProjectWriterMode.SAVE;
 		}
 
 		// save the hale connect project URN in the project properties
@@ -226,5 +228,13 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	 */
 	public URI getClientAccessUrl() {
 		return this.clientAccessUrl;
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.project.impl.AbstractProjectWriter#getLastWriterMode()
+	 */
+	@Override
+	public ProjectWriterMode getLastWriterMode() {
+		return writerMode;
 	}
 }

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/ProjectResourcesUtil.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/ProjectResourcesUtil.java
@@ -212,8 +212,8 @@ public class ProjectResourcesUtil {
 					// handle results
 					if (report.isSuccess()) {
 						advisor.handleResults(provider);
-						result.set(report);
 					}
+					result.set(report);
 				} catch (Exception e) {
 					log.error("Error executing an I/O provider.", e);
 					result.setException(e);

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -426,6 +426,9 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 								.getService(RecentProjectsService.class);
 						rfs.add(projectFile.getAbsolutePath(), provider.getProject().getName());
 					}
+					else {
+						projectFile = null;
+					}
 
 					changed = false;
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -30,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -82,6 +84,7 @@ import eu.esdihumboldt.hale.common.core.io.project.util.LocationUpdater;
 import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.supplier.DefaultInputSupplier;
 import eu.esdihumboldt.hale.common.core.io.supplier.FileIOSupplier;
+import eu.esdihumboldt.hale.common.core.io.supplier.NoStreamOutputSupplier;
 import eu.esdihumboldt.hale.common.core.service.cleanup.Cleanup;
 import eu.esdihumboldt.hale.common.core.service.cleanup.CleanupContext;
 import eu.esdihumboldt.hale.common.core.service.cleanup.CleanupService;
@@ -646,7 +649,7 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 			saveConfig = main.getSaveConfiguration();
 		}
 
-		if (projectFile != null) {
+		if (projectFile != null || canSaveTo(projectLocation)) {
 			Collection<IOProviderDescriptor> providers = HaleIO
 					.getProviderFactories(ProjectWriter.class);
 
@@ -688,7 +691,12 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 					writer.loadConfiguration(saveConfig.getProviderConfiguration());
 					// overwrite target with projectFile (as it may have been
 					// moved externally)
-					writer.setTarget(new FileIOSupplier(projectFile));
+					if (projectFile != null) {
+						writer.setTarget(new FileIOSupplier(projectFile));
+					}
+					else {
+						writer.setTarget(new NoStreamOutputSupplier(projectLocation));
+					}
 
 					ProjectResourcesUtil.executeProvider(writer, saveProjectAdvisor, null);
 				}
@@ -699,7 +707,7 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 					saveAs();
 				}
 			}
-			else {
+			else if (projectFile != null) {
 				// use I/O provider and content type mechanisms to try saving
 				// the project file
 				ProjectWriter writer = HaleIO.findIOProvider(ProjectWriter.class,
@@ -713,10 +721,18 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 					saveAs();
 				}
 			}
+			else {
+				saveAs();
+			}
 		}
 		else {
 			saveAs();
 		}
+	}
+
+	private boolean canSaveTo(URI target) {
+		// TODO Discover plugin responsible for the target scheme and delegate
+		return "hc".equals(target.getScheme());
 	}
 
 	/**
@@ -810,7 +826,8 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 			currentLocation = projectLocation;
 		}
 
-		if (currentLocation != null) {
+		if (currentLocation != null
+				&& Arrays.asList("file", "http", "https").contains(currentLocation.getScheme())) {
 			// use I/O provider and content type mechanisms to enable loading of
 			// a project file
 			ProjectReader reader = HaleIO.findIOProvider(ProjectReader.class,

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -778,7 +778,6 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 			public void run() {
 				SaveProjectWizard wizard;
 
-				// Find all project archive content types
 				IContentType archiveContentType = HalePlatform.getContentTypeManager()
 						.getContentType(ProjectIO.PROJECT_ARCHIVE_CONTENT_TYPE_ID);
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -777,17 +777,25 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 			@Override
 			public void run() {
 				SaveProjectWizard wizard;
-				if (projectLoadContentType != null && projectLoadContentType.getId()
-						.equals(ProjectIO.PROJECT_ARCHIVE_CONTENT_TYPE_ID)) {
+
+				// Find all project archive content types
+				IContentType archiveContentType = HalePlatform.getContentTypeManager()
+						.getContentType(ProjectIO.PROJECT_ARCHIVE_CONTENT_TYPE_ID);
+
+				if (archiveContentType != null && projectLoadContentType != null
+						&& projectLoadContentType.isKindOf(archiveContentType)) {
 					/*
 					 * For project archives, saving the project has to be
 					 * restricted to project archives again, as the files only
 					 * reside in a temporary location.
 					 */
-					wizard = new SaveProjectWizard(projectLoadContentType);
+					List<IContentType> archiveTypes = HaleIO.findContentTypesOfKind(
+							HalePlatform.getContentTypeManager().getAllContentTypes(),
+							archiveContentType);
+					wizard = new SaveProjectWizard(archiveTypes);
 				}
 				else {
-					wizard = new SaveProjectWizard(null);
+					wizard = new SaveProjectWizard();
 				}
 				wizard.setAdvisor(saveProjectAdvisor, null);
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -616,14 +616,18 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 					}
 				}
 
-				String title;
+				String projectName = getProjectInfo().getName();
+				String title = appTitle + " - " + ((projectName == null || projectName.isEmpty())
+						? "Unnamed" : projectName);
 				if (projectFile == null) {
-					title = appTitle;
+					// TODO Use scheme to discover plugin that can provide title
+					// information
+					if (projectLocation != null && "hc".equals(projectLocation.getScheme())) {
+						title += " - [hale connect]";
+					}
 				}
 				else {
-					String pn = getProjectInfo().getName();
-					title = appTitle + " - " + ((pn == null || pn.isEmpty()) ? ("Unnamed") : (pn))
-							+ " - " + projectFile;
+					title += " - " + projectFile;
 				}
 
 				if (changed) {

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -702,7 +702,24 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 						writer.setTarget(new NoStreamOutputSupplier(projectLocation));
 					}
 
-					ProjectResourcesUtil.executeProvider(writer, saveProjectAdvisor, null);
+					ListenableFuture<IOReport> result = ProjectResourcesUtil.executeProvider(writer,
+							saveProjectAdvisor, true, null);
+
+					PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
+
+						@Override
+						public void run() {
+							try {
+								IOReport report = result.get();
+								if (!report.isSuccess()) {
+									log.userError(
+											"The project could not be saved. Please check the report for more details.");
+								}
+							} catch (InterruptedException | ExecutionException e) {
+								log.userError("The project could not be saved.", e);
+							}
+						}
+					});
 				}
 				else {
 					log.info(


### PR DESCRIPTION
Introduces the possibility to save changes directly to hale connect (#422). ~Currently limited to projects that were imported from hale connect.~ Also adds support for saving a project to hale connect and having subsequent saves update the remote project (#429).

~Currently also includes changes from PRs #424 and #426. To be rebased after these have been merged.~
