### PR TITLE
Prevent CR line endings when serializing Text values

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/impl/TextType.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/impl/TextType.java
@@ -58,14 +58,21 @@ public class TextType implements ComplexValueType<Text, Void> {
 			result.setPrefix("core");
 			result.setAttribute("xml:space", "preserve");
 
+			String text = value.getText();
+			if (!text.isEmpty() && text.contains("\r") && !text.contains("\n")) {
+				// replace deprecated Mac OS \r line endings with \n
+				// TODO also replace \r\n endings with \n ?
+				text = text.replaceAll("\r", "\n");
+			}
+
 			StringBuilder content = new StringBuilder();
 			// wrap content in line breaks for better looks in XML
 			// if it itself contains line breaks
-			boolean wrap = !value.getText().isEmpty() && value.getText().contains("\n");
+			boolean wrap = !text.isEmpty() && text.contains("\n");
 			if (wrap) {
 				content.append('\n');
 			}
-			content.append(value.getText());
+			content.append(text);
 			if (wrap) {
 				content.append('\n');
 			}


### PR DESCRIPTION
This prevents writing `\r` line endings for `Text` values, e.g. Groovy scripts. 

Although values with a `\r` line ending get de-serialized fine, they prevent effective git diffs because (at least on Windows) the `\r` is not recognized as a line ending by the diff tool and the whole text ends up on a single line.