### PR TITLE
Fix opening a file when launching

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
@@ -32,7 +32,7 @@ https://www.wetransform.to/services/support/
 
    <launcherArgs>
       <programArgs>-clean
--name &quot;HUMBOLDT Alignment Editor&quot;
+-name &quot;hale studio&quot;
 --launcher.defaultAction openFile
       </programArgs>
       <vmArgs>-Xmx1000m


### PR DESCRIPTION
Because the `-name` argument was not updated when the application title was changed to `hale studio`, opening a file that is specified on the command line no longer worked.