### PR TITLE
Enable software updates from remote p2 repositories

### DIFF
--- a/platform/hale-platform.target
+++ b/platform/hale-platform.target
@@ -18,6 +18,12 @@
 <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="2.9.1.201705291011"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
 <repository location="http://build-artifacts.wetransform.to/p2/mirror/photon-releases"/>
+	<unit id="org.eclipse.ecf.core.feature.feature.group" version="1.5.0.v20180426-1936"/>
+	<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.100.v20180301-0201"/>
+	<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.0.v20180306-0429"/>
+	<unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.14.0.v20180301-0132"/>
+	<unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.100.v20180301-0132"/>
+	<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.100.v20180301-0132"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>

--- a/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
@@ -60,7 +60,6 @@ https://www.wetransform.to/services/support/
    <launcher name="HALE">
       <linux icon="/eu.esdihumboldt.hale.ui.application/images/hale.xpm"/>
       <macosx icon="/eu.esdihumboldt.hale.ui.application/images/hale.icns"/>
-      <solaris/>
       <win useIco="true">
          <ico path="/eu.esdihumboldt.hale.ui.application/images/hale.ico"/>
          <bmp/>
@@ -108,6 +107,7 @@ https://www.wetransform.to/services/support/
       <feature id="eu.esdihumboldt.hale.io.feature.msaccess"/>
       <feature id="eu.esdihumboldt.hale.io.feature.mssql"/>
       <feature id="eu.esdihumboldt.hale.io.feature.deegree"/>
+      <feature id="org.eclipse.equinox.p2.core.feature"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
This PR adds to HALE support for remote software updates.

To achieve this, a few features from the [ECF framework](https://www.eclipse.org/ecf/) have been added to HALE's target platform, and the feature `org.eclipse.equinox.p2.core.feature` has been added to `HALE.product`.

Remote updates have been manually tested using a HALE build incorporating the changes in this PR. 

Related forum discussion is [here](https://discuss.wetransform.to/#/thread/i15b/Installing-new-features-from-remote-p2-update-sites).