### PR TITLE
Don't overwrite target of save config when loading from hale connect

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectReader.java
@@ -74,8 +74,16 @@ public class HaleConnectProjectReader extends ArchiveProjectReader {
 			saveConfig.setProviderId(HaleConnectProjectWriter.ID);
 			saveConfig.getProviderConfiguration().put(ExportProvider.PARAM_CONTENT_TYPE,
 					Value.of(HaleConnectProjectWriter.HALECONNECT_CONTENT_TYPE_ID));
-			saveConfig.getProviderConfiguration().put(ExportProvider.PARAM_TARGET,
-					Value.of(source.getLocation()));
+
+			/*
+			 * Don't overwrite the target of the save configuration which is, at
+			 * this point, set to the temporary location of the extracted
+			 * project archive. The reason for this is to make sure that
+			 * PathUpdate can correctly resolve all relative resource paths.
+			 * (https://github.com/halestudio/hale/issues/506)
+			 */
+//			saveConfig.getProviderConfiguration().put(ExportProvider.PARAM_TARGET,
+//					Value.of(source.getLocation()));
 
 			getProject().setSaveConfiguration(saveConfig);
 		}


### PR DESCRIPTION
This allows `PathUpdate` to correctly resolve relative resource paths (#506).