### PR TITLE
Add partitioning by feature type to GML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 
 ## [Unreleased]
 
+### Added
+
+- Split GML output by feature type
+
+### Fixed
+
 - Fixed hale connect integration when using a proxy
 - Fix CLI transformations when source data contains unknown or invalid CRS definitions
 

--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/impl/SingleTypeInstanceCollection.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/impl/SingleTypeInstanceCollection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.instance.model.impl;
+
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.ext.helper.InstanceCollectionDecorator;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+
+/**
+ * InstanceCollection decorator for collections that contain instances of only
+ * one type
+ * 
+ * @author Florian Esser
+ */
+public class SingleTypeInstanceCollection extends InstanceCollectionDecorator {
+
+	private final TypeDefinition type;
+
+	/**
+	 * @param decoratee Collection to decorate
+	 * @param type Type of the contained instances
+	 */
+	public SingleTypeInstanceCollection(InstanceCollection decoratee, TypeDefinition type) {
+		super(decoratee);
+
+		this.type = type;
+	}
+
+	/**
+	 * @return the type of the instances contained in this collection
+	 */
+	public TypeDefinition getType() {
+		return type;
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
@@ -141,7 +141,16 @@ public class PartitionConfigurationPage
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER)
 				.applyTo(partitionMode.getControl());
 
-		activatePartitioningByFeatureType = new Button(part, SWT.CHECK);
+		Group gml = new Group(page, SWT.NONE);
+		gml.setLayout(new GridLayout(3, false));
+		gml.setText("Split by feature type");
+		groupData.applyTo(gml);
+
+		activatePartitioningByFeatureType = new Button(gml, SWT.CHECK);
+		activatePartitioningByFeatureType
+				.setText("Create separate output file for every feature type");
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.BEGINNING).span(3, 1).grab(true, false)
+				.applyTo(activatePartitioningByFeatureType);
 		activatePartitioningByFeatureType.setSelection(false);
 		activatePartitioningByFeatureType.addSelectionListener(new SelectionAdapter() {
 
@@ -150,11 +159,6 @@ public class PartitionConfigurationPage
 				update();
 			}
 		});
-
-		Label labelByFeatureType = new Label(part, SWT.NONE);
-		labelByFeatureType.setText("Create a separate output file for every feature type");
-		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.BEGINNING).span(2, 1).grab(true, false)
-				.applyTo(labelByFeatureType);
 
 		update();
 		setPageComplete(true);

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/PartitionConfigurationPage.java
@@ -53,6 +53,7 @@ public class PartitionConfigurationPage
 	private Button activatePartitioning;
 	private Spinner instances;
 	private ComboViewer partitionMode;
+	private Button activatePartitioningByFeatureType;
 
 	/**
 	 * Default constructor.
@@ -76,11 +77,18 @@ public class PartitionConfigurationPage
 
 	@Override
 	public boolean updateConfiguration(StreamGmlWriter provider) {
-		int threshold = activatePartitioning.getSelection() ? instances.getSelection()
-				: StreamGmlWriter.NO_PARTITIONING;
-		provider.setParameter(StreamGmlWriter.PARAM_INSTANCES_THRESHOLD, Value.of(threshold));
+		if (activatePartitioning.getSelection()) {
+			provider.setParameter(StreamGmlWriter.PARAM_PARTITION_BY_FEATURE_TYPE, Value.of(false));
 
-		applyPartitionMode(partitionMode, provider);
+			int threshold = instances.getSelection();
+			provider.setParameter(StreamGmlWriter.PARAM_INSTANCES_THRESHOLD, Value.of(threshold));
+			applyPartitionMode(partitionMode, provider);
+		}
+		else if (activatePartitioningByFeatureType.getSelection()) {
+			provider.setParameter(StreamGmlWriter.PARAM_INSTANCES_THRESHOLD,
+					Value.of(StreamGmlWriter.NO_PARTITIONING));
+			provider.setParameter(StreamGmlWriter.PARAM_PARTITION_BY_FEATURE_TYPE, Value.of(true));
+		}
 
 		return true;
 	}
@@ -132,6 +140,21 @@ public class PartitionConfigurationPage
 		partitionMode = createPartitionModeSelector(part);
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER)
 				.applyTo(partitionMode.getControl());
+
+		activatePartitioningByFeatureType = new Button(part, SWT.CHECK);
+		activatePartitioningByFeatureType.setSelection(false);
+		activatePartitioningByFeatureType.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				update();
+			}
+		});
+
+		Label labelByFeatureType = new Label(part, SWT.NONE);
+		labelByFeatureType.setText("Create a separate output file for every feature type");
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.BEGINNING).span(2, 1).grab(true, false)
+				.applyTo(labelByFeatureType);
 
 		update();
 		setPageComplete(true);
@@ -206,6 +229,8 @@ public class PartitionConfigurationPage
 	private void update() {
 		instances.setEnabled(activatePartitioning.getSelection());
 		partitionMode.getControl().setEnabled(activatePartitioning.getSelection());
+		activatePartitioningByFeatureType.setEnabled(!activatePartitioning.getSelection());
+		activatePartitioning.setEnabled(!activatePartitioningByFeatureType.getSelection());
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/DefaultMultipartHandler.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/DefaultMultipartHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.google.common.io.Files;
+
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+
+/**
+ * Handler that adds an incrementing number to the target file name.
+ * 
+ * @author Florian Esser
+ */
+public class DefaultMultipartHandler implements MultipartHandler {
+
+	private int currentPart = 1;
+
+	@Override
+	public String getTargetFilename(InstanceCollection part, URI location) {
+		return formatTargetFilename(location);
+	}
+
+	private String formatTargetFilename(URI location) {
+		Path origPath = Paths.get(location).normalize();
+		return String.format("%s%s%s.%04d.%s", origPath.getParent(), File.separator,
+				Files.getNameWithoutExtension(origPath.toString()), currentPart++,
+				Files.getFileExtension(origPath.toString()));
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/LocalReferenceUpdater.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/LocalReferenceUpdater.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.http.client.utils.URIBuilder;
+
+import eu.esdihumboldt.util.io.IOUtils;
+
+/**
+ * Reference updater that updates local references (starting with
+ * "<code>#</code>" ) to relative references according to an ID->target map.
+ * 
+ * @author Florian Esser
+ */
+public class LocalReferenceUpdater implements ReferenceUpdater {
+
+	private final Map<String, URI> idToTargetMapping;
+	private final URI originalTarget;
+
+	/**
+	 * Create the reference updater
+	 * 
+	 * @param idToTargetMapping Mapping of local IDs to the new target URIs
+	 * @param originalTarget URI of the original target
+	 */
+	public LocalReferenceUpdater(Map<String, URI> idToTargetMapping, URI originalTarget) {
+		this.idToTargetMapping = idToTargetMapping;
+		this.originalTarget = originalTarget;
+	}
+
+	@Override
+	public String updateReference(String value) {
+		if (!value.startsWith("#")) {
+			return value;
+		}
+
+		String id = value.substring(1);
+		if (idToTargetMapping.containsKey(id)) {
+			URI idTarget = idToTargetMapping.get(id);
+			if (!originalTarget.equals(idTarget)) {
+				URI relativeUri = IOUtils.getRelativePath(idTarget, originalTarget);
+				URIBuilder builder = new URIBuilder(relativeUri);
+				builder.setFragment(id);
+				value = builder.toString();
+			}
+		}
+
+		return value;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/MultipartHandler.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/MultipartHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+import java.net.URI;
+
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+
+/**
+ * Interface for handlers that control writing instances to multiple XML/GML
+ * files.
+ * 
+ * @author Florian Esser
+ */
+public interface MultipartHandler {
+
+	/**
+	 * Build the target file name for the given part
+	 * 
+	 * @param part Part
+	 * @param originalTarget Output target originally provided
+	 * @return The modified output target for the given part
+	 */
+	String getTargetFilename(InstanceCollection part, URI originalTarget);
+
+	/**
+	 * Extension point to provide a stream writer with special capabilities.
+	 * Returns the provided writer unless overridden by the handler
+	 * implementation.
+	 * 
+	 * @param writer Original writer
+	 * @param target Output target
+	 * @return The decorated writer
+	 */
+	default PrefixAwareStreamWriter getDecoratedWriter(PrefixAwareStreamWriter writer, URI target) {
+		return writer;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/PerTypePartsHandler.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/PerTypePartsHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
+import com.google.common.io.Files;
+
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.impl.SingleTypeInstanceCollection;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+
+/**
+ * Handler for writing instances split by feature type.
+ * 
+ * @author Florian Esser
+ */
+public class PerTypePartsHandler implements MultipartHandler {
+
+	private final Map<TypeDefinition, URI> typeToTargetMapping;
+	private final Map<String, TypeDefinition> idToTypeMapping;
+
+	/**
+	 * Create the handler
+	 * 
+	 * @param typeToTargetMapping Mapping between feature type and target file
+	 * @param idToTypeMapping Mapping between the GML IDs and the associated
+	 *            feature type
+	 */
+	public PerTypePartsHandler(Map<TypeDefinition, URI> typeToTargetMapping,
+			Map<String, TypeDefinition> idToTypeMapping) {
+		this.typeToTargetMapping = typeToTargetMapping;
+		this.idToTypeMapping = idToTypeMapping;
+	}
+
+	@Override
+	public String getTargetFilename(InstanceCollection part, URI location) {
+		if (!(part instanceof SingleTypeInstanceCollection)) {
+			throw new IllegalArgumentException(
+					"This handler only supports SingleTypeInstanceCollections");
+		}
+		SingleTypeInstanceCollection stic = (SingleTypeInstanceCollection) part;
+		// TODO Does not work for two feature types with same local part
+		// but different namespace
+
+		return getTargetFilename(stic.getType().getName(), location);
+	}
+
+	/**
+	 * Build the target file name for a given type name
+	 * 
+	 * @param typeName Type name
+	 * @param location Original target location
+	 * @return The modified file name
+	 */
+	public static String getTargetFilename(QName typeName, URI location) {
+		Path origPath = Paths.get(location).normalize();
+		return String.format("%s%s%s.%s.%s", origPath.getParent().toString(), File.separator,
+				Files.getNameWithoutExtension(origPath.toString()), typeName.getLocalPart(),
+				Files.getFileExtension(origPath.toString()));
+	}
+
+	@Override
+	public PrefixAwareStreamWriter getDecoratedWriter(PrefixAwareStreamWriter writer, URI target) {
+		Map<String, URI> idToTargetMapping = idToTypeMapping.entrySet().stream().collect(
+				Collectors.toMap(Map.Entry::getKey, e -> typeToTargetMapping.get(e.getValue())));
+		LocalReferenceUpdater updater = new LocalReferenceUpdater(idToTargetMapping, target);
+
+		return new ReferenceUpdatingStreamWriter(writer, updater);
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/ReferenceUpdater.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/ReferenceUpdater.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+/**
+ * Interface for updating referencing
+ * 
+ * @author Florian Esser
+ */
+public interface ReferenceUpdater {
+
+	/**
+	 * Update the given reference
+	 * 
+	 * @param originalRef Reference to update
+	 * @return The updated reference
+	 */
+	String updateReference(String originalRef);
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/ReferenceUpdatingStreamWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/ReferenceUpdatingStreamWriter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.writer.internal;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Prefix-aware stream writer that updates local links in a specified attribute.
+ * If the attribute is not explicitly named, all attributes with the local part
+ * <code>"href"</code> will be updated.
+ * 
+ * @author Florian Esser
+ */
+public class ReferenceUpdatingStreamWriter extends PrefixAwareStreamWriterDecorator {
+
+	private final ReferenceUpdater updater;
+	private final QName attribute;
+
+	/**
+	 * Create the writer.
+	 * 
+	 * @param decoratee Writer to decorate
+	 * @param updater Reference updater to use
+	 */
+	public ReferenceUpdatingStreamWriter(XMLStreamWriter decoratee, ReferenceUpdater updater) {
+		super(decoratee);
+		this.updater = updater;
+		this.attribute = new QName("href");
+	}
+
+	/**
+	 * Create the writer that updates the specified attribute. If the attribute
+	 * to update contains only a local part (i.e. no prefix and namespace are
+	 * specified), all attributes with that local part will be updated.
+	 * 
+	 * @param decoratee Writer to decorate
+	 * @param updater Reference updater to use
+	 * @param attributeToUpdate The attribute to update.
+	 */
+	public ReferenceUpdatingStreamWriter(XMLStreamWriter decoratee, ReferenceUpdater updater,
+			QName attributeToUpdate) {
+		super(decoratee);
+		this.updater = updater;
+
+		if (attributeToUpdate.getLocalPart() == null
+				|| attributeToUpdate.getLocalPart().trim().isEmpty()) {
+			throw new IllegalArgumentException(
+					"Local part of attribute to update must not be empty");
+		}
+		this.attribute = attributeToUpdate;
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.io.gml.writer.internal.XMLStreamWriterDecorator#writeAttribute(java.lang.String,
+	 *      java.lang.String, java.lang.String, java.lang.String)
+	 */
+	@Override
+	public void writeAttribute(String prefix, String namespaceURI, String localName, String value)
+			throws XMLStreamException {
+		if (!isMatchingAttribute(prefix, namespaceURI, localName)) {
+			super.writeAttribute(prefix, namespaceURI, localName, value);
+			return;
+		}
+
+		value = updater.updateReference(value);
+		super.writeAttribute(prefix, namespaceURI, localName, value);
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.io.gml.writer.internal.XMLStreamWriterDecorator#writeAttribute(java.lang.String,
+	 *      java.lang.String, java.lang.String)
+	 */
+	@Override
+	public void writeAttribute(String namespaceURI, String localName, String value)
+			throws XMLStreamException {
+		if (!isMatchingAttribute(null, namespaceURI, localName)) {
+			super.writeAttribute(namespaceURI, localName, value);
+			return;
+		}
+
+		value = updater.updateReference(value);
+		super.writeAttribute(namespaceURI, localName, value);
+	}
+
+	private boolean isMatchingAttribute(String prefix, String namespaceUri, String localName) {
+		boolean result = true;
+		if (StringUtils.hasText(attribute.getPrefix())) {
+			result &= attribute.getPrefix().equals(prefix);
+		}
+		if (StringUtils.hasText(attribute.getNamespaceURI())) {
+			result &= attribute.getNamespaceURI().equals(namespaceUri);
+		}
+
+		result &= attribute.getLocalPart().equals(localName);
+
+		return result;
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/internal/StreamGmlWriter.java
@@ -168,6 +168,11 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	public static final String PARAM_INSTANCES_THRESHOLD = "instancesPerFile";
 
 	/**
+	 * Name of the parameter to create separate files for each feature type
+	 */
+	public static final String PARAM_PARTITION_BY_FEATURE_TYPE = "partition.byFeatureType";
+
+	/**
 	 * Name of the parameter stating the mode to use for instance partitioning.
 	 */
 	public static final String PARAM_PARTITION_MODE = "partition.mode";
@@ -452,6 +457,10 @@ public class StreamGmlWriter extends AbstractGeoInstanceWriter
 	private boolean isThresholdConfigured() {
 		int threshold = getParameter(PARAM_INSTANCES_THRESHOLD).as(Integer.class, NO_PARTITIONING);
 		return threshold != NO_PARTITIONING && threshold > 0;
+	}
+
+	private boolean isPartitionByFeatureTypeConfigured() {
+		return getParameter(PARAM_PARTITION_BY_FEATURE_TYPE).as(Boolean.class, false);
 	}
 
 	@Override

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/RecentProjectsMenu.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/RecentProjectsMenu.java
@@ -17,6 +17,7 @@
 package eu.esdihumboldt.hale.ui.service.project;
 
 import java.io.File;
+import java.text.MessageFormat;
 
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jface.action.ContributionItem;
@@ -27,6 +28,9 @@ import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.ui.PlatformUI;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
+
 /**
  * A menu filled with the list of recently opened files (MRU).
  * 
@@ -34,6 +38,8 @@ import org.eclipse.ui.PlatformUI;
  * @author Simon Templer
  */
 public class RecentProjectsMenu extends ContributionItem {
+
+	private static final ALogger log = ALoggerFactory.getLogger(RecentProjectsMenu.class);
 
 	/**
 	 * The string filled in for the gap in the filename
@@ -71,7 +77,13 @@ public class RecentProjectsMenu extends ContributionItem {
 		@Override
 		public void widgetSelected(SelectionEvent e) {
 			ProjectService ps = PlatformUI.getWorkbench().getService(ProjectService.class);
-			ps.load(file.toURI());
+			if (!file.exists()) {
+				log.userError(MessageFormat.format("The file \"{0}\" does not exist.",
+						file.getAbsolutePath()));
+			}
+			else {
+				ps.load(file.toURI());
+			}
 		}
 	}
 


### PR DESCRIPTION
See feature request #564.

This implements the option to split the GML output by feature type. The type name is included in the output file name, e.g. `output.gml` turns into `output.<type name>.gml`. Local references to other types will be updated to relative references, e.g. `#FeatureTypeA_feature1` will turn into `output.FeatureTypeA.gml#FeatureTypeA_feature1` (this does _not_ rely on the feature type name being part of the feature ID).

The feature type split cannot be combined with the partitioning by number of objects.