### PR TITLE
InstanceAccessor: support descending into all children

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessorTest.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.groovy.test/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessorTest.groovy
@@ -217,4 +217,35 @@ class InstanceAccessorTest extends GroovyTestCase {
 		assertTrue instance.properties.relative.first() instanceof Instance
 	}
 
+	void testAllChildren() {
+		// build instance
+		Instance instance = new InstanceBuilder().instance {
+			name 'Max Mustermann'
+			age 31
+			address {
+				street 'Musterstrasse'
+				number 12
+				city 'Musterstadt'
+			}
+			address2 {
+				street 'Taubengasse'
+				number 13
+			}
+			address3 {
+				street 'Lalaweg'
+				number 7
+			}
+		}
+
+		def streets = instance.p.'*'.street.values()
+		assertEquals(new HashSet([
+			'Musterstrasse',
+			'Taubengasse',
+			'Lalaweg'
+		]), new HashSet(streets))
+
+		def numbers = instance.p.''.number.values()
+		assertEquals(new HashSet([7, 12, 13]), new HashSet(numbers))
+	}
+
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.instance.groovy/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessor.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.groovy/src/eu/esdihumboldt/hale/common/instance/groovy/InstanceAccessor.groovy
@@ -116,6 +116,9 @@ class InstanceAccessor extends AbstractAccessor<Object> {
 			fullName = new QName(name)
 		}
 
+		// special case - get all children
+		boolean allChildren = name == null || name.isEmpty() || name == '*'
+
 		List<Path<Object>> allPaths = (List<Path<Object>>) all() // Groovy CompileStatic can't deal properly with ? extends ...
 		allPaths.collectMany { Path<Object> parentPath ->
 			// search for possible children and
@@ -128,7 +131,16 @@ class InstanceAccessor extends AbstractAccessor<Object> {
 				// there may only be children if this is a group
 				Group group = (Group) object
 
-				if (group.definition != null) {
+				if (allChildren) {
+					// yield all children
+					def valueList = []
+					group.propertyNames.each { QName pname ->
+						def pvalues = group.getProperty(pname)
+						pvalues?.each { valueList << it }
+					}
+					values = valueList
+				}
+				else if (group.definition != null) {
 					// access based on definitions
 
 					// find possible paths to children


### PR DESCRIPTION
@JohannaOtt With this PR you can access all children on a certain level with the instance accessor.

Usage for instance like `instance.p.'*'.street.values()` as in the example in the commit (the asterisk picks up "address", "address2" and "address3").

But you have to be careful as this also picks up groups (e.g. choices). So in your use case I think you have to go down two levels using this.