### PR TITLE
Fix hale connect login on Welcome Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hale connect login on Welcome Page to work for user names and passwords w/ special characters
+
 ## [3.3.1]
 
 ### Fixed

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/templates/welcome-login.vm
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/templates/welcome-login.vm
@@ -57,8 +57,8 @@
 	<script type="text/javascript">
 		function login() {
 			var params = {
-				"username": document.getElementById('hc-username').value,
-				"password": document.getElementById('hc-password').value,
+				"username": encodeURIComponent(document.getElementById('hc-username').value),
+				"password": encodeURIComponent(document.getElementById('hc-password').value),
 				"savecreds": document.getElementById('hc-savecreds').checked
 			}
 			


### PR DESCRIPTION
If either the user name or the password contained special characters like '%', the entered values were not passed correctly to the hale connect login API.