### PR TITLE
don't use dots in value constraint IDs

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema/schema/eu.esdihumboldt.hale.schema.valueconstraint.exsd
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema/schema/eu.esdihumboldt.hale.schema.valueconstraint.exsd
@@ -59,6 +59,8 @@
             <annotation>
                <documentation>
                   Unique identifier representing the constraint type and factory. Used for resolving a factory and recreating a constraint from a value.
+
+Do not use dots inside the identifier for compatibility reasons.
                </documentation>
             </annotation>
          </attribute>

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc/plugin.xml
@@ -163,37 +163,61 @@
          point="eu.esdihumboldt.hale.schema.valueconstraint">
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.AutoIncrementFlagFactory"
-            id="jdbc.autoinc"
+            id="jdbc_autoinc"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.AutoIncrementFlag">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.SQLArrayFactory"
-            id="jdbc.array"
+            id="jdbc_array"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.SQLArray">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.SQLTypeFactory"
-            id="jdbc.sqltype"
+            id="jdbc_sqltype"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.SQLType">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.DefaultValueFactory"
-            id="jdbc.default"
+            id="jdbc_default"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.DefaultValue">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.DatabaseTableFactory"
-            id="jdbc.table"
+            id="jdbc_table"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.DatabaseTable">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.jdbc.constraints.factory.SQLQueryFactory"
-            id="jdbc.sqlquery"
+            id="jdbc_sqlquery"
             type="eu.esdihumboldt.hale.io.jdbc.constraints.SQLQuery">
       </valueconstraint>
       <alias
             for="geometry-metadata"
             id="jdbc.geometry">
+      </alias>
+      <alias
+            for="jdbc_autoinc"
+            id="jdbc.autoinc">
+      </alias>
+      <alias
+            for="jdbc_array"
+            id="jdbc.array">
+      </alias>
+      <alias
+            for="jdbc_sqltype"
+            id="jdbc.sqltype">
+      </alias>
+      <alias
+            for="jdbc_default"
+            id="jdbc.default">
+      </alias>
+      <alias
+            for="jdbc_table"
+            id="jdbc.table">
+      </alias>
+      <alias
+            for="jdbc_sqlquery"
+            id="jdbc.sqlquery">
       </alias>
    </extension>
 

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd/plugin.xml
@@ -55,29 +55,49 @@
          point="eu.esdihumboldt.hale.schema.valueconstraint">
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.xsd.reader.internal.constraint.factory.XLinkReferenceFactory"
-            id="xsd.xlink"
+            id="xsd_xlink"
             type="eu.esdihumboldt.hale.io.xsd.reader.internal.constraint.XLinkReference">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.xsd.constraint.factory.XmlAttributeFlagFactory"
-            id="xsd.attribute"
+            id="xsd_attribute"
             type="eu.esdihumboldt.hale.io.xsd.constraint.XmlAttributeFlag">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.xsd.constraint.factory.RestrictionFlagFactory"
-            id="xsd.restriction"
+            id="xsd_restriction"
             type="eu.esdihumboldt.hale.io.xsd.constraint.RestrictionFlag">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.xsd.constraint.factory.XmlMixedFlagFactory"
-            id="xsd.mixed"
+            id="xsd_mixed"
             type="eu.esdihumboldt.hale.io.xsd.constraint.XmlMixedFlag">
       </valueconstraint>
       <valueconstraint
             factory="eu.esdihumboldt.hale.io.xsd.reader.internal.constraint.factory.SkipGeometryValidationFactory"
-            id="xsd.skip-geometry-validation"
+            id="xsd_skip-geometry-validation"
             type="eu.esdihumboldt.hale.io.xsd.reader.internal.constraint.SkipGeometryValidation">
       </valueconstraint>
+      <alias
+            for="xsd_xlink"
+            id="xsd.xlink">
+      </alias>
+      <alias
+            for="xsd_attribute"
+            id="xsd.attribute">
+      </alias>
+      <alias
+            for="xsd_restriction"
+            id="xsd.restriction">
+      </alias>
+      <alias
+            for="xsd_mixed"
+            id="xsd.mixed">
+      </alias>
+      <alias
+            for="xsd_skip-geometry-validation"
+            id="xsd.skip-geometry-validation">
+      </alias>
    </extension>
    <extension
          point="eu.esdihumboldt.util.groovy.sandbox">


### PR DESCRIPTION
For compatibility with MongoDB.

Extensions like the pro plugins also need to be adapted accordingly.