### PR TITLE
Cell Replace: Preserve annotations and pass existing function parameters to wizard

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/BaseAlignmentCell.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/BaseAlignmentCell.java
@@ -207,6 +207,13 @@ public class BaseAlignmentCell implements ModifiableCell {
 				"Cannot add annotation to a cell of a base alignment.");
 	}
 
+	@Override
+	public void addAnnotation(String type, Object annotation) {
+		// TODO allow adding annotations?
+		throw new UnsupportedOperationException(
+				"Cannot add annotation to a cell of a base alignment.");
+	}
+
 	/**
 	 * @see eu.esdihumboldt.hale.common.align.model.Cell#removeAnnotation(java.lang.String,
 	 *      java.lang.Object)

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/Cell.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/Cell.java
@@ -111,6 +111,15 @@ public interface Cell {
 	public Object addAnnotation(String type);
 
 	/**
+	 * Add an existing annotation object.
+	 * 
+	 * @param type the annotation type identifier as registered in the
+	 *            corresponding extension point
+	 * @param annotation annotation object to add
+	 */
+	void addAnnotation(String type, Object annotation);
+
+	/**
 	 * Remove the given annotation object.
 	 * 
 	 * @param type the annotation type identifier as registered in the

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/DefaultCell.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/DefaultCell.java
@@ -157,16 +157,6 @@ public class DefaultCell implements Cell, MutableCell {
 		return Multimaps.unmodifiableListMultimap(parameters);
 	}
 
-	/**
-	 * Add an annotation object.
-	 * 
-	 * @param type the annotation type
-	 * @param annotation the annotation object
-	 */
-	public void addAnnotation(String type, Object annotation) {
-		annotations.put(type, annotation);
-	}
-
 	@Override
 	public List<?> getAnnotations(String type) {
 		return Collections.unmodifiableList(annotations.get(type));
@@ -182,6 +172,27 @@ public class DefaultCell implements Cell, MutableCell {
 			return annotation;
 		}
 		return null;
+	}
+
+	/**
+	 * Add an annotation object.
+	 * 
+	 * @param type the annotation type
+	 * @param annotation the annotation object
+	 */
+	@Override
+	public void addAnnotation(String type, Object annotation) {
+		AnnotationDescriptor<?> descriptor = AnnotationExtension.getInstance().get(type);
+		if (descriptor == null) {
+			throw new IllegalArgumentException("Invalid annotation type");
+		}
+
+		if (!descriptor.create().getClass().equals(annotation.getClass())) {
+			throw new IllegalArgumentException(
+					"Provided annotation object does not match annotation type");
+		}
+
+		annotations.put(type, annotation);
 	}
 
 	@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/MutableCellDecorator.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/model/impl/MutableCellDecorator.java
@@ -115,6 +115,11 @@ public class MutableCellDecorator implements MutableCell {
 	}
 
 	@Override
+	public void addAnnotation(String type, Object annotation) {
+		decoratee.addAnnotation(type, annotation);
+	}
+
+	@Override
 	public void removeAnnotation(String type, Object annotation) {
 		decoratee.removeAnnotation(type, annotation);
 	}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/AbstractFunctionWizard.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/AbstractFunctionWizard.java
@@ -18,7 +18,10 @@ package eu.esdihumboldt.hale.ui.function;
 
 import org.eclipse.jface.wizard.Wizard;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
 
 /**
@@ -29,8 +32,8 @@ import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
 public abstract class AbstractFunctionWizard extends Wizard implements FunctionWizard {
 
 	private final Cell initCell;
-
 	private final SchemaSelection initSelection;
+	private final ListMultimap<String, ParameterValue> initParameters;
 
 	/**
 	 * Create a function wizard based on an existing cell
@@ -42,6 +45,7 @@ public abstract class AbstractFunctionWizard extends Wizard implements FunctionW
 
 		this.initCell = cell;
 		this.initSelection = null;
+		this.initParameters = null;
 	}
 
 	/**
@@ -50,10 +54,22 @@ public abstract class AbstractFunctionWizard extends Wizard implements FunctionW
 	 * @param selection the schema selection, may be <code>null</code>
 	 */
 	public AbstractFunctionWizard(SchemaSelection selection) {
+		this(selection, null);
+	}
+
+	/**
+	 * Create a function wizard based on a schema selection
+	 * 
+	 * @param selection the schema selection, may be <code>null</code>
+	 * @param parameters the initial function parameters
+	 */
+	public AbstractFunctionWizard(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters) {
 		super();
 
 		this.initCell = null;
 		this.initSelection = selection;
+		this.initParameters = parameters;
 	}
 
 	/**
@@ -66,8 +82,11 @@ public abstract class AbstractFunctionWizard extends Wizard implements FunctionW
 		if (initCell != null) {
 			init(initCell);
 		}
-		else {
+		else if (initParameters == null) {
 			init(initSelection);
+		}
+		else {
+			init(initSelection, initParameters);
 		}
 	}
 
@@ -86,11 +105,30 @@ public abstract class AbstractFunctionWizard extends Wizard implements FunctionW
 	}
 
 	/**
+	 * @return the initial parameters
+	 */
+	public ListMultimap<String, ParameterValue> getInitParameters() {
+		return initParameters;
+	}
+
+	/**
 	 * Initialize the wizard based on a schema selection.
 	 * 
 	 * @param selection the schema selection, may be <code>null</code>
 	 */
 	protected void init(SchemaSelection selection) {
+		// override me
+	}
+
+	/**
+	 * Initialize the wizard based on a schema selection and prefill the
+	 * function parameters.
+	 * 
+	 * @param selection the schema selection, may be <code>null</code>
+	 * @param parameters the function parameters to prefill
+	 */
+	protected void init(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters) {
 		// override me
 	}
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
@@ -64,8 +64,12 @@ public class ReplaceFunctionWizardAction
 	 */
 	@Override
 	protected void handleResult(MutableCell cell) {
-		// remove the original cell
-		// and add the new cell
+		// Copy annotations to new Cell
+		for (String annotationType : originalCell.getAnnotationTypes()) {
+			originalCell.getAnnotations(annotationType).stream()
+					.forEach(a -> cell.addAnnotation(annotationType, a));
+		}
+
 		alignmentService.replaceCell(originalCell, cell);
 	}
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
@@ -64,11 +64,15 @@ public class ReplaceFunctionWizardAction
 	 */
 	@Override
 	protected void handleResult(MutableCell cell) {
-		// Copy annotations to new Cell
+		// Copy properties to new Cell
 		for (String annotationType : originalCell.getAnnotationTypes()) {
 			originalCell.getAnnotations(annotationType).stream()
 					.forEach(a -> cell.addAnnotation(annotationType, a));
 		}
+		cell.getDocumentation().putAll(originalCell.getDocumentation());
+		cell.setPriority(originalCell.getPriority());
+		cell.setTransformationMode(originalCell.getTransformationMode());
+		originalCell.getDisabledFor().stream().forEach(c -> cell.setDisabledFor(c, true));
 
 		alignmentService.replaceCell(originalCell, cell);
 	}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/contribution/internal/ReplaceFunctionWizardAction.java
@@ -29,8 +29,8 @@ import eu.esdihumboldt.hale.ui.service.align.AlignmentService;
  * 
  * @author Simon Templer
  */
-public class ReplaceFunctionWizardAction extends
-		AbstractWizardAction<SchemaSelectionFunctionContribution> {
+public class ReplaceFunctionWizardAction
+		extends AbstractWizardAction<SchemaSelectionFunctionContribution> {
 
 	private final Cell originalCell;
 
@@ -55,7 +55,8 @@ public class ReplaceFunctionWizardAction extends
 	 */
 	@Override
 	protected FunctionWizard createWizard() {
-		return descriptor.createNewWizard(functionContribution.getSelection());
+		return descriptor.createNewWizard(functionContribution.getSelection(),
+				originalCell.getTransformationParameters());
 	}
 
 	/**

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/FunctionWizardFactory.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/FunctionWizardFactory.java
@@ -15,7 +15,10 @@
  */
 package eu.esdihumboldt.hale.ui.function.extension;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.function.FunctionWizard;
 import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
 
@@ -36,6 +39,18 @@ public interface FunctionWizardFactory {
 	 * @return the new wizard instance
 	 */
 	public FunctionWizard createNewWizard(SchemaSelection schemaSelection);
+
+	/**
+	 * Creates a wizard for creating a new cell based on the given schema
+	 * selection.
+	 * 
+	 * @param schemaSelection the schema selection or <code>null</code> if no
+	 *            pre-selection is available
+	 * @param parameters initial function parameters
+	 * @return the new wizard instance
+	 */
+	public FunctionWizard createNewWizard(SchemaSelection schemaSelection,
+			ListMultimap<String, ParameterValue> parameters);
 
 	/**
 	 * Creates a wizard for editing an existing cell.

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/impl/AbstractFunctionWizardDescriptor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/impl/AbstractFunctionWizardDescriptor.java
@@ -20,12 +20,15 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 
+import com.google.common.collect.ListMultimap;
+
 import de.fhg.igd.eclipse.util.extension.AbstractConfigurationFactory;
 import de.fhg.igd.eclipse.util.extension.AbstractObjectFactory;
 import de.fhg.igd.eclipse.util.extension.ExtensionObjectDefinition;
 import de.fhg.igd.eclipse.util.extension.ExtensionObjectFactory;
 import eu.esdihumboldt.hale.common.align.extension.function.FunctionDefinition;
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.function.FunctionWizard;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardDescriptor;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory;
@@ -139,6 +142,15 @@ public abstract class AbstractFunctionWizardDescriptor<T extends FunctionDefinit
 	@Override
 	public FunctionWizard createNewWizard(SchemaSelection schemaSelection) {
 		return getFactory().createNewWizard(schemaSelection);
+	}
+
+	/**
+	 * @see FunctionWizardFactory#createNewWizard(SchemaSelection, ListMultimap)
+	 */
+	@Override
+	public FunctionWizard createNewWizard(SchemaSelection schemaSelection,
+			ListMultimap<String, ParameterValue> parameters) {
+		return getFactory().createNewWizard(schemaSelection, parameters);
 	}
 
 	/**

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/impl/FactoryWizardDescriptor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/extension/impl/FactoryWizardDescriptor.java
@@ -18,9 +18,12 @@ package eu.esdihumboldt.hale.ui.function.extension.impl;
 
 import java.net.URL;
 
+import com.google.common.collect.ListMultimap;
+
 import de.fhg.igd.eclipse.util.extension.AbstractObjectFactory;
 import eu.esdihumboldt.hale.common.align.extension.function.FunctionDefinition;
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.function.FunctionWizard;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardDescriptor;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory;
@@ -84,6 +87,12 @@ public class FactoryWizardDescriptor<T extends FunctionDefinition<?>> extends
 	}
 
 	@Override
+	public FunctionWizard createNewWizard(SchemaSelection schemaSelection,
+			ListMultimap<String, ParameterValue> parameters) {
+		return factory.createNewWizard(schemaSelection, parameters);
+	}
+
+	@Override
 	public FunctionWizard createEditWizard(Cell cell) {
 		return factory.createEditWizard(cell);
 	}
@@ -102,5 +111,4 @@ public class FactoryWizardDescriptor<T extends FunctionDefinition<?>> extends
 	public URL getIconURL() {
 		return function.getIconURL();
 	}
-
 }

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/AbstractGenericFunctionWizard.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/AbstractGenericFunctionWizard.java
@@ -96,6 +96,22 @@ public abstract class AbstractGenericFunctionWizard<P extends ParameterDefinitio
 	}
 
 	/**
+	 * Create a generic function wizard for a certain function based on a schema
+	 * selection
+	 * 
+	 * @param selection the schema selection, may be <code>null</code>
+	 * @param parameters initial function parameters
+	 * @param functionId the function identifier
+	 */
+	public AbstractGenericFunctionWizard(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters, String functionId) {
+		super(selection, parameters);
+
+		setHelpAvailable(true);
+		this.functionId = functionId;
+	}
+
+	/**
 	 * @see AbstractFunctionWizard#AbstractFunctionWizard(Cell)
 	 */
 	public AbstractGenericFunctionWizard(Cell cell) {
@@ -121,8 +137,14 @@ public abstract class AbstractGenericFunctionWizard<P extends ParameterDefinitio
 		entitiesPage = createEntitiesPage(getInitSelection(), getInitCell());
 
 		// create parameter pages
-		if (!getFunction().getDefinedParameters().isEmpty())
-			parameterPages = createParameterPages(getInitCell());
+		if (!getFunction().getDefinedParameters().isEmpty()) {
+			if (getInitCell() != null) {
+				parameterPages = createParameterPages(getInitCell());
+			}
+			else {
+				parameterPages = createParameterPages(getInitParameters());
+			}
+		}
 	}
 
 	/**
@@ -133,6 +155,14 @@ public abstract class AbstractGenericFunctionWizard<P extends ParameterDefinitio
 		// create a new cell
 		resultCell = new DefaultCell();
 		resultCell.setTransformationIdentifier(getFunctionId());
+	}
+
+	@Override
+	protected void init(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters) {
+		init(selection);
+
+		resultCell.setTransformationParameters(parameters);
 	}
 
 	/**
@@ -162,21 +192,15 @@ public abstract class AbstractGenericFunctionWizard<P extends ParameterDefinitio
 	protected abstract EntitiesPage<T, P, ?> createEntitiesPage(SchemaSelection initSelection,
 			Cell initCell);
 
-	/**
-	 * Create the page for configuring the function parameters.
-	 * 
-	 * @param initialCell the initial cell, may be <code>null</code>
-	 * @return the parameter configuration page or <code>null</code>
-	 */
-	protected List<ParameterPage> createParameterPages(Cell initialCell) {
+	protected List<ParameterPage> createParameterPages(
+			ListMultimap<String, ParameterValue> initialValues) {
 		LinkedList<ParameterPage> parameterPages = new LinkedList<ParameterPage>();
+
 		// create copy of function parameter set
 		Set<FunctionParameterDefinition> functionParameters = new LinkedHashSet<>();
 		for (FunctionParameterDefinition param : getFunction().getDefinedParameters())
 			functionParameters.add(param);
-		// get initial values
-		ListMultimap<String, ParameterValue> initialValues = initialCell == null ? null
-				: initialCell.getTransformationParameters();
+
 		if (initialValues != null)
 			initialValues = Multimaps.unmodifiableListMultimap(initialValues);
 		// get available parameter pages
@@ -223,6 +247,20 @@ public abstract class AbstractGenericFunctionWizard<P extends ParameterDefinitio
 		}
 
 		return parameterPages;
+	}
+
+	/**
+	 * Create the page for configuring the function parameters.
+	 * 
+	 * @param initialCell the initial cell, may be <code>null</code>
+	 * @return the parameter configuration page or <code>null</code>
+	 */
+	protected List<ParameterPage> createParameterPages(Cell initialCell) {
+		// get initial values
+		ListMultimap<String, ParameterValue> initialValues = (initialCell == null) ? null
+				: initialCell.getTransformationParameters();
+
+		return createParameterPages(initialValues);
 	}
 
 	@Override

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericPropertyFunctionWizard.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericPropertyFunctionWizard.java
@@ -16,10 +16,13 @@
 
 package eu.esdihumboldt.hale.ui.function.generic;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.extension.function.FunctionUtil;
 import eu.esdihumboldt.hale.common.align.extension.function.PropertyFunctionDefinition;
 import eu.esdihumboldt.hale.common.align.extension.function.PropertyParameterDefinition;
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.HaleUI;
 import eu.esdihumboldt.hale.ui.function.generic.pages.EntitiesPage;
 import eu.esdihumboldt.hale.ui.function.generic.pages.PropertyEntitiesPage;
@@ -46,6 +49,15 @@ public class GenericPropertyFunctionWizard extends
 	 */
 	public GenericPropertyFunctionWizard(SchemaSelection selection, String functionId) {
 		super(selection, functionId);
+	}
+
+	/**
+	 * @see AbstractGenericFunctionWizard#AbstractGenericFunctionWizard(SchemaSelection,
+	 *      ListMultimap, String)
+	 */
+	public GenericPropertyFunctionWizard(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters, String functionId) {
+		super(selection, parameters, functionId);
 	}
 
 	/**

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericPropertyFunctionWizardFactory.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericPropertyFunctionWizardFactory.java
@@ -16,7 +16,10 @@
 
 package eu.esdihumboldt.hale.ui.function.generic;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.function.FunctionWizard;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory;
 import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
@@ -41,6 +44,16 @@ public class GenericPropertyFunctionWizardFactory extends AbstractGenericFunctio
 	@Override
 	public FunctionWizard createNewWizard(SchemaSelection schemaSelection) {
 		return new GenericPropertyFunctionWizard(schemaSelection, getFunctionId());
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory#createNewWizard(eu.esdihumboldt.hale.ui.selection.SchemaSelection,
+	 *      com.google.common.collect.ListMultimap)
+	 */
+	@Override
+	public FunctionWizard createNewWizard(SchemaSelection schemaSelection,
+			ListMultimap<String, ParameterValue> parameters) {
+		return new GenericPropertyFunctionWizard(schemaSelection, parameters, getFunctionId());
 	}
 
 	/**

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericTypeFunctionWizard.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericTypeFunctionWizard.java
@@ -16,10 +16,13 @@
 
 package eu.esdihumboldt.hale.ui.function.generic;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.extension.function.FunctionUtil;
 import eu.esdihumboldt.hale.common.align.extension.function.TypeFunctionDefinition;
 import eu.esdihumboldt.hale.common.align.extension.function.TypeParameterDefinition;
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.HaleUI;
 import eu.esdihumboldt.hale.ui.function.generic.pages.EntitiesPage;
 import eu.esdihumboldt.hale.ui.function.generic.pages.TypeEntitiesPage;
@@ -30,8 +33,8 @@ import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
  * 
  * @author Simon Templer
  */
-public class GenericTypeFunctionWizard extends
-		AbstractGenericFunctionWizard<TypeParameterDefinition, TypeFunctionDefinition> {
+public class GenericTypeFunctionWizard
+		extends AbstractGenericFunctionWizard<TypeParameterDefinition, TypeFunctionDefinition> {
 
 	/**
 	 * @see AbstractGenericFunctionWizard#AbstractGenericFunctionWizard(Cell)
@@ -46,6 +49,15 @@ public class GenericTypeFunctionWizard extends
 	 */
 	public GenericTypeFunctionWizard(SchemaSelection selection, String functionId) {
 		super(selection, functionId);
+	}
+
+	/**
+	 * @see AbstractGenericFunctionWizard#AbstractGenericFunctionWizard(
+	 *      SchemaSelection, ListMultimap, String)
+	 */
+	public GenericTypeFunctionWizard(SchemaSelection selection,
+			ListMultimap<String, ParameterValue> parameters, String functionId) {
+		super(selection, parameters, functionId);
 	}
 
 	/**

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericTypeFunctionWizardFactory.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/function/generic/GenericTypeFunctionWizardFactory.java
@@ -16,7 +16,10 @@
 
 package eu.esdihumboldt.hale.ui.function.generic;
 
+import com.google.common.collect.ListMultimap;
+
 import eu.esdihumboldt.hale.common.align.model.Cell;
+import eu.esdihumboldt.hale.common.align.model.ParameterValue;
 import eu.esdihumboldt.hale.ui.function.FunctionWizard;
 import eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory;
 import eu.esdihumboldt.hale.ui.selection.SchemaSelection;
@@ -44,6 +47,16 @@ public class GenericTypeFunctionWizardFactory extends AbstractGenericFunctionWiz
 	}
 
 	/**
+	 * @see eu.esdihumboldt.hale.ui.function.extension.FunctionWizardFactory#createNewWizard(eu.esdihumboldt.hale.ui.selection.SchemaSelection,
+	 *      com.google.common.collect.ListMultimap)
+	 */
+	@Override
+	public FunctionWizard createNewWizard(SchemaSelection schemaSelection,
+			ListMultimap<String, ParameterValue> parameters) {
+		return new GenericTypeFunctionWizard(schemaSelection, parameters, getFunctionId());
+	}
+
+	/**
 	 * @see FunctionWizardFactory#createEditWizard(Cell)
 	 */
 	@Override
@@ -51,5 +64,4 @@ public class GenericTypeFunctionWizardFactory extends AbstractGenericFunctionWiz
 		assert getFunctionId().equals(cell.getTransformationIdentifier());
 		return new GenericTypeFunctionWizard(cell);
 	}
-
 }


### PR DESCRIPTION
When replacing a `Cell`, copy all annotations of the old `Cell` to the new one. Additionally, pass all existing function parameters of the old `Cell` to the function wizard. All parameters from the old function that are also supported by the new function will the be pre-filled in the wizard.