### PR TITLE
Allow to ignore the total number of features reported by a WFS

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlReaderSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlReaderSettingsPage.java
@@ -136,7 +136,7 @@ public class GmlReaderSettingsPage
 		featuresPerRequest.setSelection(1000);
 
 		ignoreNumberMatched = new Button(wfsGroup, SWT.CHECK);
-		ignoreNumberMatched.setText("Ignore total number of features reported by WFS");
+		ignoreNumberMatched.setText("Ignore total number of features reported by the WFS");
 		// default
 		ignoreNumberMatched.setSelection(false);
 

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlReaderSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlReaderSettingsPage.java
@@ -43,6 +43,7 @@ public class GmlReaderSettingsPage
 		extends AbstractConfigurationPage<StreamGmlReader, IOWizard<StreamGmlReader>> {
 
 	private Button ignoreNamespaces;
+	private Button ignoreNumberMatched;
 	private Button strict;
 	private Button rootAsInstance;
 	private Button requestPaginationEnabled;
@@ -69,6 +70,8 @@ public class GmlReaderSettingsPage
 				Value.of(requestPaginationEnabled.getSelection()));
 		provider.setParameter(StreamGmlReader.PARAM_FEATURES_PER_WFS_REQUEST,
 				Value.of(featuresPerRequest.getText()));
+		provider.setParameter(StreamGmlReader.PARAM_IGNORE_NUMBER_MATCHED,
+				Value.of(ignoreNumberMatched.getSelection()));
 		return true;
 	}
 
@@ -107,13 +110,13 @@ public class GmlReaderSettingsPage
 		descRoot.setText(
 				"Will only take effect if the root element type is classified as mapping relevant type.\nOnly select if you are sure you need it.");
 
-		Group featuresPerRequestGroup = new Group(page, SWT.NONE);
-		featuresPerRequestGroup.setText("WFS requests");
+		Group wfsGroup = new Group(page, SWT.NONE);
+		wfsGroup.setText("WFS requests");
 		GridLayoutFactory.swtDefaults().numColumns(2).equalWidth(false)
-				.applyTo(featuresPerRequestGroup);
-		GridDataFactory.fillDefaults().grab(true, false).applyTo(featuresPerRequestGroup);
+				.applyTo(wfsGroup);
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(wfsGroup);
 
-		requestPaginationEnabled = new Button(featuresPerRequestGroup, SWT.CHECK);
+		requestPaginationEnabled = new Button(wfsGroup, SWT.CHECK);
 		requestPaginationEnabled
 				.setText("Paginate WFS requests; number of features per WFS request:");
 		requestPaginationEnabled.setSelection(true);
@@ -125,12 +128,17 @@ public class GmlReaderSettingsPage
 			}
 		});
 
-		featuresPerRequest = new Spinner(featuresPerRequestGroup, SWT.BORDER);
+		featuresPerRequest = new Spinner(wfsGroup, SWT.BORDER);
 		featuresPerRequest.setMinimum(1);
 		featuresPerRequest.setMaximum(500000);
 		featuresPerRequest.setIncrement(100);
 		featuresPerRequest.setPageIncrement(1000);
 		featuresPerRequest.setSelection(1000);
+
+		ignoreNumberMatched = new Button(wfsGroup, SWT.CHECK);
+		ignoreNumberMatched.setText("Ignore total number of features reported by WFS");
+		// default
+		ignoreNumberMatched.setSelection(false);
 
 		setPageComplete(true);
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
@@ -172,6 +172,15 @@
             </parameterBinding>
          </providerParameter>
          <providerParameter
+               description="Ignore number of matched features reported by the WFS"
+               label="Ignore number of matched features reported by the WFS"
+               name="ignoreNumberMatched"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Boolean">
+            </parameterBinding>
+         </providerParameter>
+         <providerParameter
                description="The identifier of the algorithm to use for the interpolation of Arc and Circle geometries"
                label="Interpolation algorithm"
                name="interpolation.algorithm"
@@ -294,6 +303,15 @@
                optional="true">
             <parameterBinding
                   class="java.lang.Integer">
+            </parameterBinding>
+         </providerParameter>
+         <providerParameter
+               description="Ignore number of matched features reported by the WFS"
+               label="Ignore number of matched features reported by the WFS"
+               name="ignoreNumberMatched"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Boolean">
             </parameterBinding>
          </providerParameter>
          <providerParameter

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/StreamGmlReader.java
@@ -76,6 +76,12 @@ public class StreamGmlReader extends AbstractInstanceReader {
 	public static final String PARAM_FEATURES_PER_WFS_REQUEST = "featuresPerWfsRequest";
 
 	/**
+	 * The name of the parameter specifying if hale should ignore the total
+	 * number of features reported by the WFS.
+	 */
+	public static final String PARAM_IGNORE_NUMBER_MATCHED = "ignoreNumberMatched";
+
+	/**
 	 * The name of the parameter specifying if the selection of mapping relevant
 	 * types for instances that are processed should be ignored.
 	 * 
@@ -125,6 +131,9 @@ public class StreamGmlReader extends AbstractInstanceReader {
 			boolean ignoreNamespaces = getParameter(PARAM_IGNORE_NAMESPACES).as(Boolean.class,
 					false);
 			boolean paginateRequest = getParameter(PARAM_PAGINATE_REQUEST).as(Boolean.class, false);
+			boolean ignoreNumberMatched = getParameter(PARAM_IGNORE_NUMBER_MATCHED)
+					.as(Boolean.class, false);
+
 			int featuresPerRequest;
 			if (paginateRequest) {
 				featuresPerRequest = getParameter(PARAM_FEATURES_PER_WFS_REQUEST).as(Integer.class,
@@ -150,7 +159,7 @@ public class StreamGmlReader extends AbstractInstanceReader {
 
 				instances = new WfsBackedGmlInstanceCollection(getSource(), getSourceSchema(),
 						restrictToFeatures, ignoreRoot, strict, ignoreNamespaces, getCrsProvider(),
-						this, featuresPerRequest);
+						this, featuresPerRequest, ignoreNumberMatched);
 			}
 			else {
 				instances = new GmlInstanceCollection(getSource(), getSourceSchema(),


### PR DESCRIPTION
One of the RWS WFS reports the number of features returned per request instead of the total number of features. To be able to load all data from that WFS, the value in `numberMatched` must be ignored by hale.