### PR TITLE
Update default hale connect endpoints

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/internal/HaleConnectUIPlugin.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/internal/HaleConnectUIPlugin.java
@@ -26,6 +26,7 @@ import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectService;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices;
 import eu.esdihumboldt.hale.io.haleconnect.ui.preferences.PreferenceConstants;
+import eu.esdihumboldt.hale.io.haleconnect.ui.preferences.PreferenceInitializer;
 import eu.esdihumboldt.hale.ui.HaleUI;
 
 /**
@@ -55,14 +56,40 @@ public class HaleConnectUIPlugin extends AbstractUIPlugin {
 		try {
 			HaleConnectService hcs = HaleUI.getServiceProvider()
 					.getService(HaleConnectService.class);
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
-					getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_USERS));
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
-					getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA));
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
-					getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_PROJECTS));
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
-					getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_CLIENT));
+
+			boolean useDefaults;
+			if (!HaleConnectUIPlugin.getDefault().getPreferenceStore()
+					.contains(PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS)) {
+				useDefaults = true;
+				HaleConnectUIPlugin.getDefault().getPreferenceStore()
+						.setValue(PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS, true);
+			}
+			else {
+				useDefaults = HaleConnectUIPlugin.getDefault().getPreferenceStore()
+						.getBoolean(PreferenceConstants.HALE_CONNECT_BASEPATH_USE_DEFAULTS);
+			}
+
+			if (useDefaults) {
+				// Force default values
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
+						PreferenceInitializer.HALE_CONNECT_BASEPATH_USERS_DEFAULT);
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
+						PreferenceInitializer.HALE_CONNECT_BASEPATH_DATA_DEFAULT);
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
+						PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT);
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
+						PreferenceInitializer.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT);
+			}
+			else {
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
+						getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_USERS));
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
+						getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_DATA));
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
+						getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_PROJECTS));
+				hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
+						getPreference(PreferenceConstants.HALE_CONNECT_BASEPATH_CLIENT));
+			}
 		} catch (Throwable t) {
 			log.error("Error initializing HaleConnectService", t);
 		}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
@@ -13,17 +13,17 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	/**
 	 * Default base path of the hale connect user service
 	 */
-	public static String HALE_CONNECT_BASEPATH_USERS_DEFAULT = "https://users.haleconnect.com/v1";
+	public static String HALE_CONNECT_BASEPATH_USERS_DEFAULT = "https://haleconnect.com/accounts/v1";
 
 	/**
 	 * Default base path of the hale connect project store
 	 */
-	public static final String HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT = "https://project-store.haleconnect.com";
+	public static final String HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT = "https://haleconnect.com/store/projects";
 
 	/**
 	 * Default base path of the hale connect bucket service
 	 */
-	public static final String HALE_CONNECT_BASEPATH_DATA_DEFAULT = "https://data.haleconnect.com";
+	public static final String HALE_CONNECT_BASEPATH_DATA_DEFAULT = "https://haleconnect.com/store/data";
 
 	/**
 	 * Default base path of the hale connect web client


### PR DESCRIPTION
Adapts the hale connect endpoints to the new URL scheme of the swarm deployment and fixes an issue with loading the default endpoints when a user had defined custom endpoints previously.

@stempler I used `https://haleconnect.com/<service>` as the new URL scheme (not `*www*.haleconnect.com/<service>`). Is that correct?