### PR TITLE
[WIP] Support XSD types with <xs:all>

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/property/AllGroupFlag.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/property/AllGroupFlag.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+package eu.esdihumboldt.hale.common.schema.model.constraint.property;
+
+import eu.esdihumboldt.hale.common.schema.model.Constraint;
+import eu.esdihumboldt.hale.common.schema.model.GroupPropertyConstraint;
+import eu.esdihumboldt.hale.common.schema.model.constraint.AbstractFlagConstraint;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Flags if a property group is an "all" group that supports children to appear
+ * in any order.
+ * 
+ * @author Florian Esser
+ */
+@Immutable
+@Constraint(mutable = false)
+public class AllGroupFlag extends AbstractFlagConstraint implements GroupPropertyConstraint {
+
+	/**
+	 * Enabled all group flag
+	 */
+	public static final AllGroupFlag ENABLED = new AllGroupFlag(true);
+
+	/**
+	 * Disabled all group flag
+	 */
+	public static final AllGroupFlag DISABLED = new AllGroupFlag(false);
+
+	/**
+	 * Get the all group flag
+	 * 
+	 * @param isAllGroup if the flag shall be enabled
+	 * @return the flag
+	 */
+	public static AllGroupFlag get(boolean isAllGroup) {
+		return (isAllGroup) ? (ENABLED) : (DISABLED);
+	}
+
+	/**
+	 * Creates a default flag, which is disabled. If possible, instead of
+	 * creating an instance, use {@link #get(boolean)}, {@link #ENABLED} or
+	 * {@link #DISABLED}.
+	 * 
+	 * @see Cardinality
+	 */
+	public AllGroupFlag() {
+		this(false);
+	}
+
+	/**
+	 * @see AbstractFlagConstraint#AbstractFlagConstraint(boolean)
+	 */
+	private AllGroupFlag(boolean enabled) {
+		super(enabled);
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+
+<items xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="allgroup.xsd">
+	<umbrella>Some umbrella</umbrella>
+	<hat>And hat</hat>
+	<shirt>Some shirt</shirt>
+</items>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xsd
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xsd
@@ -1,0 +1,13 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="items" type="ItemsType"/>
+
+  <xs:complexType name="ItemsType">
+    <xs:all minOccurs="0" maxOccurs="1">
+      <xs:element name="shirt" type="xs:string"/>
+      <xs:element name="hat" type="xs:string"/>
+      <xs:element name="umbrella" type="xs:string"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollectionTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollectionTest.java
@@ -37,6 +37,7 @@ import eu.esdihumboldt.hale.common.instance.model.Group;
 import eu.esdihumboldt.hale.common.instance.model.Instance;
 import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
 import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
+import eu.esdihumboldt.hale.common.instance.model.impl.DefaultGroup;
 import eu.esdihumboldt.hale.common.schema.io.SchemaReader;
 import eu.esdihumboldt.hale.common.schema.model.Schema;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
@@ -274,6 +275,53 @@ public class GmlInstanceCollectionTest {
 	}
 
 	/**
+	 * Test loading a simple XML file with one instance including an <xs:all>
+	 * group.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testLoadAllGroup() throws Exception {
+		GmlInstanceCollection instances = loadInstances(
+				getClass().getResource("/data/allgroup/allgroup.xsd").toURI(),
+				getClass().getResource("/data/allgroup/allgroup.xml").toURI(), false, false, false);
+
+		ResourceIterator<Instance> it = instances.iterator();
+		try {
+			assertTrue(it.hasNext());
+
+			Instance instance = it.next();
+			assertNotNull(instance);
+
+			// all
+			Object[] all_1 = instance.getProperty(new QName("/ItemsType", "all_1"));
+			assertNotNull(all_1);
+			assertEquals(1, all_1.length);
+			DefaultGroup all = (DefaultGroup) all_1[0];
+
+			Object[] umbrella = all.getProperty(new QName("umbrella"));
+			assertNotNull(umbrella);
+			assertEquals(1, umbrella.length);
+			assertEquals("Some umbrella", umbrella[0]);
+
+			Object[] shirt = all.getProperty(new QName("shirt"));
+			assertNotNull(shirt);
+			assertEquals(1, shirt.length);
+			assertEquals("Some shirt", shirt[0]);
+
+			Object[] hat = all.getProperty(new QName("hat"));
+			assertNotNull(hat);
+			assertEquals(1, hat.length);
+			assertEquals("And hat", hat[0]);
+
+			// only one object
+			assertFalse(it.hasNext());
+		} finally {
+			it.close();
+		}
+	}
+
+	/**
 	 * Test loading a simple XML file with one instance including a choice and a
 	 * sub-choice.
 	 * 
@@ -335,7 +383,7 @@ public class GmlInstanceCollectionTest {
 		GmlInstanceCollection instances = loadInstances(
 				getClass().getResource("/data/sample_wva/wfs_va.xsd").toURI(),
 				getClass().getResource("/data/sample_wva/wfs_va_sample_namespace.gml").toURI(),
-				true, true);
+				true, true, true);
 
 		testWVAInstances(instances);
 	}
@@ -467,12 +515,12 @@ public class GmlInstanceCollectionTest {
 
 	private GmlInstanceCollection loadInstances(URI schemaLocation, URI xmlLocation,
 			boolean restrictToFeatures) throws IOException, IOProviderConfigurationException {
-		return loadInstances(schemaLocation, xmlLocation, restrictToFeatures, true);
+		return loadInstances(schemaLocation, xmlLocation, restrictToFeatures, true, true);
 	}
 
 	private GmlInstanceCollection loadInstances(URI schemaLocation, URI xmlLocation,
-			boolean restrictToFeatures, boolean ignoreNamespace)
-					throws IOException, IOProviderConfigurationException {
+			boolean restrictToFeatures, boolean ignoreNamespace, boolean strict)
+			throws IOException, IOProviderConfigurationException {
 		SchemaReader reader = new XmlSchemaReader();
 		reader.setSharedTypes(null);
 		reader.setSource(new DefaultInputSupplier(schemaLocation));
@@ -481,7 +529,7 @@ public class GmlInstanceCollectionTest {
 		Schema sourceSchema = reader.getSchema();
 
 		return new GmlInstanceCollection(new DefaultInputSupplier(xmlLocation), sourceSchema,
-				restrictToFeatures, false, true, ignoreNamespace, null, reader);
+				restrictToFeatures, false, strict, ignoreNamespace, null, reader);
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupPath.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupPath.java
@@ -31,7 +31,6 @@ import eu.esdihumboldt.hale.common.instance.model.impl.DefaultGroup;
 import eu.esdihumboldt.hale.common.schema.model.ChildDefinition;
 import eu.esdihumboldt.hale.common.schema.model.DefinitionGroup;
 import eu.esdihumboldt.hale.common.schema.model.GroupPropertyDefinition;
-import eu.esdihumboldt.hale.common.schema.model.constraint.property.AllGroupFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.ChoiceFlag;
 
 /**
@@ -187,12 +186,6 @@ public class GroupPath {
 				if (((GroupPropertyDefinition) child).getConstraint(ChoiceFlag.class).isEnabled()) {
 					// group is a choice
 					return true;
-				}
-				else if (((GroupPropertyDefinition) child).getConstraint(AllGroupFlag.class)
-						.isEnabled()) {
-					// TODO must check if property was added already (in an
-					// "all" group each element must not occur more than once)
-					return true; // XXX
 				}
 			}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupPath.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupPath.java
@@ -31,6 +31,7 @@ import eu.esdihumboldt.hale.common.instance.model.impl.DefaultGroup;
 import eu.esdihumboldt.hale.common.schema.model.ChildDefinition;
 import eu.esdihumboldt.hale.common.schema.model.DefinitionGroup;
 import eu.esdihumboldt.hale.common.schema.model.GroupPropertyDefinition;
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.AllGroupFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.ChoiceFlag;
 
 /**
@@ -176,17 +177,23 @@ public class GroupPath {
 		else {
 			// check last child
 			DefinitionGroup child = children.get(children.size() - 1);
-			ChildDefinition<?> property = GroupUtil
-					.findChild(child, propertyName, ignoreNamespaces);
+			ChildDefinition<?> property = GroupUtil.findChild(child, propertyName,
+					ignoreNamespaces);
 			if (property == null) {
 				return false;
 			}
 
-			if (child instanceof GroupPropertyDefinition
-					&& ((GroupPropertyDefinition) child).getConstraint(ChoiceFlag.class)
-							.isEnabled()) {
-				// group is a choice
-				return true;
+			if (child instanceof GroupPropertyDefinition) {
+				if (((GroupPropertyDefinition) child).getConstraint(ChoiceFlag.class).isEnabled()) {
+					// group is a choice
+					return true;
+				}
+				else if (((GroupPropertyDefinition) child).getConstraint(AllGroupFlag.class)
+						.isEnabled()) {
+					// TODO must check if property was added already (in an
+					// "all" group each element must not occur more than once)
+					return true; // XXX
+				}
 			}
 
 			return !strict || GroupUtil.allowAdd(null, child, property.getName());

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
@@ -39,6 +39,7 @@ import eu.esdihumboldt.hale.common.schema.model.DefinitionUtil;
 import eu.esdihumboldt.hale.common.schema.model.GroupPropertyDefinition;
 import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.AllGroupFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.Cardinality;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.ChoiceFlag;
 import eu.esdihumboldt.hale.io.xsd.constraint.XmlAttributeFlag;
@@ -502,8 +503,9 @@ public class GroupUtil {
 			else {
 				// sequence, group(, attributeGroup)
 
-				// check order
-				if (!allowAddCheckOrder(group, propertyName, def)) {
+				// check order if not <all>
+				if (!gpdef.getConstraint(AllGroupFlag.class).isEnabled()
+						&& !allowAddCheckOrder(group, propertyName, def)) {
 					return false;
 				}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd.test/src/testdata/definitive/allgroup.xsd
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd.test/src/testdata/definitive/allgroup.xsd
@@ -1,0 +1,12 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="items" type="ItemsType"/>
+
+  <xs:complexType name="ItemsType">
+    <xs:all minOccurs="0" maxOccurs="1">
+      <xs:element name="name" type="xs:string" minOccurs="0"/>
+      <xs:element name="id" type="xs:ID"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
Add support for `<xs:all>` in addition to `<xs:choice>` and `<xs:sequence>` in the XML schema reader (see #467)

To do:

- [x]  Assert that each element of the `<all>` group can be added only once