### PR TITLE
[Do not merge] Use Groovy 2.4

### DIFF
--- a/build/build.gradle
+++ b/build/build.gradle
@@ -119,10 +119,6 @@ ext {
 	excludeBundles = [
 	  // dependencies for this feature currently not included in platform
     //'eu.esdihumboldt.hale.ui.feature.liveeditor'
-		// FIXME Groovy compiler error that suddenly appeared (local build), unclear cause
-		// FIXME results in tests not being automatically run
-		//'eu.esdihumboldt.hale.common.align.merge.test',
-		//'eu.esdihumboldt.hale.adv.merge.test'
 	]
 
 	// bundles or fragments that are required additionally for compilation

--- a/build/build.gradle
+++ b/build/build.gradle
@@ -121,8 +121,8 @@ ext {
     //'eu.esdihumboldt.hale.ui.feature.liveeditor'
 		// FIXME Groovy compiler error that suddenly appeared (local build), unclear cause
 		// FIXME results in tests not being automatically run
-		'eu.esdihumboldt.hale.common.align.merge.test',
-		'eu.esdihumboldt.hale.adv.merge.test'
+		//'eu.esdihumboldt.hale.common.align.merge.test',
+		//'eu.esdihumboldt.hale.adv.merge.test'
 	]
 
 	// bundles or fragments that are required additionally for compilation

--- a/build/templates/pom-parent.xml
+++ b/build/templates/pom-parent.xml
@@ -10,12 +10,24 @@
   <packaging>pom</packaging>
   <name>HALE RCP Parent</name>
   
-  <!-- pluginRepositories>
-    <pluginRepository>
+  <pluginRepositories>
+    <!-- pluginRepository>
       <id>artifactory</id>
       <url>http://www.cityserver3d.de:8082/artifactory/repo</url>
+    </pluginRepository -->
+    <!-- see https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#how-to-use-the-compiler-plugin---setting-up-the-pom -->
+    <pluginRepository>
+      <id>bintray</id>
+      <name>Groovy Bintray</name>
+      <url>https://dl.bintray.com/groovy/maven</url>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </pluginRepository>
-  </pluginRepositories -->
+  </pluginRepositories>
   
   <!-- repositories>
     <repository>

--- a/build/templates/pom-parent.xml
+++ b/build/templates/pom-parent.xml
@@ -15,7 +15,7 @@
       <id>artifactory</id>
       <url>http://www.cityserver3d.de:8082/artifactory/repo</url>
     </pluginRepository -->
-    <!-- see https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#how-to-use-the-compiler-plugin---setting-up-the-pom -->
+    <!-- see https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin -->
     <pluginRepository>
       <id>bintray</id>
       <name>Groovy Bintray</name>

--- a/build/templates/pom-plugin.xml
+++ b/build/templates/pom-plugin.xml
@@ -118,12 +118,12 @@
             <dependency>
 	        	<groupId>org.codehaus.groovy</groupId>
 	        	<artifactId>groovy-eclipse-compiler</artifactId>
-	        	<version>2.9.1-01</version>
+	        	<version>2.9.2-04</version>
 	        </dependency>
 	        <dependency>
 	        	<groupId>org.codehaus.groovy</groupId>
 	        	<artifactId>groovy-eclipse-batch</artifactId>
-	        	<version>2.3.7-01</version>
+	        	<version>2.4.13-02</version>
 	        	<!-- OLD REMARK FOR GROOVY 2.1
 	        	For some reasons with the most up-to-date version
 	        	the compiled Groovy is not consistent with the

--- a/common/plugins/eu.esdihumboldt.hale.common.align.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.align.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/DefaultSchemaMigration.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/DefaultSchemaMigration.groovy
@@ -60,7 +60,7 @@ class DefaultSchemaMigration implements AlignmentMigration {
 
 		if (entity.propertyPath.empty) {
 			// type entity definition - yield
-			return Optional.of(typeEntity)
+			return Optional.<EntityDefinition>of(typeEntity)
 		}
 		else {
 			// property entity definition -> follow the path

--- a/common/plugins/eu.esdihumboldt.hale.common.align.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.align.tgraph.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.tgraph.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.align.tgraph/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.tgraph/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.align/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.core.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.core.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.core/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.instance.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.lookup/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.lookup/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.groovy/src/eu/esdihumboldt/hale/common/schema/groovy/constraints/CardinalityFactory.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.groovy/src/eu/esdihumboldt/hale/common/schema/groovy/constraints/CardinalityFactory.groovy
@@ -50,7 +50,7 @@ class CardinalityFactory extends OptionalContextConstraintFactory<Cardinality> {
 		}
 		else if (arg instanceof Number) {
 			// defined with a single number
-			return Cardinality.get(arg, arg)
+			return Cardinality.get(arg.longValue(), arg.longValue())
 		}
 		else {
 			// defined as something else

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/common/plugins/eu.esdihumboldt.hale.common.test/Tests.product
+++ b/common/plugins/eu.esdihumboldt.hale.common.test/Tests.product
@@ -101,6 +101,7 @@
       <plugin id="eu.esdihumboldt.cst.functions.numeric"/>
       <plugin id="eu.esdihumboldt.cst.functions.string"/>
       <plugin id="eu.esdihumboldt.cst.test"/>
+      <plugin id="eu.esdihumboldt.hale.adv.merge.test"/>
       <plugin id="eu.esdihumboldt.hale.app.transform"/>
       <plugin id="eu.esdihumboldt.hale.app.transform.test"/>
       <plugin id="eu.esdihumboldt.hale.common.align"/>
@@ -108,6 +109,7 @@
       <plugin id="eu.esdihumboldt.hale.common.align.groovy.test"/>
       <plugin id="eu.esdihumboldt.hale.common.align.io.model.jaxb"/>
       <plugin id="eu.esdihumboldt.hale.common.align.merge"/>
+      <plugin id="eu.esdihumboldt.hale.common.align.merge.test"/>
       <plugin id="eu.esdihumboldt.hale.common.align.test"/>
       <plugin id="eu.esdihumboldt.hale.common.align.tgraph"/>
       <plugin id="eu.esdihumboldt.hale.common.align.tgraph.test"/>
@@ -220,7 +222,7 @@
       <plugin id="eu.esdihumboldt.util.groovy.meta.fragment" fragment="true"/>
       <plugin id="eu.esdihumboldt.util.groovy.sandbox"/>
       <plugin id="eu.esdihumboldt.util.groovy.sandbox.test"/>
-      <plugin id="eu.esdihumboldt.util.groovy.test" fragment="true"/>
+      <plugin id="eu.esdihumboldt.util.groovy.test"/>
       <plugin id="eu.esdihumboldt.util.http"/>
       <plugin id="eu.esdihumboldt.util.orient.embedded.test"/>
       <plugin id="eu.esdihumboldt.util.resource"/>

--- a/cst/plugins/eu.esdihumboldt.cst.functions.collector/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.collector/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/GeometryHelperFunctions.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/GeometryHelperFunctions.groovy
@@ -421,7 +421,7 @@ class GeometryHelperFunctions {
 	static Collection<GeometryProperty<? extends Geometry>> _splitMulti(def geometryHolders) {
 		List<GeometryProperty<? extends Geometry>> all = _findAll(geometryHolders)
 
-		return all.collectMany { prop ->
+		return (Collection<GeometryProperty<? extends Geometry>>) all.collectMany { prop ->
 			Geometry geom = prop.getGeometry()
 			if (geom.getNumGeometries() > 1) {
 				Deque<Geometry> multis = new ArrayDeque<>()

--- a/cst/plugins/eu.esdihumboldt.cst.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/cst/plugins/eu.esdihumboldt.cst.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ext/ageobw/eu.esdihumboldt.hale.app.bgis.ade/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ext/ageobw/eu.esdihumboldt.hale.app.bgis.ade/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ext/ageobw/eu.esdihumboldt.hale.ui.util.bbr/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ext/ageobw/eu.esdihumboldt.hale.ui.util.bbr/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ext/xslt/eu.esdihumboldt.hale.io.xslt.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ext/xslt/eu.esdihumboldt.hale.io.xslt.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ext/xslt/eu.esdihumboldt.hale.io.xslt/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ext/xslt/eu.esdihumboldt.hale.io.xslt/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/io/plugins/eu.esdihumboldt.hale.io.html.svg.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/io/plugins/eu.esdihumboldt.hale.io.html.svg.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/io/plugins/eu.esdihumboldt.hale.io.html.svg/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/io/plugins/eu.esdihumboldt.hale.io.html.svg/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/platform/hale-platform.target
+++ b/platform/hale-platform.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eu.esdihumboldt.hale.platform" sequenceNumber="309">
+<?pde version="3.8"?><target name="eu.esdihumboldt.hale.platform" sequenceNumber="310">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 <unit id="de.fhg.igd.eclipse.ui.util.feature.feature.group" version="1.0.0.201407081822"/>
@@ -39,8 +39,8 @@
 <repository location="http://build-artifacts.wetransform.to/p2/equinox-test/build_3"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-<unit id="eu.esdihumboldt.hale.platform.feature.group" version="3.3.0.i20170529"/>
-<repository location="https://gitlab.wetransform.to/hale/hale-build-support/raw/c80253ce6e419aec7b80e29ed52ccf4df97d787d/updatesites/platform"/>
+<unit id="eu.esdihumboldt.hale.platform.feature.group" version="3.3.0.i201803131622"/>
+<repository location="https://gitlab.wetransform.to/hale/hale-build-support/raw/0bc7636a07579250d9c7150aee60127fc7d8b679/updatesites/platform"/>
 </location>
 </locations>
 </target>

--- a/server/plugins/eu.esdihumboldt.hale.server.api.base/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/server/plugins/eu.esdihumboldt.hale.server.api.base/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/server/plugins/eu.esdihumboldt.hale.server.api.war/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/server/plugins/eu.esdihumboldt.hale.server.api.war/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/server/plugins/eu.esdihumboldt.hale.server.model/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/server/plugins/eu.esdihumboldt.hale.server.model/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/server/plugins/eu.esdihumboldt.hale.server.templates.war/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/server/plugins/eu.esdihumboldt.hale.server.templates.war/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/server/plugins/eu.esdihumboldt.hale.server.templates/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/server/plugins/eu.esdihumboldt.hale.server.templates/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.codelist.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.codelist.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.codelist/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.codelist/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.core/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.core/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.templates/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.templates/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/ui/plugins/eu.esdihumboldt.hale.ui/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/util/plugins/eu.esdihumboldt.util.blueprints.entities.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/util/plugins/eu.esdihumboldt.util.blueprints.entities.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/util/plugins/eu.esdihumboldt.util.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/util/plugins/eu.esdihumboldt.util.groovy.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/util/plugins/eu.esdihumboldt.util.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/util/plugins/eu.esdihumboldt.util.groovy/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24


### PR DESCRIPTION
Solved the compilation problems with the Alignment Merger tests for me. Let's see what the test run says on possible other implications. I think it is quite a risky change to merge into the current snapshot and I would prefer to do it on a new snapshot.

One other thing: The Groovy Eclipse compiler seems to support invoke dynamic now, so we could try if we can use that.