### PR TITLE
Add missing entries to artifact map so Maven artifacts can be verified.

### DIFF
--- a/build/bundleArtifactMap.json
+++ b/build/bundleArtifactMap.json
@@ -150,7 +150,9 @@
         "group": "commons-codec",
         "name": "commons-codec",
         "versions": {
-            "1.6.0.i20150413": "1.6"
+            "1.6.0.i20150413": "1.6",
+            "1.7.0.i20180427": "1.7",
+            "1.9.0.v20170208-1614": "1.9"
         }
     },
     "org.apache.commons.configuration": {


### PR DESCRIPTION
Fixes build problem introduced w/ #691 