### PR TITLE
Allow importing Shapefiles with shortened property names

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.shp.ui/src/eu/esdihumboldt/hale/io/shp/ui/TypeSelectionPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp.ui/src/eu/esdihumboldt/hale/io/shp/ui/TypeSelectionPage.java
@@ -28,6 +28,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
@@ -52,14 +53,16 @@ import eu.esdihumboldt.util.Pair;
  * @author Simon Templer
  */
 @SuppressWarnings("restriction")
-public class TypeSelectionPage extends InstanceReaderConfigurationPage implements
-		ShapefileConstants {
+public class TypeSelectionPage extends InstanceReaderConfigurationPage
+		implements ShapefileConstants {
 
 	private TypeDefinitionSelector selector;
 
 	private LocatableInputSupplier<? extends InputStream> lastSource;
 
 	private TypeDefinition lastType;
+
+	private Button matchShortPropertyNames;
 
 	private Composite page;
 
@@ -109,6 +112,12 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 				}
 			});
 
+			matchShortPropertyNames = new Button(page, SWT.CHECK);
+			matchShortPropertyNames.setLayoutData(
+					GridDataFactory.fillDefaults().grab(false, false).span(2, 1).create());
+			matchShortPropertyNames.setText(
+					"Match shortened property names in Shapefile to target type properties");
+
 			page.layout();
 			page.pack();
 		}
@@ -125,9 +134,8 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 				// try to find a candidate for default selection
 				if (lastType != null) {
 					Pair<TypeDefinition, Integer> pt = ShapeInstanceReader
-							.getMostCompatibleShapeType(
-									getWizard().getProvider().getSourceSchema(), lastType, lastType
-											.getName().getLocalPart());
+							.getMostCompatibleShapeType(getWizard().getProvider().getSourceSchema(),
+									lastType, lastType.getName().getLocalPart());
 					if (pt != null) {
 						selector.setSelection(new StructuredSelection(pt.getFirst()));
 					}
@@ -217,6 +225,8 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 		if (selector.getSelectedObject() != null) {
 			QName name = selector.getSelectedObject().getName();
 			provider.setParameter(PARAM_TYPENAME, Value.of(name.toString()));
+			provider.setParameter(PARAM_MATCH_SHORT_PROPERTY_NAMES,
+					Value.of(matchShortPropertyNames.getSelection()));
 		}
 		else {
 			return false;

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/.classpath
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/.settings/org.eclipse.jdt.core.prefs
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,3 @@
-#Updated from default preferences Jul 24, 2013 2:15:12 PM
-#Wed Jul 24 14:15:12 CEST 2013
 eclipse.preferences.version=1
 org.eclipse.jdt.core.builder.cleanOutputFolder=clean
 org.eclipse.jdt.core.builder.duplicateResourceTask=warning
@@ -20,9 +18,9 @@ org.eclipse.jdt.core.codeComplete.staticFieldSuffixes=
 org.eclipse.jdt.core.codeComplete.staticFinalFieldPrefixes=
 org.eclipse.jdt.core.codeComplete.staticFinalFieldSuffixes=
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -107,7 +105,7 @@ org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete=disa
 org.eclipse.jdt.core.compiler.problem.unusedPrivateMember=warning
 org.eclipse.jdt.core.compiler.problem.unusedWarningToken=warning
 org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast=warning
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Shapefile Schema/Instance I/O
 Bundle-SymbolicName: eu.esdihumboldt.hale.io.shp;singleton:=true
 Bundle-Version: 3.5.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.google.common.collect;version="15.0.0",
  com.google.common.io;version="17.0.0",
  com.vividsolutions.jts,
@@ -43,4 +43,4 @@ Require-Bundle: org.geotools;bundle-version="2.6.4",
 Export-Package: eu.esdihumboldt.hale.io.shp,
  eu.esdihumboldt.hale.io.shp.internal;x-internal:=true,
  eu.esdihumboldt.hale.io.shp.reader.internal;x-internal:=true
-Bundle-Vendor: data harmonisation panel
+Bundle-Vendor: wetransform GmbH

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/plugin.xml
@@ -52,6 +52,23 @@
                      class="java.lang.String">
                </parameterBinding>
          </providerParameter>
+         <providerParameter
+               description="Match property names in Shapefile to target type properties by checking if there is exactly one target type 
+               		property name that starts with the Shapefile property name. If there are multiple property names in the target type
+               		that start with the Shapefile property name, the property will not be imported."
+               label="Match short property names"
+               name="matchShortPropertyNames"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.Boolean">
+            </parameterBinding>
+            <valueDescriptor
+                  default="false"
+                  defaultDescription="By default a source property will only be imported if there is an exact match to a target type property"
+                  sample="true"
+                  sampleDescription="Activate the matching of short property names">
+            </valueDescriptor>
+         </providerParameter>
       </provider>
    </extension>
    <extension

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/ShapefileConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/ShapefileConstants.java
@@ -57,4 +57,12 @@ public interface ShapefileConstants {
 	 */
 	public static final String PARAM_TYPENAME = "typename";
 
+	/**
+	 * Name of the parameter for {@link ShapeInstanceReader} to activate
+	 * matching of Shapefile property names to schema property names by checking
+	 * if there is exactly one schema property whose name starts with the
+	 * Shapefile property name.
+	 */
+	public static final String PARAM_MATCH_SHORT_PROPERTY_NAMES = "matchShortPropertyNames";
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapeInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapeInstanceReader.java
@@ -161,7 +161,7 @@ public class ShapeInstanceReader extends AbstractInstanceReader implements Shape
 				type = getSourceSchema().getType(typeName);
 			}
 			boolean matchShortParameterNames = getParameter(PARAM_MATCH_SHORT_PROPERTY_NAMES)
-					.as(Boolean.class);
+					.as(Boolean.class, false);
 			collections.put(type, new ShapesInstanceCollection(features, type, getCrsProvider(),
 					name.getLocalPart(), matchShortParameterNames));
 		}

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapeInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapeInstanceReader.java
@@ -118,8 +118,8 @@ public class ShapeInstanceReader extends AbstractInstanceReader implements Shape
 		if (defaultType == null) {
 			// check if typename was supplied w/o namespace
 			try {
-				defaultType = getSourceSchema().getType(
-						new QName(ShapefileConstants.SHAPEFILE_NS, typename));
+				defaultType = getSourceSchema()
+						.getType(new QName(ShapefileConstants.SHAPEFILE_NS, typename));
 			} catch (Exception e) {
 				// ignore
 				// TODO report?
@@ -160,9 +160,10 @@ public class ShapeInstanceReader extends AbstractInstanceReader implements Shape
 				QName typeName = new QName(ShapefileConstants.SHAPEFILE_NS, name.getLocalPart());
 				type = getSourceSchema().getType(typeName);
 			}
-
+			boolean matchShortParameterNames = getParameter(PARAM_MATCH_SHORT_PROPERTY_NAMES)
+					.as(Boolean.class);
 			collections.put(type, new ShapesInstanceCollection(features, type, getCrsProvider(),
-					name.getLocalPart()));
+					name.getLocalPart(), matchShortParameterNames));
 		}
 
 		instances = new PerTypeInstanceCollection(collections);
@@ -196,8 +197,8 @@ public class ShapeInstanceReader extends AbstractInstanceReader implements Shape
 		TypeDefinition maxType = null;
 
 		// check preferred name first
-		TypeDefinition preferredType = types.getType(new QName(ShapefileConstants.SHAPEFILE_NS,
-				preferredName));
+		TypeDefinition preferredType = types
+				.getType(new QName(ShapefileConstants.SHAPEFILE_NS, preferredName));
 		if (preferredType != null) {
 			int comp = checkCompatibility(preferredType, dataType);
 			if (comp >= 100) {

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/reader/internal/ShapesInstanceCollection.java
@@ -17,10 +17,13 @@
 package eu.esdihumboldt.hale.io.shp.reader.internal;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
@@ -55,6 +58,7 @@ import eu.esdihumboldt.hale.common.instance.model.impl.DefaultInstance;
 import eu.esdihumboldt.hale.common.instance.model.impl.FilteredInstanceCollection;
 import eu.esdihumboldt.hale.common.instance.model.impl.PseudoInstanceReference;
 import eu.esdihumboldt.hale.common.schema.geometry.CRSDefinition;
+import eu.esdihumboldt.hale.common.schema.model.ChildDefinition;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.io.shp.ShapefileConstants;
 
@@ -123,13 +127,32 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 						property.getName().getLocalPart());
 
 				if (type.getChild(propertyName) == null) {
-					if (!missingProperties.contains(propertyName)) {
-						log.warn("Discarding values of property " + propertyName.getLocalPart()
-								+ " as it is not contained in the schema type.");
-						missingProperties.add(propertyName);
+					final QName currentPropertyName = propertyName;
+					List<? extends ChildDefinition<?>> candidates = new ArrayList<>();
+					if (matchShortPropertyNames) {
+						// Try to guess the property name in cases where the
+						// names in the source file are shortened versions of
+						// the target type properties
+
+						candidates = type.getChildren().stream()
+								.filter(c -> c.getName().getLocalPart()
+										.startsWith(currentPropertyName.getLocalPart()))
+								.collect(Collectors.toList());
 					}
-					// only add values for properties contained in the type
-					continue;
+					if (candidates.size() == 1) {
+						// unique child property found whose name starts with
+						// the source property's name
+						propertyName = candidates.get(0).getName();
+					}
+					else {
+						if (!missingProperties.contains(propertyName)) {
+							log.warn("Discarding values of property " + propertyName.getLocalPart()
+									+ " as it is not contained in the schema type.");
+							missingProperties.add(propertyName);
+						}
+						// only add values for properties contained in the type
+						continue;
+					}
 				}
 
 				// wrap geometry
@@ -236,6 +259,7 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 	private final TypeDefinition type;
 	private final SimpleFeatureSource source;
 	private final String fileName;
+	private final boolean matchShortPropertyNames;
 
 	/**
 	 * Cache for resolved CRSs
@@ -250,13 +274,17 @@ public class ShapesInstanceCollection implements InstanceCollection2 {
 	 * @param crsProvider CRS provider in case no CRS is specified, may be
 	 *            <code>null</code>
 	 * @param fileName the file name to store in the augmented property
+	 * @param matchShortPropertyNames if true try to check if Shapefile property
+	 *            names are shortened versions of target type property names and
+	 *            match accordingly
 	 */
 	public ShapesInstanceCollection(SimpleFeatureSource features, TypeDefinition type,
-			CRSProvider crsProvider, String fileName) {
+			CRSProvider crsProvider, String fileName, boolean matchShortPropertyNames) {
 		this.source = features;
 		this.type = type;
 		this.crsProvider = crsProvider;
 		this.fileName = fileName;
+		this.matchShortPropertyNames = matchShortPropertyNames;
 	}
 
 	/**


### PR DESCRIPTION
This adds an option to the Shapefile importer to try to match its property names to a target type property by checking if there is exactly one target type property name that starts with the Shapefile property name. 

In case such a property exists (e.g. `beschreibu` in the Shapefile and `beschreibung` in the target type) the source property will be imported to the target property. 

In case of multiple property names in the target type that start with the Shapefile property name, the property will not be imported.

This behaviour is deactivated by default and can be activated by the new Shapefile reader parameter `matchShortPropertyNames`.