### PR TITLE
Refactor CRS resolution to avoid axis flip

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
@@ -18,11 +18,9 @@ package eu.esdihumboldt.hale.common.instance.geometry.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.geotools.gml2.SrsSyntax;
-import org.geotools.referencing.CRS;
-import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
+import eu.esdihumboldt.hale.common.instance.geometry.CRSDefinitionUtil;
 import eu.esdihumboldt.hale.common.instance.geometry.CRSResolveCache;
 import eu.esdihumboldt.hale.common.schema.geometry.CRSDefinition;
 
@@ -39,22 +37,7 @@ public class EPSGResolveCache implements CRSResolveCache {
 	public CRSDefinition resolveCRS(final CoordinateReferenceSystem crs) {
 		CRSDefinition result = cached.get(crs);
 		if (result == null) {
-			try {
-				Integer epsgCode = CRS.lookupEpsgCode(crs, true);
-				if (epsgCode != null) {
-					String code = SrsSyntax.OGC_URN.getPrefix() + String.valueOf(epsgCode);
-					CoordinateReferenceSystem resolved = CRS.decode(code);
-					result = new CodeDefinition(code, resolved);
-				}
-			} catch (FactoryException e) {
-				// ignore
-			}
-
-			if (result == null) {
-				// prevent further lookups of this CRS
-				result = new WKTDefinition(crs.toWKT(), crs);
-			}
-
+			result = CRSDefinitionUtil.lookupCrs(crs);
 			cached.put(crs, result);
 		}
 


### PR DESCRIPTION
After the changes of #480, there were suddenly occasional axis flip problems when importing shapefiles. This patch improves the CRS lookup so that the axis order of the projection file is passed on to Geotools. Interestingly, Geotools honours the `longitudeFirst` parameter only for codes prefixed with `EPSG:` but not for those prefixed with `urn:ogc:def:crs:EPSG::`.