### PR TITLE
Support XSD types with <xs:all>

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/type/IgnoreOrderFlag.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/type/IgnoreOrderFlag.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.schema.model.constraint.type;
+
+import eu.esdihumboldt.hale.common.schema.model.Constraint;
+import eu.esdihumboldt.hale.common.schema.model.TypeConstraint;
+import eu.esdihumboldt.hale.common.schema.model.constraint.AbstractFlagConstraint;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Specifies if the order of the immediate children of the type should be
+ * ignored, e.g. in case the <code>&lt;complexContent&gt;</code> is composed of
+ * <code>&lt;all&gt;</code> instead of <code>&lt;sequence&gt;</code>.
+ * 
+ * @author Florian Esser
+ */
+@Immutable
+@Constraint
+public class IgnoreOrderFlag extends AbstractFlagConstraint implements TypeConstraint {
+
+	/**
+	 * Enabled flag
+	 */
+	public static final IgnoreOrderFlag ENABLED = new IgnoreOrderFlag(true);
+
+	/**
+	 * Disabled flag
+	 */
+	public static final IgnoreOrderFlag DISABLED = new IgnoreOrderFlag(false);
+
+	/**
+	 * Get a flag instance
+	 * 
+	 * @param hasValue if the flag shall be enabled
+	 * @return the flag
+	 */
+	public static IgnoreOrderFlag get(boolean hasValue) {
+		return hasValue ? ENABLED : DISABLED;
+	}
+
+	/**
+	 * Creates a default flag, which is disabled. If possible, instead of
+	 * creating an instance, use {@link #ENABLED} or {@link #DISABLED}.
+	 * 
+	 * @see Constraint
+	 */
+	public IgnoreOrderFlag() {
+		this(false);
+	}
+
+	private IgnoreOrderFlag(boolean enabled) {
+		super(enabled);
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.common.schema.model.TypeConstraint#isInheritable()
+	 */
+	@Override
+	public boolean isInheritable() {
+		// TODO This depends on the XSD version used. In XSD 1.0, extending a
+		// type that uses `xs:all` is not allowed but that restriction was
+		// lifted in XSD 1.1 (see https://stackoverflow.com/a/62376539).
+		return true;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+
+<items xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="allgroup.xsd">
+	<umbrella>Some umbrella</umbrella>
+	<hat>And hat</hat>
+	<shirt>Some shirt</shirt>
+</items>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xsd
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/data/allgroup/allgroup.xsd
@@ -1,0 +1,13 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="items" type="ItemsType"/>
+
+  <xs:complexType name="ItemsType">
+    <xs:all>
+      <xs:element name="shirt" type="xs:string"/>
+      <xs:element name="hat" type="xs:string"/>
+      <xs:element name="umbrella" type="xs:string"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollectionTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.test/src/eu/esdihumboldt/hale/io/gml/reader/internal/GmlInstanceCollectionTest.java
@@ -274,6 +274,47 @@ public class GmlInstanceCollectionTest {
 	}
 
 	/**
+	 * Test loading a simple XML file with one instance including an <xs:all>
+	 * group.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testLoadAllGroup() throws Exception {
+		GmlInstanceCollection instances = loadInstances(
+				getClass().getResource("/data/allgroup/allgroup.xsd").toURI(),
+				getClass().getResource("/data/allgroup/allgroup.xml").toURI(), false, false, false);
+
+		ResourceIterator<Instance> it = instances.iterator();
+		try {
+			assertTrue(it.hasNext());
+
+			Instance instance = it.next();
+			assertNotNull(instance);
+
+			Object[] umbrella = instance.getProperty(new QName("umbrella"));
+			assertNotNull(umbrella);
+			assertEquals(1, umbrella.length);
+			assertEquals("Some umbrella", umbrella[0]);
+
+			Object[] shirt = instance.getProperty(new QName("shirt"));
+			assertNotNull(shirt);
+			assertEquals(1, shirt.length);
+			assertEquals("Some shirt", shirt[0]);
+
+			Object[] hat = instance.getProperty(new QName("hat"));
+			assertNotNull(hat);
+			assertEquals(1, hat.length);
+			assertEquals("And hat", hat[0]);
+
+			// only one object
+			assertFalse(it.hasNext());
+		} finally {
+			it.close();
+		}
+	}
+
+	/**
 	 * Test loading a simple XML file with one instance including a choice and a
 	 * sub-choice.
 	 * 
@@ -335,7 +376,7 @@ public class GmlInstanceCollectionTest {
 		GmlInstanceCollection instances = loadInstances(
 				getClass().getResource("/data/sample_wva/wfs_va.xsd").toURI(),
 				getClass().getResource("/data/sample_wva/wfs_va_sample_namespace.gml").toURI(),
-				true, true);
+				true, true, true);
 
 		testWVAInstances(instances);
 	}
@@ -467,12 +508,12 @@ public class GmlInstanceCollectionTest {
 
 	private GmlInstanceCollection loadInstances(URI schemaLocation, URI xmlLocation,
 			boolean restrictToFeatures) throws IOException, IOProviderConfigurationException {
-		return loadInstances(schemaLocation, xmlLocation, restrictToFeatures, true);
+		return loadInstances(schemaLocation, xmlLocation, restrictToFeatures, true, true);
 	}
 
 	private GmlInstanceCollection loadInstances(URI schemaLocation, URI xmlLocation,
-			boolean restrictToFeatures, boolean ignoreNamespace)
-					throws IOException, IOProviderConfigurationException {
+			boolean restrictToFeatures, boolean ignoreNamespace, boolean strict)
+			throws IOException, IOProviderConfigurationException {
 		SchemaReader reader = new XmlSchemaReader();
 		reader.setSharedTypes(null);
 		reader.setSource(new DefaultInputSupplier(schemaLocation));
@@ -481,7 +522,7 @@ public class GmlInstanceCollectionTest {
 		Schema sourceSchema = reader.getSchema();
 
 		return new GmlInstanceCollection(new DefaultInputSupplier(xmlLocation), sourceSchema,
-				restrictToFeatures, false, true, ignoreNamespace, null, reader);
+				restrictToFeatures, false, strict, ignoreNamespace, null, reader);
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
@@ -41,6 +41,7 @@ import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.Cardinality;
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.ChoiceFlag;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.IgnoreOrderFlag;
 import eu.esdihumboldt.hale.io.xsd.constraint.XmlAttributeFlag;
 
 /**
@@ -511,8 +512,10 @@ public class GroupUtil {
 			// type
 			TypeDefinition typeDef = (TypeDefinition) def;
 
-			// check order
-			if (!allowAddCheckOrder(group, propertyName, typeDef)) {
+			// check order unless IgnoreOrderFlag is set (e.g. in case of an
+			// <xs:all> group)
+			if (!typeDef.getConstraint(IgnoreOrderFlag.class).isEnabled()
+					&& !allowAddCheckOrder(group, propertyName, typeDef)) {
 				return false;
 			}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd.test/src/testdata/definitive/allgroup.xsd
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd.test/src/testdata/definitive/allgroup.xsd
@@ -1,0 +1,12 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="items" type="ItemsType"/>
+
+  <xs:complexType name="ItemsType">
+    <xs:all>
+      <xs:element name="name" type="xs:string" minOccurs="0"/>
+      <xs:element name="id" type="xs:ID"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/XmlSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/XmlSchemaReader.java
@@ -33,6 +33,7 @@ import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.ws.commons.schema.XmlSchema;
+import org.apache.ws.commons.schema.XmlSchemaAll;
 import org.apache.ws.commons.schema.XmlSchemaAnnotated;
 import org.apache.ws.commons.schema.XmlSchemaAny;
 import org.apache.ws.commons.schema.XmlSchemaAppInfo;
@@ -94,6 +95,7 @@ import eu.esdihumboldt.hale.common.schema.model.constraint.property.NillableFlag
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.AbstractFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.Enumeration;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.HasValueFlag;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.IgnoreOrderFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.MappableFlag;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.MappingRelevantFlag;
 import eu.esdihumboldt.hale.common.schema.model.impl.AbstractDefinition;
@@ -993,6 +995,59 @@ public class XmlSchemaReader extends AbstractSchemaReader {
 				}
 			}
 			// </sequence>
+		}
+		else if (particle instanceof XmlSchemaAll) {
+			// <all>
+			XmlSchemaAll all = (XmlSchemaAll) particle;
+
+			// Declaring group must be the type, <all> groups can't be
+			// children of other groups.
+			if (!(declaringGroup instanceof XmlTypeDefinition)) {
+				reporter.error(
+						"<xs:all> groups that are not immediate children of a type definition are not allowed.");
+				return;
+			}
+
+			XmlTypeDefinition type = (XmlTypeDefinition) declaringGroup;
+			type.setConstraint(IgnoreOrderFlag.ENABLED);
+
+			// create group only if necessary (sequences that appear exactly
+			// once will result in no group if not forced)
+			if (forceGroup || all.getMinOccurs() != 1 || all.getMaxOccurs() != 1) {
+				// create a sequence group
+				QName sequenceName = createGroupName(declaringGroup, "all");
+				DefaultGroupPropertyDefinition sequenceGroup = new DefaultGroupPropertyDefinition(
+						sequenceName, declaringGroup, false);
+				// set cardinality
+				long max = (all.getMaxOccurs() == Long.MAX_VALUE) ? (Cardinality.UNBOUNDED)
+						: (all.getMaxOccurs());
+				sequenceGroup.setConstraint(Cardinality.get(all.getMinOccurs(), max));
+				// set choice constraint (no choice)
+				sequenceGroup.setConstraint(ChoiceFlag.DISABLED);
+				// set metadata
+				setMetadata(sequenceGroup, all, schemaLocation);
+
+				// use group as parent
+				declaringGroup = sequenceGroup;
+			}
+
+			for (int j = 0; j < all.getItems().getCount(); j++) {
+				XmlSchemaObject object = all.getItems().getItem(j);
+				if (object instanceof XmlSchemaElement) {
+					// <element>
+					createPropertyFromElement((XmlSchemaElement) object, declaringGroup,
+							schemaLocation, schemaNamespace);
+					// </element>
+				}
+				else if (object instanceof XmlSchemaParticle) {
+					// contained particles, e.g. a choice
+					// content doesn't need to be grouped, it can be decided in
+					// the method
+					createPropertiesFromParticle(declaringGroup, (XmlSchemaParticle) object,
+							schemaLocation, schemaNamespace, false);
+				}
+			}
+			// </all>
 		}
 		else if (particle instanceof XmlSchemaChoice) {
 			// <choice>


### PR DESCRIPTION
Add support for <xs:all> in addition to <xs:choice> and <xs:sequence> in the XML schema reader (see #467). This PR replaces #624.

Changed the implementation to use a type-based constraint rather than a group-based constraint b/c in most practical cases the `<xs:all>` group will be removed and the constraint won't be available.
