### PR TITLE
Support migration of Merge, Join parameters when remapping schemas

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align.test/src/eu/esdihumboldt/hale/common/align/io/JaxbAlignmentIOTest.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.test/src/eu/esdihumboldt/hale/common/align/io/JaxbAlignmentIOTest.java
@@ -37,7 +37,8 @@ public class JaxbAlignmentIOTest extends DefaultAlignmentIOTest {
 	protected MutableAlignment loadAlignment(InputStream input, TypeIndex source, TypeIndex target)
 			throws Exception {
 		// assume no location update needed
-		return JaxbAlignmentIO.load(input, null, source, target, new PathUpdate(null, null), null);
+		return JaxbAlignmentIO.load(input, null, source, target, new PathUpdate(null, null), null,
+				null);
 	}
 
 	@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentIO.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentIO.java
@@ -34,6 +34,7 @@ import eu.esdihumboldt.hale.common.align.model.Alignment;
 import eu.esdihumboldt.hale.common.align.model.MutableAlignment;
 import eu.esdihumboldt.hale.common.core.io.PathUpdate;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
+import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
 import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
 
 /**
@@ -61,17 +62,18 @@ public class JaxbAlignmentIO {
 	 * @param updater the path updater to use for base alignments
 	 * @param resolver the entity resolver, <code>null</code> to use the default
 	 *            resolver
+	 * @param serviceProvider the service provider
 	 * @return the alignment
 	 * @throws JAXBException if reading the alignment failed
 	 * @throws IOException if loading of base alignments failed
 	 */
 	public static MutableAlignment load(InputStream in, IOReporter reporter, TypeIndex sourceTypes,
-			TypeIndex targetTypes, PathUpdate updater, EntityResolver resolver)
-					throws JAXBException, IOException {
+			TypeIndex targetTypes, PathUpdate updater, EntityResolver resolver,
+			ServiceProvider serviceProvider) throws JAXBException, IOException {
 		AlignmentType genAlignment = JaxbToAlignment.load(in, reporter);
 		// convert to alignment
 		return new JaxbToAlignment(genAlignment, reporter, sourceTypes, targetTypes, updater,
-				resolver).convert();
+				resolver, serviceProvider).convert();
 	}
 
 	/**
@@ -90,7 +92,7 @@ public class JaxbAlignmentIO {
 	 */
 	public static void addBaseAlignment(MutableAlignment alignment, URI newBase,
 			URI projectLocation, TypeIndex sourceTypes, TypeIndex targetTypes, IOReporter reporter)
-					throws IOException {
+			throws IOException {
 		JaxbToAlignment.addBaseAlignment(alignment, newBase, projectLocation, sourceTypes,
 				targetTypes, reporter);
 	}

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentReader.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/JaxbAlignmentReader.java
@@ -60,7 +60,7 @@ public class JaxbAlignmentReader extends AbstractAlignmentReader {
 				entityResolver = getServiceProvider().getService(EntityResolver.class);
 			}
 			alignment = JaxbAlignmentIO.load(in, reporter, getSourceSchema(), getTargetSchema(),
-					getPathUpdater(), entityResolver);
+					getPathUpdater(), entityResolver, getServiceProvider());
 		} catch (Exception e) {
 			reporter.error(new IOMessageImpl(e.getMessage(), e));
 			reporter.setSuccess(false);

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/internal/JaxbToAlignment.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/internal/JaxbToAlignment.java
@@ -69,6 +69,7 @@ import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.core.io.impl.ElementValue;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
+import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
 import eu.esdihumboldt.hale.common.schema.SchemaSpaceID;
 import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
 
@@ -87,6 +88,7 @@ public class JaxbToAlignment
 	private final AlignmentType alignment;
 	private final PathUpdate updater;
 	private final EntityResolver resolver;
+	private final ServiceProvider serviceProvider;
 
 	/**
 	 * Private constructor for internal use.
@@ -100,6 +102,7 @@ public class JaxbToAlignment
 		// no custom resolver here, this constructor is used when loading base
 		// alignments
 		this.resolver = DefaultEntityResolver.getInstance();
+		this.serviceProvider = null;
 	}
 
 	/**
@@ -109,9 +112,11 @@ public class JaxbToAlignment
 	 * @param targetTypes the target types for resolving target entities
 	 * @param updater the path updater to use for base alignments
 	 * @param resolver the entity resolver
+	 * @param serviceProvider Service provider
 	 */
 	public JaxbToAlignment(AlignmentType alignment, IOReporter reporter, TypeIndex sourceTypes,
-			TypeIndex targetTypes, PathUpdate updater, EntityResolver resolver) {
+			TypeIndex targetTypes, PathUpdate updater, EntityResolver resolver,
+			ServiceProvider serviceProvider) {
 		this.alignment = alignment;
 		this.reporter = reporter;
 		this.sourceTypes = sourceTypes;
@@ -123,6 +128,7 @@ public class JaxbToAlignment
 		else {
 			this.resolver = resolver;
 		}
+		this.serviceProvider = serviceProvider;
 	}
 
 	/**

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/internal/JaxbToAlignment.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/io/impl/internal/JaxbToAlignment.java
@@ -36,13 +36,17 @@ import com.google.common.base.Function;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
 
 import eu.esdihumboldt.hale.common.align.extension.annotation.AnnotationExtension;
+import eu.esdihumboldt.hale.common.align.extension.function.FunctionDefinition;
+import eu.esdihumboldt.hale.common.align.extension.function.FunctionUtil;
 import eu.esdihumboldt.hale.common.align.extension.function.custom.CustomPropertyFunction;
 import eu.esdihumboldt.hale.common.align.io.EntityResolver;
 import eu.esdihumboldt.hale.common.align.io.LoadAlignmentContext;
 import eu.esdihumboldt.hale.common.align.io.impl.DefaultEntityResolver;
 import eu.esdihumboldt.hale.common.align.io.impl.JaxbAlignmentIO;
+import eu.esdihumboldt.hale.common.align.io.impl.dummy.DummyEntityResolver;
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.AbstractParameterType;
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.AlignmentType;
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.AlignmentType.Base;
@@ -55,8 +59,12 @@ import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.ModifierType
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.ModifierType.DisableFor;
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.NamedEntityType;
 import eu.esdihumboldt.hale.common.align.io.impl.internal.generated.ParameterType;
+import eu.esdihumboldt.hale.common.align.migrate.CellMigrator;
+import eu.esdihumboldt.hale.common.align.migrate.impl.DefaultCellMigrator;
+import eu.esdihumboldt.hale.common.align.migrate.impl.UnmigratedCell;
 import eu.esdihumboldt.hale.common.align.model.AnnotationDescriptor;
 import eu.esdihumboldt.hale.common.align.model.Entity;
+import eu.esdihumboldt.hale.common.align.model.EntityDefinition;
 import eu.esdihumboldt.hale.common.align.model.MutableAlignment;
 import eu.esdihumboldt.hale.common.align.model.MutableCell;
 import eu.esdihumboldt.hale.common.align.model.ParameterValue;
@@ -72,6 +80,7 @@ import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
 import eu.esdihumboldt.hale.common.core.service.ServiceProvider;
 import eu.esdihumboldt.hale.common.schema.SchemaSpaceID;
 import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
+import eu.esdihumboldt.util.Pair;
 
 /**
  * Converts an {@link AlignmentType} loaded with JAXB to a
@@ -180,7 +189,7 @@ public class JaxbToAlignment
 	 */
 	public static void addBaseAlignment(MutableAlignment alignment, URI newBase,
 			URI projectLocation, TypeIndex sourceTypes, TypeIndex targetTypes, IOReporter reporter)
-					throws IOException {
+			throws IOException {
 		new JaxbToAlignment().internalAddBaseAlignment(alignment, newBase, projectLocation,
 				sourceTypes, targetTypes, reporter);
 	}
@@ -195,11 +204,65 @@ public class JaxbToAlignment
 		return super.createAlignment(alignment, sourceTypes, targetTypes, updater, reporter);
 	}
 
-	private static MutableCell convert(CellType cell, LoadAlignmentContext context,
-			IOReporter reporter, EntityResolver resolver) {
-		DefaultCell result = new DefaultCell();
+	private static UnmigratedCell createUnmigratedCell(CellType cell, LoadAlignmentContext context,
+			IOReporter reporter, EntityResolver resolver, ServiceProvider serviceProvider) {
+		// The sourceCell represents the cell as it was imported from the
+		// XML alignment. The conversion to the resolved cell must be performed
+		// later by migrating the UnmigratedCell returned from this function.
+		final DefaultCell sourceCell = new DefaultCell();
+		sourceCell.setTransformationIdentifier(cell.getRelation());
 
-		result.setTransformationIdentifier(cell.getRelation());
+		final FunctionDefinition<?> cellFunction = FunctionUtil
+				.getFunction(sourceCell.getTransformationIdentifier(), serviceProvider);
+		final CellMigrator migrator;
+		if (cellFunction != null) {
+			migrator = cellFunction.getCustomMigrator().orElse(new DefaultCellMigrator());
+		}
+		else {
+			migrator = new DefaultCellMigrator();
+		}
+
+		Map<EntityDefinition, EntityDefinition> mappings = new HashMap<>();
+		try {
+			// The returned Entity pair consists of
+			// (1st) a dummy entity representing the entity read from JAXB
+			// (2nd) the resolved entity
+			ListMultimap<String, Pair<Entity, Entity>> convertedSourceEntities = convertEntities(
+					cell.getSource(), context.getSourceTypes(), SchemaSpaceID.SOURCE, resolver);
+			if (convertedSourceEntities == null) {
+				sourceCell.setSource(null);
+			}
+			else {
+				sourceCell.setSource(Multimaps.transformValues(convertedSourceEntities,
+						pair -> pair.getFirst()));
+				for (Pair<Entity, Entity> pair : convertedSourceEntities.values()) {
+					mappings.put(pair.getFirst().getDefinition(), pair.getSecond().getDefinition());
+				}
+			}
+
+			ListMultimap<String, Pair<Entity, Entity>> convertedTargetEntities = convertEntities(
+					cell.getTarget(), context.getTargetTypes(), SchemaSpaceID.TARGET, resolver);
+			if (convertedTargetEntities == null) {
+				sourceCell.setTarget(null);
+			}
+			else {
+				sourceCell.setTarget(Multimaps.transformValues(convertedTargetEntities,
+						pair -> pair.getFirst()));
+				for (Pair<Entity, Entity> pair : convertedTargetEntities.values()) {
+					mappings.put(pair.getFirst().getDefinition(), pair.getSecond().getDefinition());
+				}
+			}
+
+			if (sourceCell.getTarget() == null || sourceCell.getTarget().isEmpty()) {
+				// target is mandatory for cells!
+				throw new IllegalStateException("Cannot create cell without target");
+			}
+		} catch (Exception e) {
+			if (reporter != null) {
+				reporter.error(new IOMessageImpl("Could not create cell", e));
+			}
+			return null;
+		}
 
 		if (!cell.getAbstractParameter().isEmpty()) {
 			ListMultimap<String, ParameterValue> parameters = ArrayListMultimap.create();
@@ -208,8 +271,8 @@ public class JaxbToAlignment
 				if (apt instanceof ParameterType) {
 					// treat string parameters or null parameters
 					ParameterType pt = (ParameterType) apt;
-					parameters.put(pt.getName(),
-							new ParameterValue(pt.getType(), Value.of(pt.getValue())));
+					ParameterValue pv = new ParameterValue(pt.getType(), Value.of(pt.getValue()));
+					parameters.put(pt.getName(), pv);
 				}
 				else if (apt instanceof ComplexParameterType) {
 					// complex parameters
@@ -220,23 +283,7 @@ public class JaxbToAlignment
 				else
 					throw new IllegalStateException("Illegal parameter type");
 			}
-			result.setTransformationParameters(parameters);
-		}
-
-		try {
-			result.setSource(convertEntities(cell.getSource(), context.getSourceTypes(),
-					SchemaSpaceID.SOURCE, resolver));
-			result.setTarget(convertEntities(cell.getTarget(), context.getTargetTypes(),
-					SchemaSpaceID.TARGET, resolver));
-			if (result.getTarget() == null || result.getTarget().isEmpty()) {
-				// target is mandatory for cells!
-				throw new IllegalStateException("Cannot create cell without target");
-			}
-		} catch (Exception e) {
-			if (reporter != null) {
-				reporter.error(new IOMessageImpl("Could not create cell", e));
-			}
-			return null;
+			sourceCell.setTransformationParameters(parameters);
 		}
 
 		// annotations & documentation
@@ -251,7 +298,7 @@ public class JaxbToAlignment
 				if (desc != null) {
 					try {
 						Object value = desc.fromDOM(annot.getAny(), null);
-						result.addAnnotation(annot.getType(), value);
+						sourceCell.addAnnotation(annot.getType(), value);
 					} catch (Exception e) {
 						if (reporter != null) {
 							reporter.error(new IOMessageImpl("Error loading cell annotation", e));
@@ -268,34 +315,35 @@ public class JaxbToAlignment
 			else if (element instanceof DocumentationType) {
 				// add documentation to the cell
 				DocumentationType doc = (DocumentationType) element;
-				result.getDocumentation().put(doc.getType(), doc.getValue());
+				sourceCell.getDocumentation().put(doc.getType(), doc.getValue());
 			}
 		}
 
-		result.setId(cell.getId());
+		sourceCell.setId(cell.getId());
 
 		// a default value is assured for priority
 		String priorityStr = cell.getPriority().value();
 		Priority priority = Priority.fromValue(priorityStr);
 		if (priority != null) {
-			result.setPriority(priority);
+			sourceCell.setPriority(priority);
 		}
 		else {
 			// TODO check if it makes sense to do something. Default value is
 			// used.
 			throw new IllegalArgumentException();
 		}
-		return result;
+
+		return new UnmigratedCell(sourceCell, migrator, mappings);
 	}
 
-	private static ListMultimap<String, ? extends Entity> convertEntities(
+	private static ListMultimap<String, Pair<Entity, Entity>> convertEntities(
 			List<NamedEntityType> namedEntities, TypeIndex types, SchemaSpaceID schemaSpace,
 			EntityResolver resolver) {
 		if (namedEntities == null || namedEntities.isEmpty()) {
 			return null;
 		}
 
-		ListMultimap<String, Entity> result = ArrayListMultimap.create();
+		ListMultimap<String, Pair<Entity, Entity>> result = ArrayListMultimap.create();
 
 		for (NamedEntityType namedEntity : namedEntities) {
 			/**
@@ -309,11 +357,19 @@ public class JaxbToAlignment
 			 * cell</li>
 			 * </ul>
 			 */
-			Entity entity = resolver.resolve(namedEntity.getAbstractEntity().getValue(), types,
-					schemaSpace);
 
-			if (entity != null) {
-				result.put(namedEntity.getName(), entity);
+			// Create a dummy entity from the original XML definition
+			DummyEntityResolver dummyResolver = new DummyEntityResolver();
+			Entity dummyEntity = dummyResolver.resolve(namedEntity.getAbstractEntity().getValue(),
+					types, schemaSpace);
+
+			// Resolve the real entity
+			Entity resolvedEntity = resolver.resolve(namedEntity.getAbstractEntity().getValue(),
+					types, schemaSpace);
+
+			if (resolvedEntity != null) {
+				result.put(namedEntity.getName(),
+						new Pair<Entity, Entity>(dummyEntity, resolvedEntity));
 			}
 		}
 
@@ -368,7 +424,7 @@ public class JaxbToAlignment
 		LoadAlignmentContextImpl context = new LoadAlignmentContextImpl();
 		context.setSourceTypes(sourceTypes);
 		context.setTargetTypes(targetTypes);
-		return convert(cell, context, reporter, resolver);
+		return createUnmigratedCell(cell, context, reporter, resolver, serviceProvider);
 	}
 
 	@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/AlignmentMigrationNameLookupSupport.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/AlignmentMigrationNameLookupSupport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.align.migrate;
+
+import java.util.Optional;
+
+import eu.esdihumboldt.hale.common.align.model.EntityDefinition;
+
+/**
+ * Interface describing an alignment migration, adding a method for lenient
+ * lookup via the entity name.
+ * 
+ * @author Florian Esser
+ */
+public interface AlignmentMigrationNameLookupSupport extends AlignmentMigration {
+
+	/**
+	 * Yields a replacement for an entity of which only the name is known, e.g.
+	 * a function parameter referencing a property
+	 * 
+	 * @param name entity name
+	 * @return the replacement entity, if the entity should be replaced
+	 */
+	Optional<EntityDefinition> entityReplacement(String name);
+
+}

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/impl/UnmigratedCell.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/impl/UnmigratedCell.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.align.migrate.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+
+import eu.esdihumboldt.hale.common.align.migrate.AlignmentMigration;
+import eu.esdihumboldt.hale.common.align.migrate.AlignmentMigrationNameLookupSupport;
+import eu.esdihumboldt.hale.common.align.migrate.CellMigrator;
+import eu.esdihumboldt.hale.common.align.migrate.MigrationOptions;
+import eu.esdihumboldt.hale.common.align.model.EntityDefinition;
+import eu.esdihumboldt.hale.common.align.model.MutableCell;
+import eu.esdihumboldt.hale.common.align.model.impl.MutableCellDecorator;
+
+/**
+ * Decorator for a {@link MutableCell} that allows to do lazy migration.
+ * 
+ * @author Florian Esser
+ */
+public class UnmigratedCell extends MutableCellDecorator {
+
+	private final CellMigrator migrator;
+	private final Map<EntityDefinition, EntityDefinition> entityMappings;
+
+	/**
+	 * Create an unmigrated cell
+	 * 
+	 * @param unmigratedCell Original cell that is to be migrated later
+	 * @param migrator The migrator to apply
+	 * @param mappings The original {@link EntityDefinition}s mapped to the
+	 *            resolved ones
+	 */
+	public UnmigratedCell(MutableCell unmigratedCell, CellMigrator migrator,
+			Map<EntityDefinition, EntityDefinition> mappings) {
+		super(unmigratedCell);
+		this.migrator = migrator;
+		this.entityMappings = mappings;
+	}
+
+	/**
+	 * @return true if a migrator was defined
+	 */
+	public boolean canMigrate() {
+		return migrator != null;
+	}
+
+	/**
+	 * Perform the migration of the original cell and return the migrated cell.
+	 * The <code>UnmigratedCell</code> instance is not changed.
+	 * 
+	 * @param additionalMappings Additional mappings of original
+	 *            {@link EntityDefinition}s to the resolved ones that should be
+	 *            considered in the migration
+	 * @return the migrated cell
+	 */
+	public MutableCell migrate(Map<EntityDefinition, EntityDefinition> additionalMappings) {
+		final Map<EntityDefinition, EntityDefinition> joinedMappings = new HashMap<>(
+				entityMappings);
+		joinedMappings.putAll(additionalMappings);
+
+		AlignmentMigration migration = new AlignmentMigrationNameLookupSupport() {
+
+			@Override
+			public Optional<EntityDefinition> entityReplacement(EntityDefinition entity) {
+
+				return Optional.ofNullable(joinedMappings.get(entity));
+			}
+
+			@Override
+			public Optional<EntityDefinition> entityReplacement(String name) {
+				for (EntityDefinition original : joinedMappings.keySet()) {
+					QName entityName = original.getDefinition().getName();
+					if (entityName != null && entityName.getLocalPart().equals(name)) {
+						return Optional.of(original);
+					}
+				}
+
+				return Optional.empty();
+			}
+		};
+
+		MigrationOptions options = new MigrationOptions() {
+
+			@Override
+			public boolean updateTarget() {
+				return true;
+			}
+
+			@Override
+			public boolean updateSource() {
+				return true;
+			}
+
+			@Override
+			public boolean transferBase() {
+				return false;
+			}
+		};
+
+		return migrator.updateCell(this, migration, options);
+	}
+
+	/**
+	 * @return the mappings of original entity definition to the resolved ones
+	 */
+	public Map<EntityDefinition, EntityDefinition> getEntityMappings() {
+		return entityMappings;
+	}
+}

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/MutableCellDecorator.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/MutableCellDecorator.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.align.model.impl;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ListMultimap;
+
+import eu.esdihumboldt.hale.common.align.model.Entity;
+import eu.esdihumboldt.hale.common.align.model.MutableCell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
+import eu.esdihumboldt.hale.common.align.model.Priority;
+import eu.esdihumboldt.hale.common.align.model.TransformationMode;
+
+/**
+ * Decorator for {@link MutableCell}s
+ * 
+ * @author Florian Esser
+ */
+public class MutableCellDecorator implements MutableCell {
+
+	private final MutableCell decoratee;
+
+	/**
+	 * Create the decorator
+	 * 
+	 * @param decoratee <code>MutableCell</code> to decorate
+	 */
+	public MutableCellDecorator(MutableCell decoratee) {
+		this.decoratee = decoratee;
+	}
+
+	@Override
+	public void setDisabledFor(String cellId, boolean disabled) {
+		decoratee.setDisabledFor(cellId, disabled);
+	}
+
+	@Override
+	public void setTransformationMode(TransformationMode mode) {
+		decoratee.setTransformationMode(mode);
+	}
+
+	@Override
+	public void setTransformationIdentifier(String transformation) {
+		decoratee.setTransformationIdentifier(transformation);
+	}
+
+	@Override
+	public void setTransformationParameters(ListMultimap<String, ParameterValue> parameters) {
+		decoratee.setTransformationParameters(parameters);
+	}
+
+	@Override
+	public void setSource(ListMultimap<String, ? extends Entity> source) {
+		decoratee.setSource(source);
+	}
+
+	@Override
+	public void setTarget(ListMultimap<String, ? extends Entity> target) {
+		decoratee.setTarget(target);
+	}
+
+	@Override
+	public void setId(String id) {
+		decoratee.setId(id);
+	}
+
+	@Override
+	public void setPriority(Priority priority) {
+		decoratee.setPriority(priority);
+	}
+
+	@Override
+	public ListMultimap<String, ? extends Entity> getSource() {
+		return decoratee.getSource();
+	}
+
+	@Override
+	public ListMultimap<String, ? extends Entity> getTarget() {
+		return decoratee.getTarget();
+	}
+
+	@Override
+	public ListMultimap<String, ParameterValue> getTransformationParameters() {
+		return decoratee.getTransformationParameters();
+	}
+
+	@Override
+	public List<?> getAnnotations(String type) {
+		return decoratee.getAnnotations(type);
+	}
+
+	@Override
+	public Set<String> getAnnotationTypes() {
+		return decoratee.getAnnotationTypes();
+	}
+
+	@Override
+	public Object addAnnotation(String type) {
+		return decoratee.addAnnotation(type);
+	}
+
+	@Override
+	public void removeAnnotation(String type, Object annotation) {
+		decoratee.removeAnnotation(type, annotation);
+	}
+
+	@Override
+	public ListMultimap<String, String> getDocumentation() {
+		return decoratee.getDocumentation();
+	}
+
+	@Override
+	public String getTransformationIdentifier() {
+		return decoratee.getTransformationIdentifier();
+	}
+
+	@Override
+	public String getId() {
+		return decoratee.getId();
+	}
+
+	@Override
+	public Set<String> getDisabledFor() {
+		return decoratee.getDisabledFor();
+	}
+
+	@Override
+	public Priority getPriority() {
+		return decoratee.getPriority();
+	}
+
+	@Override
+	public TransformationMode getTransformationMode() {
+		return decoratee.getTransformationMode();
+	}
+
+	@Override
+	public boolean isBaseCell() {
+		return decoratee.isBaseCell();
+	}
+
+}

--- a/common/plugins/eu.esdihumboldt.hale.common.test/src/eu/esdihumboldt/hale/common/test/TestUtil.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.test/src/eu/esdihumboldt/hale/common/test/TestUtil.java
@@ -66,8 +66,8 @@ public class TestUtil {
 	 *             configuration failed
 	 * @throws IOException if the schema could not be loaded
 	 */
-	public static Schema loadSchema(URI location) throws IOProviderConfigurationException,
-			IOException {
+	public static Schema loadSchema(URI location)
+			throws IOProviderConfigurationException, IOException {
 		DefaultInputSupplier input = new DefaultInputSupplier(location);
 
 		XmlSchemaReader reader = new XmlSchemaReader();
@@ -93,8 +93,8 @@ public class TestUtil {
 	 * @return the loaded alignment
 	 * @throws Exception if the alignment or other resources could not be loaded
 	 */
-	public static Alignment loadAlignment(final URI location, Schema sourceTypes, Schema targetTypes)
-			throws Exception {
+	public static Alignment loadAlignment(final URI location, Schema sourceTypes,
+			Schema targetTypes) throws Exception {
 		DefaultInputSupplier input = new DefaultInputSupplier(location);
 
 		IOReporter report = new DefaultIOReporter(new Locatable() {
@@ -110,7 +110,7 @@ public class TestUtil {
 					new PathUpdate(null, null));
 		} catch (Exception e) {
 			alignment = JaxbAlignmentIO.load(input.getInput(), report, sourceTypes, targetTypes,
-					new PathUpdate(null, null), null);
+					new PathUpdate(null, null), null, null);
 		}
 
 		assertTrue("Errors are contained in the report", report.getErrors().isEmpty());


### PR DESCRIPTION
When importing an alignment that includes types and/or properties that do not have a matching type/property in the source/target schemas, hale studio offers remapping these missing types/properties to existing ones. Until now, when a remapping was done on a property that was at the same time a merge property or join condition, the respective transformation parameters were not updated and needed to be changed manually (see #428).

This patch modifies the remapping of the imported alignment so that the for every cell its respective `CellMigrator` is used to make sure that transformation parameters are migrated as well.