### PR TITLE
identify source data configurations by action ID

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/project/internal/ProjectServiceImpl.java
@@ -92,7 +92,6 @@ import eu.esdihumboldt.hale.common.core.service.cleanup.CleanupService;
 import eu.esdihumboldt.hale.common.core.service.cleanup.TemporaryFiles;
 import eu.esdihumboldt.hale.common.instance.helper.PropertyResolver;
 import eu.esdihumboldt.hale.common.instance.io.InstanceIO;
-import eu.esdihumboldt.hale.common.instance.io.InstanceReader;
 import eu.esdihumboldt.hale.ui.HaleUI;
 import eu.esdihumboldt.hale.ui.io.project.OpenProjectWizard;
 import eu.esdihumboldt.hale.ui.io.project.SaveProjectWizard;
@@ -268,9 +267,7 @@ public class ProjectServiceImpl extends AbstractProjectService implements Projec
 			// loaded
 			List<IOConfiguration> sourceDataConfigurations = new ArrayList<>();
 			for (IOConfiguration conf : confs) {
-				IOProviderDescriptor descriptor = IOProviderExtension.getInstance()
-						.getFactory(conf.getProviderId());
-				if (InstanceReader.class.isAssignableFrom(descriptor.getProviderType())) {
+				if (InstanceIO.ACTION_LOAD_SOURCE_DATA.equals(conf.getActionId())) {
 					sourceDataConfigurations.add(conf);
 				}
 			}


### PR DESCRIPTION
Avoids a possible error in case an I/O provider is not known,
that would prevent loading the project.

@thorsten-reitz Addresses the issue you had this morning. The user then should be able to load the project partially and get a more useful error.