### PR TITLE
Updates to the CRS selection dialog

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSDefinitionUtil.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/geometry/CRSDefinitionUtil.java
@@ -109,14 +109,12 @@ public abstract class CRSDefinitionUtil {
 				// return the lat/lon variant...
 				String code = SrsSyntax.EPSG_CODE.getPrefix() + String.valueOf(epsgCode);
 
-				// Check if the input CRS is lon/lat
-				boolean lonFirst = (CRS.getAxisOrder(crs) == AxisOrder.EAST_NORTH);
-
 				// Look up the code
-				CoordinateReferenceSystem resolved = CRS.decode(code, lonFirst);
+				CoordinateReferenceSystem resolved = CRS.decode(code);
 
-				// Use the CRS resolved by Geotools only if the axis order
-				// is still the same (not guaranteed)
+				// Use the CRS resolved by GeoTools only if its axis order
+				// is the same as the axis order of the provided CRS (not
+				// guaranteed)
 				if (CRS.getAxisOrder(crs).equals(CRS.getAxisOrder(resolved))) {
 					return new CodeDefinition(code, resolved);
 				}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/StreamGmlHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/StreamGmlHelper.java
@@ -295,13 +295,14 @@ public abstract class StreamGmlHelper {
 							&& ((GeometryProperty<?>) value).getCRSDefinition() == null)) {
 						// try to resolve value of srsName attribute
 
-						CRSDefinition geometryCrs = crsProvider.getCRS(parentType, propertyPath,
-								lastCrs);
-						if (geometryCrs != null) {
+						if (lastCrs == null) {
+							lastCrs = crsProvider.getCRS(parentType, propertyPath, lastCrs);
+						}
+
+						if (lastCrs != null) {
 							Geometry geom = (value instanceof Geometry) ? ((Geometry) value)
 									: (((GeometryProperty<?>) value).getGeometry());
-							resultVals
-									.add(new DefaultGeometryProperty<Geometry>(geometryCrs, geom));
+							resultVals.add(new DefaultGeometryProperty<Geometry>(lastCrs, geom));
 							continue;
 						}
 					}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
@@ -188,31 +188,27 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 
 	}
 
-	private static final String DEFAULT_CODE = "EPSG:4326"; //$NON-NLS-1$
-
-	private static final String DEFAULT_WKT = "PROJCS[\"MGI (Ferro)/AustriaGKWestZone\",\n" + //$NON-NLS-1$
-			"\tGEOGCS[\"MGI (Ferro)\",\n" + //$NON-NLS-1$
-			"\t\tDATUM[\"Militar-Geographische Institut (Ferro)\",\n" + //$NON-NLS-1$
-			"\t\t\tSPHEROID[\"Bessel 1841\",6377397.155,299.1528128,\n" + //$NON-NLS-1$
-			"\t\t\tAUTHORITY[\"EPSG\",\"7004\"]],AUTHORITY[\"EPSG\",\"6805\"]],\n" + //$NON-NLS-1$
-			"\t\tPRIMEM[\"Ferro\",-17.666666666666668,AUTHORITY[\"EPSG\",\"8909\"]],\n" + //$NON-NLS-1$
-			"\t\tUNIT[\"degree\",0.017453292519943295],\n" + //$NON-NLS-1$
-			"\t\tAXIS[\"Geodetic latitude\",NORTH],\n" + //$NON-NLS-1$
-			"\t\tAXIS[\"Geodetic longitude\",EAST],\n" + //$NON-NLS-1$
-			"\t\tAUTHORITY[\"EPSG\",\"4805\"]],\n" + //$NON-NLS-1$
-			"\tPROJECTION[\"Transverse Mercator\"],\n" + //$NON-NLS-1$
-			"PARAMETER[\"central_meridian\",28.0],\n" + //$NON-NLS-1$
-			"PARAMETER[\"latitude_of_origin\",0.0],\n" + //$NON-NLS-1$
-			"PARAMETER[\"scale_factor\",1.0],\n" + //$NON-NLS-1$
-			"PARAMETER[\"false_easting\",0.0],\n" + //$NON-NLS-1$
-			"PARAMETER[\"false_northing\",-5000000.0],\n" + //$NON-NLS-1$
-			"UNIT[\"m\",1.0],\n" + //$NON-NLS-1$
-			"AXIS[\"Y\",EAST],\n" + //$NON-NLS-1$
-			"AXIS[\"X\",NORTH],\n" + //$NON-NLS-1$
-			"AUTHORITY[\"EPSG\",\"31251\"]]"; //$NON-NLS-1$
+	private static final String DEFAULT_CODE = "EPSG:4258"; //$NON-NLS-1$
 
 	private static String lastCode = DEFAULT_CODE;
-	private static String lastWKT = DEFAULT_WKT;
+	private static String lastWKT;
+	static {
+		try {
+			lastWKT = CRS.decode(DEFAULT_CODE).toWKT();
+		} catch (Exception e) {
+			lastWKT = "GEOGCS[\"ETRS89\",\n" + //$NON-NLS-1$
+					"\tDATUM[\"European_Terrestrial_Reference_System_1989\",\n" + //$NON-NLS-1$
+					"\t\tSPHEROID[\"GRS 1980\",6378137,298.257222101,\n" + //$NON-NLS-1$
+					"\t\t\tAUTHORITY[\"EPSG\",\"7019\"]],\n" + //$NON-NLS-1$
+					"\t\tTOWGS84[0,0,0,0,0,0,0],\n" + //$NON-NLS-1$
+					"\t\tAUTHORITY[\"EPSG\",\"6258\"]],\n" + //$NON-NLS-1$
+					"\tPRIMEM[\"Greenwich\",0,\n" + //$NON-NLS-1$
+					"\t\tAUTHORITY[\"EPSG\",\"8901\"]],\n" + //$NON-NLS-1$
+					"\tUNIT[\"degree\",0.0174532925199433,\n" + //$NON-NLS-1$
+					"\t\tAUTHORITY[\"EPSG\",\"9122\"]],\n" + //$NON-NLS-1$
+					"\tAUTHORITY[\"EPSG\",\"4258\"]]"; //$NON-NLS-1$
+		}
+	}
 
 	private CRSFieldEditor crsField;
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
@@ -35,7 +35,9 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.geotools.referencing.CRS;
@@ -216,6 +218,8 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 
 	private WKText wktField;
 
+	private Label wktWarning;
+
 	private static final String DEF_MESSAGE = ""; //$NON-NLS-1$
 
 	private Button radioCRS;
@@ -316,6 +320,18 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 		crsField.setPropertyChangeListener(this);
 		crsField.setEnabled(lastWasCode, group);
 
+		new Label(group, SWT.NONE);
+
+		wktWarning = new Label(group, SWT.NONE);
+		wktWarning.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+		wktWarning.setText(
+				"Please be aware that if you provide a WKT definition here, hale studio may\n"
+						+ "not be able to perform accurate coordinate transformations due to missing\n"
+						+ "Bursa-Wolf parameters. If you intend to perform coordinate transformations,\n"
+						+ "please provide an appropriate CRS code instead.");
+		wktWarning.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_DARK_RED));
+		wktWarning.setVisible(!lastWasCode);
+
 		// WKT string
 		radioWKT = new Button(group, SWT.RADIO);
 		radioWKT.setSelection(!lastWasCode);
@@ -345,6 +361,7 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 
 		crsField.setEnabled(enableCode, group);
 		wktField.getTextField().setEnabled(!enableCode);
+		wktWarning.setVisible(!enableCode);
 
 		updateMessage();
 		updateState();

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/instance/crs/SelectCRSDialog.java
@@ -313,6 +313,10 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 		if (value instanceof CodeDefinition) {
 			code = ((CodeDefinition) value).getCode();
 		}
+		else if (value instanceof WKTDefinition) {
+			// Don't show possibly contradicting code
+			code = "";
+		}
 		else {
 			code = lastCode;
 		}
@@ -343,6 +347,15 @@ public class SelectCRSDialog extends TitleAreaDialog implements IPropertyChangeL
 		String wkt;
 		if (value instanceof WKTDefinition) {
 			wkt = ((WKTDefinition) value).getWkt();
+		}
+		else if (value instanceof CodeDefinition) {
+			// Display WKT corresponding to the given code, if possible
+			try {
+				wkt = ((CodeDefinition) value).getCRS().toWKT();
+			} catch (Exception e) {
+				// Avoid displaying possibly contradicting WKT
+				wkt = "";
+			}
 		}
 		else {
 			wkt = lastWKT;


### PR DESCRIPTION
- Use guessed EPSG code for .prj file only if axis order is consistent
- Don't prompt user for CRS if resolvable `srsName` is available in GML source
- Add Bursa-Wolf parameter warning to CRS selection dialog if WKT is provided
- Avoid displaying contradicting WKT/codes in CRS selection dialog
- Replace default CRS in selection dialog by ETRS89 (4258)