### PR TITLE
Support multiple organisations in hale connect integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 - Enhanced CRS detection when parsing GML files
 - Added support for multiple organisations to hale connect integration
 
+### Changed
+
+- Support relogin to hale connect without having to clear stored credentials
+
 ### Fixed
 
 - Fixed hale connect login on Welcome Page to work for user names and passwords w/ special characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 
 - When importing a shapefile resource, prefill character set dialog with encoding read from accompanying `.cpg` file
 - Enhanced CRS detection when parsing GML files
+- Added support for multiple organisations to hale connect integration
 
 ### Fixed
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/plugin.xml
@@ -54,14 +54,6 @@
       <handler
             class="eu.esdihumboldt.hale.io.haleconnect.ui.HaleConnectLoginHandler"
             commandId="eu.esdihumboldt.hale.io.haleconnect.ui.login">
-         <activeWhen>
-            <with
-                  variable="eu.esdihumboldt.hale.io.haleconnect.ui.login.status">
-               <equals
-                     value="false">
-               </equals>
-            </with>
-         </activeWhen>
       </handler>
       <handler
             class="eu.esdihumboldt.hale.io.haleconnect.ui.HaleConnectLogoutHandler"

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/HaleConnectLoginHandler.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/HaleConnectLoginHandler.java
@@ -116,7 +116,7 @@ public class HaleConnectLoginHandler extends AbstractHandler {
 		if (hcs.isLoggedIn()) {
 			if (!MessageDialog.openQuestion(parent, "Login to hale connect",
 					MessageFormat.format(
-							"You are currently logged in as \"{0}\". Do you wish to login with different credentials?",
+							"You are currently logged in as \"{0}\". Do you wish to log in again?",
 							hcs.getSession().getUsername()))) {
 				return null;
 			}

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.java
@@ -127,6 +127,15 @@ public class ChooseHaleConnectProjectWizardPage
 						return;
 					}
 
+					if (t instanceof HaleConnectException
+							&& ((HaleConnectException) t).getStatusCode() == 401) {
+						// In case of 401 (Unauthorized) the most likely cause
+						// is that the API token has expired
+						log.userError(
+								"Unable to retrieve projects from hale connect due to missing permissions. Please re-login and try again.");
+						return;
+					}
+
 					String configuredBasePath = haleConnect.getBasePathManager()
 							.getBasePath(HaleConnectServices.PROJECT_STORE);
 					if (configuredBasePath

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectSource.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectSource.java
@@ -319,7 +319,6 @@ public class HaleConnectSource<P extends ImportProvider> extends AbstractProvide
 
 	private void updateLoginStatus() {
 		HaleConnectService hcs = HaleUI.getServiceProvider().getService(HaleConnectService.class);
-		loginButton.setEnabled(!hcs.isLoggedIn());
 		selectProjectButton.setEnabled(hcs.isLoggedIn());
 		if (hcs.isLoggedIn()) {
 			loginStatusLabel

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -22,12 +22,19 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.events.MouseAdapter;
@@ -44,6 +51,11 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.PlatformUI;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
 
 import de.fhg.igd.slf4jplus.ALogger;
 import de.fhg.igd.slf4jplus.ALoggerFactory;
@@ -51,6 +63,8 @@ import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.core.io.project.ProjectInfoService;
 import eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectWriter;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableOutputSupplier;
+import eu.esdihumboldt.hale.io.haleconnect.HaleConnectException;
+import eu.esdihumboldt.hale.io.haleconnect.HaleConnectOrganisationInfo;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectProjectInfo;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectService;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectUrnBuilder;
@@ -81,6 +95,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 	private Composite ownershipGroup;
 	private Button ownerUser;
 	private Button ownerOrg;
+	private ComboViewer orgSelector;
 	private Button includeWebResources;
 	private Button excludeData;
 	private Button excludeCachedResources;
@@ -181,8 +196,8 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 		newProjectControls.setLayoutData(grid);
 
 		ownershipGroup = new Composite(newProjectControls, SWT.NONE);
-		ownershipGroup.setLayout(new GridLayout(3, false));
-		ownershipGroup.setLayoutData(new GridData(SWT.LEAD, SWT.LEAD, false, false, 3, 1));
+		ownershipGroup.setLayout(new GridLayout(4, false));
+		ownershipGroup.setLayoutData(new GridData(SWT.LEAD, SWT.LEAD, false, false, 4, 1));
 
 		Label ownerLabel = new Label(ownershipGroup, SWT.NONE);
 		ownerLabel.setText("Who should own the uploaded project?");
@@ -192,6 +207,48 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 
 		ownerOrg = new Button(ownershipGroup, SWT.RADIO);
 		ownerOrg.setText("Your organisation");
+
+		orgSelector = new ComboViewer(ownershipGroup);
+		GridData orgSelectorGrid = new GridData(SWT.LEAD, SWT.LEAD, false, false);
+		orgSelectorGrid.widthHint = 175;
+		orgSelector.getCombo().setLayoutData(orgSelectorGrid);
+		orgSelector.setContentProvider(new IStructuredContentProvider() {
+
+			@Override
+			public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+				//
+			}
+
+			@Override
+			public void dispose() {
+				//
+			}
+
+			@Override
+			public Object[] getElements(Object inputElement) {
+				if (inputElement instanceof List<?>) {
+					List<?> elements = (List<?>) inputElement;
+					return elements.toArray();
+				}
+				else if (inputElement instanceof Object[]) {
+					return (Object[]) inputElement;
+				}
+
+				return new Object[] {};
+			}
+		});
+		orgSelector.setLabelProvider(new LabelProvider() {
+
+			@Override
+			public String getText(Object element) {
+				if (element instanceof HaleConnectOrganisationInfo) {
+					return ((HaleConnectOrganisationInfo) element).getName();
+				}
+
+				return super.getText(element);
+			}
+
+		});
 
 		enableVersioning = new Button(newProjectControls, SWT.CHECK);
 		enableVersioning.setText("Enable versioning?");
@@ -451,8 +508,85 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 				}
 			}
 
-			ownerOrg.setEnabled(orgAllowed);
-			ownerOrg.setSelection(orgAllowed);
+			ownerOrg.setEnabled(false);
+//			orgSelector.getCombo().setEnabled(false);
+			if (orgAllowed) {
+				final SettableFuture<List<HaleConnectOrganisationInfo>> orgsFuture = SettableFuture
+						.create();
+				Futures.addCallback(orgsFuture,
+						new FutureCallback<List<HaleConnectOrganisationInfo>>() {
+
+							@Override
+							public void onSuccess(List<HaleConnectOrganisationInfo> result) {
+								PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+
+									@Override
+									public void run() {
+										ownerOrg.setEnabled(true);
+										// orgSelector.getCombo().setEnabled(true);
+										orgSelector.setInput(result);
+										if (!result.isEmpty()) {
+											orgSelector.setSelection(
+													new StructuredSelection(result.get(0)));
+										}
+									}
+								});
+							}
+
+							@Override
+							public void onFailure(Throwable t) {
+								log.userError(
+										"A problem occurred while contacting hale connect. Functionality may be limited.",
+										t);
+							}
+						});
+
+				Thread fetchOrgInfoThread = new Thread(new Runnable() {
+
+					@Override
+					public void run() {
+						boolean hadException = false;
+
+						List<HaleConnectOrganisationInfo> organisations = new ArrayList<>();
+						List<HaleConnectException> exceptions = new ArrayList<>();
+						for (String orgId : hcs.getSession().getOrganisationIds()) {
+							try {
+								HaleConnectOrganisationInfo orgInfo = hcs
+										.getOrganisationInfo(orgId);
+								if (orgInfo != null) {
+									organisations.add(orgInfo);
+								}
+							} catch (HaleConnectException e) {
+								hadException = true;
+								log.error("Error fetching organization details from hale connect.",
+										e);
+								exceptions.add(e);
+
+								// As a fallback, display dummy value that
+								// contains the
+								// orgId
+								organisations.add(new HaleConnectOrganisationInfo(orgId,
+										MessageFormat.format("<Organisation {0}>", orgId)));
+							}
+						}
+
+						orgsFuture.set(organisations);
+
+						if (hadException) {
+							PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+
+								@Override
+								public void run() {
+									log.userError(
+											"A problem occurred while contacting hale connect. Functionality may be limited.");
+								}
+							});
+						}
+					}
+				});
+
+				fetchOrgInfoThread.start();
+			}
 
 			boolean userAllowed;
 			try {
@@ -465,7 +599,11 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 				userAllowed = false;
 			}
 			ownerUser.setEnabled(userAllowed);
+
 			ownerUser.setSelection(userAllowed);
+			if (!userAllowed || !orgAllowed) {
+				ownerOrg.setSelection(orgAllowed);
+			}
 
 			if (!userAllowed && !orgAllowed) {
 				loginStatusLabel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
@@ -490,9 +628,6 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 		if (targetProject != null) {
 			projectName.setStringValue(targetProject.getProjectName());
 			updateOverwriteWarning();
-		}
-		else {
-			projectName.setStringValue("");
 		}
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -508,7 +508,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 			}
 
 			ownerOrg.setEnabled(false);
-//			orgSelector.getCombo().setEnabled(false);
+			orgSelector.getCombo().setEnabled(false);
 			if (orgAllowed) {
 				final SettableFuture<List<HaleConnectOrganisationInfo>> orgsFuture = SettableFuture
 						.create();
@@ -522,7 +522,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 									@Override
 									public void run() {
 										ownerOrg.setEnabled(true);
-										// orgSelector.getCombo().setEnabled(true);
+										orgSelector.getCombo().setEnabled(true);
 										orgSelector.setInput(result);
 										if (!result.isEmpty()) {
 											orgSelector.setSelection(

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -473,7 +473,6 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 	private void updateLoginStatus() {
 		HaleConnectService hcs = HaleUI.getServiceProvider().getService(HaleConnectService.class);
 		boolean loggedIn = hcs.isLoggedIn();
-		loginButton.setEnabled(!loggedIn);
 		ownershipGroup.setEnabled(loggedIn);
 		enableVersioning.setEnabled(loggedIn);
 		publicAccess.setEnabled(loggedIn);

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectService.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectService.java
@@ -172,18 +172,28 @@ public interface HaleConnectService {
 	/**
 	 * Get a list of available hale connect transformation projects
 	 * 
+	 * @param contextOrganisation If provided, projects owned by the given
+	 *            organisation will be returned if the currently logged in user
+	 *            has sufficient permissions. If <code>null</code> is passed,
+	 *            projects owned by the current user will be returned.
 	 * @return a list of available projects
 	 * @throws HaleConnectException thrown on any API error
 	 */
-	List<HaleConnectProjectInfo> getProjects() throws HaleConnectException;
+	List<HaleConnectProjectInfo> getProjects(String contextOrganisation)
+			throws HaleConnectException;
 
 	/**
 	 * Get a list of available hale connect transformation projects
 	 *
+	 * @param contextOrganisation If provided, projects owned by the given
+	 *            organisation will be returned if the currently logged in user
+	 *            has sufficient permissions. If <code>null</code> is passed,
+	 *            projects owned by the current user will be returned.
 	 * @return {@link ListenableFuture} of the result
 	 * @throws HaleConnectException thrown on any API error
 	 */
-	ListenableFuture<List<HaleConnectProjectInfo>> getProjectsAsync() throws HaleConnectException;
+	ListenableFuture<List<HaleConnectProjectInfo>> getProjectsAsync(String contextOrganisation)
+			throws HaleConnectException;
 
 	/**
 	 * Load a transformation from hale connect

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.java
@@ -184,7 +184,8 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		this.setTarget(new NoStreamOutputSupplier(projectUrn));
 
 		// save the hale connect project URN in the project properties
-		getProject().getProperties().put(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY, Value.of(projectUrn.toString()));
+		getProject().getProperties().put(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY,
+				Value.of(projectUrn.toString()));
 
 		// redirect project archive to temporary local file
 		File projectArchive = Files.createTempFile("hc-arc", ".zip").toFile();
@@ -232,7 +233,8 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 			HaleConnectProjectInfo hcProjectInfo = haleConnect.getProject(owner, projectId);
 
 			if (hcProjectInfo != null) {
-				getProject().getProperties().put(HaleConnectProjectReader.HALECONNECT_LAST_MODIFIED_PROPERTY,
+				getProject().getProperties().put(
+						HaleConnectProjectReader.HALECONNECT_LAST_MODIFIED_PROPERTY,
 						Value.of(hcProjectInfo.getLastModified()));
 			}
 		} catch (HaleConnectException e) {


### PR DESCRIPTION
Adds a dropdown box to `HaleConnectTarget` to allow specifying the owner organisation. This prevents unexpected results in case a user has roles in multiple organisations.

In addition, support for logging in again with different credentials is added without forcing the user to clear stored credentials. Previously, in cases where the JWT expires while hale studio is running there was no way to relogin without clearing stored credentials or restarting hale studio.