### PR TITLE
Improve CRS lookup for shapefiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 ### Added
 
 - When importing a shapefile resource, prefill character set dialog with encoding read from accompanying `.cpg` file
+- Enhanced CRS detection when parsing GML files
 
 ### Fixed
 
 - Fixed hale connect login on Welcome Page to work for user names and passwords w/ special characters
+- Fixed the CRS definition lookup when importing shapefiles, allowing for automatic detection of CRS details (Bursa-Wolf parameters)
 
 ## [3.3.1]
 

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSProvider.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSProvider.java
@@ -40,6 +40,21 @@ public interface CRSProvider {
 	 * 
 	 * @return the CRS definition or <code>null</code> if it can't be determined
 	 */
-	public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath);
+	CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath);
 
+	/**
+	 * Get the CRS definition for values of the given property definition. If no
+	 * CRS definition can be determined, use the one passed in
+	 * <code>defaultCrs</code>.
+	 * 
+	 * @param parentType the definition of the type of the parent instance
+	 * @param propertyPath the property path in the instance
+	 * @param defaultCrs Default CRS definition to use if none can be determined
+	 *            (may be null)
+	 * @return the CRS definition or <code>null</code> if it can't be determined
+	 */
+	default CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath,
+			CRSDefinition defaultCrs) {
+		return getCRS(parentType, propertyPath);
+	}
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/AbstractCRSManager.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/AbstractCRSManager.java
@@ -71,6 +71,13 @@ public abstract class AbstractCRSManager implements CRSProvider {
 
 	@Override
 	public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath) {
+		return getCRS(parentType, propertyPath, null);
+	}
+
+	@Override
+	public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath,
+			CRSDefinition defaultCrs) {
+
 		CRSDefinition result = null;
 		String resourceId = reader.getResourceIdentifier();
 		if (resourceId == null) {
@@ -98,8 +105,8 @@ public abstract class AbstractCRSManager implements CRSProvider {
 
 		// overall configuration for resource
 		if (result == null && !resourceId.isEmpty()) {
-			result = CRSDefinitionManager.getInstance().parse(
-					loadValue(resourceId + PARAM_DEFAULT_CRS));
+			result = CRSDefinitionManager.getInstance()
+					.parse(loadValue(resourceId + PARAM_DEFAULT_CRS));
 		}
 		// overall configuration
 		if (result == null) {
@@ -108,7 +115,7 @@ public abstract class AbstractCRSManager implements CRSProvider {
 
 		if (result == null && provider != null) {
 			// consult default CRS provider
-			result = provider.getCRS(parentType, propertyPath);
+			result = provider.getCRS(parentType, propertyPath, defaultCrs);
 			if (result != null) {
 				// store in configuration
 				storeValue(propertyKey, CRSDefinitionManager.getInstance().asString(result));

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
@@ -42,7 +42,7 @@ public class EPSGResolveCache implements CRSResolveCache {
 			try {
 				Integer epsgCode = CRS.lookupEpsgCode(crs, true);
 				if (epsgCode != null) {
-					String code = SrsSyntax.OGC_URN + String.valueOf(epsgCode);
+					String code = SrsSyntax.OGC_URN.getPrefix() + String.valueOf(epsgCode);
 					CoordinateReferenceSystem resolved = CRS.decode(code);
 					result = new CodeDefinition(code, resolved);
 				}

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/io/impl/AbstractInstanceReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/io/impl/AbstractInstanceReader.java
@@ -45,14 +45,26 @@ public abstract class AbstractInstanceReader extends GZipEnabledImport implement
 	private final CRSProvider wrappingProvider = new CRSProvider() {
 
 		@Override
-		public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath) {
+		public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath,
+				CRSDefinition defaultCrs) {
 			CRSDefinition result = getDefaultSRS();
 
+			// Extend interface (default) to be able to provide default if
+			// provider can't resolve it
 			if (result == null && crsProvider != null) {
-				result = crsProvider.getCRS(parentType, propertyPath);
+				result = crsProvider.getCRS(parentType, propertyPath, defaultCrs);
+			}
+
+			if (result == null) {
+				return defaultCrs;
 			}
 
 			return result;
+		}
+
+		@Override
+		public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath) {
+			return getCRS(parentType, propertyPath, null);
 		}
 	};
 

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Import-Package: com.google.common.base;version="1.0.0",
  eu.esdihumboldt.hale.common.schema.persist,
  eu.esdihumboldt.util.groovy.builder,
  eu.esdihumboldt.util.io,
+ org.opengis.referencing.crs;version="12.2.0",
  org.slf4j;version="1.5.11"
 Export-Package: eu.esdihumboldt.hale.io.jdbc,
  eu.esdihumboldt.hale.io.jdbc.constraints,

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
@@ -170,12 +170,10 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 							// Bursa-Wolf parameters is used here silently. In
 							// cases of custom CRSs that don't have an EPSG
 							// code, the user can still provide the WKT
-							// definition in the dialog.
-							//
-							// TODO Replace default WKT definition in dialog
-							// with crsDef.getWkt()?
+							// definition in the dialog. In case of a headless
+							// transformation, the WKT definition will be used.
 							crsDef = crsProvider.getCRS(type,
-									Collections.singletonList(propertyName));
+									Collections.singletonList(propertyName), crsDef);
 						}
 					}
 					else {

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/DialogCRSProvider.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/DialogCRSProvider.java
@@ -44,6 +44,15 @@ public class DialogCRSProvider implements CRSProvider {
 	 */
 	@Override
 	public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath) {
+		return getCRS(parentType, propertyPath, null);
+	}
+
+	/**
+	 * @see CRSProvider#getCRS(TypeDefinition, List, CRSDefinition)
+	 */
+	@Override
+	public CRSDefinition getCRS(TypeDefinition parentType, List<QName> propertyPath,
+			final CRSDefinition defaultCrs) {
 		// TODO extend dialog to allow selecting a CRS per property definition
 		// XXX for now always reports the same CRS definition
 		if (crsDef == null && !shown) {
@@ -55,8 +64,8 @@ public class DialogCRSProvider implements CRSProvider {
 
 				@Override
 				public void run() {
-					SelectCRSDialog dialog = new SelectCRSDialog(Display.getCurrent()
-							.getActiveShell(), null);
+					SelectCRSDialog dialog = new SelectCRSDialog(
+							Display.getCurrent().getActiveShell(), defaultCrs);
 
 					dialog.open();
 					result.set(dialog.getValue());


### PR DESCRIPTION
This fixes a bug in `EPSGResolveCache` that prevented the CRS database lookup to work properly. This will usually prevent the `missing Bursa-Wolf parameters` exception (#281) in cases where the `.prj` file contains an incomplete WKT definition but Geotools can map it to an EPSG code nonetheless.

In cases where Geotools can't map the WKT definition to an EPSG code, the CRS dialog prompt will now be forced, so that the user can select an EPSG code, or, in cases where none exists, provide a WKT definition.