### PR TITLE
Prompt user for CRS when projection file does not contain EPSG code

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSResolveCache.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSResolveCache.java
@@ -39,4 +39,13 @@ public interface CRSResolveCache {
 	@Nullable
 	CRSDefinition resolveCRS(CoordinateReferenceSystem crs);
 
+	/**
+	 * Corrects the cached {@link CRSDefinition} for the given
+	 * {@link CoordinateReferenceSystem}
+	 * 
+	 * @param crs the CRS
+	 * @param crsDef the CRS definition or <code>null</code> to remove the
+	 *            cached definition
+	 */
+	void reviseCache(CoordinateReferenceSystem crs, CRSDefinition crsDef);
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/impl/EPSGResolveCache.java
@@ -44,4 +44,18 @@ public class EPSGResolveCache implements CRSResolveCache {
 		return result;
 	}
 
+	@Override
+	public void reviseCache(CoordinateReferenceSystem crs, CRSDefinition crsDef) {
+		if (crs == null) {
+			return;
+		}
+
+		if (crsDef == null) {
+			cached.remove(crs);
+		}
+		else {
+			cached.put(crs, crsDef);
+		}
+	}
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
@@ -42,7 +42,6 @@ import eu.esdihumboldt.hale.common.instance.geometry.CRSProvider;
 import eu.esdihumboldt.hale.common.instance.geometry.CRSResolveCache;
 import eu.esdihumboldt.hale.common.instance.geometry.DefaultGeometryProperty;
 import eu.esdihumboldt.hale.common.instance.geometry.impl.EPSGResolveCache;
-import eu.esdihumboldt.hale.common.instance.geometry.impl.WKTDefinition;
 import eu.esdihumboldt.hale.common.instance.model.Filter;
 import eu.esdihumboldt.hale.common.instance.model.Instance;
 import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
@@ -162,8 +161,7 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 					if (crs != null) {
 						crsDef = CRSDefinitionUtil.createDefinition(crs, crsCache);
 
-						if (crsDef instanceof WKTDefinition
-								&& crsDef.getCRS().getIdentifiers().isEmpty()) {
+						if (crs.getIdentifiers().isEmpty()) {
 							// Force CRS dialog prompt if the WKT definition
 							// does not contain an EPSG code for the CRS. This
 							// is to prevent that a CRS definition without
@@ -172,8 +170,12 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 							// code, the user can still provide the WKT
 							// definition in the dialog. In case of a headless
 							// transformation, the WKT definition will be used.
+
 							crsDef = crsProvider.getCRS(type,
 									Collections.singletonList(propertyName), crsDef);
+							// Update the cache with the definition of the
+							// CRSProvider
+							crsCache.reviseCache(crs, crsDef);
 						}
 					}
 					else {


### PR DESCRIPTION
There are cases where CRS detection by Geotools is ambiguous when there is no `AUTHORITY` code in the WKT definition of the projection file. To prevent Geotools from silently selecting the wrong CRS, prompt the user in these cases.