### PR TITLE
Reduce join/merge handler fallback warning to info

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/join/IndexJoinHandler.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/join/IndexJoinHandler.java
@@ -78,7 +78,7 @@ public class IndexJoinHandler
 		JoinHandler fallbackHandler = new JoinHandler();
 		InstanceIndexService indexService = serviceProvider.getService(InstanceIndexService.class);
 		if (indexService == null) {
-			log.warn(MessageFormat.format(
+			log.info(MessageFormat.format(
 					"Index service not available, falling back to join handler {0}",
 					fallbackHandler.getClass().getCanonicalName()));
 			return fallbackHandler.partitionInstances(instances, transformationIdentifier, engine,
@@ -112,7 +112,7 @@ public class IndexJoinHandler
 				}
 
 				if (!Identifiable.is(i)) {
-					log.warn(MessageFormat.format(
+					log.info(MessageFormat.format(
 							"At least one instance does not have an ID, falling back to join handler {0}",
 							fallbackHandler.getClass().getCanonicalName()));
 					return fallbackHandler.partitionInstances(instances, transformationIdentifier,

--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/merge/IndexMergeHandler.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/merge/IndexMergeHandler.java
@@ -98,7 +98,7 @@ public class IndexMergeHandler
 
 		InstanceIndexService indexService = serviceProvider.getService(InstanceIndexService.class);
 		if (indexService == null) {
-			log.warn(MessageFormat.format(
+			log.info(MessageFormat.format(
 					"Index service not available, falling back to merge handler {0}",
 					fallbackHandler.getClass().getCanonicalName()));
 			return fallbackHandler.partitionInstances(instances, transformationIdentifier, engine,
@@ -145,7 +145,7 @@ public class IndexMergeHandler
 			while (it.hasNext()) {
 				Instance i = InstanceDecorator.getRoot(it.next());
 				if (!Identifiable.is(i)) {
-					log.warn(MessageFormat.format(
+					log.info(MessageFormat.format(
 							"At least one instance does not have an ID, falling back to merge handler {0}",
 							fallbackHandler.getClass().getCanonicalName()));
 					return fallbackHandler.partitionInstances(instances, transformationIdentifier,


### PR DESCRIPTION
The fallback does not affect a transformation's outcome, so this is not critical.