### PR TITLE
allow null startTime when comparing reports

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportList.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.views.report/src/eu/esdihumboldt/hale/ui/views/report/ReportList.java
@@ -191,7 +191,16 @@ public class ReportList extends PropertiesViewPart
 				else if (e1 instanceof Report<?> && e2 instanceof Report<?>) {
 					Report<?> first = (Report<?>) e1;
 					Report<?> second = (Report<?>) e2;
-					if (first.getStartTime().getTime() > second.getStartTime().getTime()) {
+					if (first.getStartTime() == null && second.getStartTime() == null) {
+						return 0;
+					}
+					else if (first.getStartTime() == null) {
+						return 1;
+					}
+					else if (second.getStartTime() == null) {
+						return -1;
+					}
+					else if (first.getStartTime().getTime() > second.getStartTime().getTime()) {
 						return -1;
 					}
 					else if (first.getStartTime().getTime() < second.getStartTime().getTime()) {


### PR DESCRIPTION
Even as with the correct usage of the hale API there shouldn't be reports w/o start time, handling the null case seems to be done in a lot of other places. Thus I added it here as well. Maybe we can use that to identify which I/O provider does not call the `success` method on the report.