### PR TITLE
refactor(io): initialize HaleConnectService with default settings

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/internal/HaleConnectUIPlugin.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/internal/HaleConnectUIPlugin.java
@@ -26,7 +26,6 @@ import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectService;
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices;
 import eu.esdihumboldt.hale.io.haleconnect.ui.preferences.PreferenceConstants;
-import eu.esdihumboldt.hale.io.haleconnect.ui.preferences.PreferenceInitializer;
 import eu.esdihumboldt.hale.ui.HaleUI;
 
 /**
@@ -72,13 +71,13 @@ public class HaleConnectUIPlugin extends AbstractUIPlugin {
 			if (useDefaults) {
 				// Force default values
 				hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
-						PreferenceInitializer.HALE_CONNECT_BASEPATH_USERS_DEFAULT);
+						HaleConnectServices.HALE_CONNECT_BASEPATH_USERS_DEFAULT);
 				hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
-						PreferenceInitializer.HALE_CONNECT_BASEPATH_DATA_DEFAULT);
+						HaleConnectServices.HALE_CONNECT_BASEPATH_DATA_DEFAULT);
 				hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
-						PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT);
+						HaleConnectServices.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT);
 				hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
-						PreferenceInitializer.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT);
+						HaleConnectServices.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT);
 			}
 			else {
 				hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/HaleConnectExtendedPreferencePage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/HaleConnectExtendedPreferencePage.java
@@ -81,14 +81,7 @@ public class HaleConnectExtendedPreferencePage extends FieldEditorPreferencePage
 
 		if (defaults.getBooleanValue()) {
 			// Force default values
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.USER_SERVICE,
-					PreferenceInitializer.HALE_CONNECT_BASEPATH_USERS_DEFAULT);
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.BUCKET_SERVICE,
-					PreferenceInitializer.HALE_CONNECT_BASEPATH_DATA_DEFAULT);
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.PROJECT_STORE,
-					PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT);
-			hcs.getBasePathManager().setBasePath(HaleConnectServices.WEB_CLIENT,
-					PreferenceInitializer.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT);
+			hcs.getBasePathManager().setDefaults();
 		}
 		else {
 			// Use individually configured values

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/preferences/PreferenceInitializer.java
@@ -1,5 +1,10 @@
 package eu.esdihumboldt.hale.io.haleconnect.ui.preferences;
 
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_BASEPATH_CLIENT_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_BASEPATH_DATA_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_BASEPATH_USERS_DEFAULT;
+
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -9,26 +14,6 @@ import eu.esdihumboldt.hale.io.haleconnect.ui.internal.HaleConnectUIPlugin;
  * Class used to initialize default preference values.
  */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
-
-	/**
-	 * Default base path of the hale connect user service
-	 */
-	public static String HALE_CONNECT_BASEPATH_USERS_DEFAULT = "https://haleconnect.com/accounts/v1";
-
-	/**
-	 * Default base path of the hale connect project store
-	 */
-	public static final String HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT = "https://haleconnect.com/store/projects";
-
-	/**
-	 * Default base path of the hale connect bucket service
-	 */
-	public static final String HALE_CONNECT_BASEPATH_DATA_DEFAULT = "https://haleconnect.com/store/data";
-
-	/**
-	 * Default base path of the hale connect web client
-	 */
-	public static final String HALE_CONNECT_BASEPATH_CLIENT_DEFAULT = "https://www.haleconnect.com/#";
 
 	/*
 	 * (non-Javadoc)

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.groovy
@@ -57,7 +57,6 @@ import eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices
 import eu.esdihumboldt.hale.io.haleconnect.HaleConnectUserInfo
 import eu.esdihumboldt.hale.io.haleconnect.Owner
 import eu.esdihumboldt.hale.io.haleconnect.OwnerType
-import eu.esdihumboldt.hale.io.haleconnect.ui.preferences.PreferenceInitializer
 import eu.esdihumboldt.hale.ui.HaleUI
 import eu.esdihumboldt.hale.ui.util.wizard.ConfigurationWizard
 import eu.esdihumboldt.hale.ui.util.wizard.ConfigurationWizardPage;
@@ -136,7 +135,7 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 							String configuredBasePath = haleConnect.getBasePathManager()
 									.getBasePath(HaleConnectServices.PROJECT_STORE);
 							if (configuredBasePath
-							.equals(PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT)) {
+							.equals(HaleConnectServices.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT)) {
 								log.userError(
 										"Unable to connect to hale connect, please check your network connection.",
 										t);
@@ -147,7 +146,7 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 										MessageFormat.format(
 										"Unable to connect to hale connect, please check your network connection.\n\nNote that the configured project store base path ({0}) differs from the default value ({1}), which may also be the cause of this error.",
 										configuredBasePath,
-										PreferenceInitializer.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT),
+										HaleConnectServices.HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT),
 										t);
 							}
 
@@ -251,7 +250,8 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 
 		List<OwnerFilterEntry> availableFilters = new ArrayList<>();
 		availableFilters.add(NULL_FILTER);
-		availableFilters.add(new OwnerFilterEntry(owner: [new Owner(type: OwnerType.USER, id: haleConnect.getSession().getUserId())] as Owner[] , label: "My projects"));
+		availableFilters.add(new OwnerFilterEntry(owner: [
+			new Owner(type: OwnerType.USER, id: haleConnect.getSession().getUserId())] as Owner[] , label: "My projects"));
 
 		List<Owner> orgs = new ArrayList<>();
 		for (String orgId : haleConnect.getSession().getOrganisationIds()) {
@@ -435,7 +435,9 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 
 		} catch (HaleConnectException e1) {
 			log.error(e1.getMessage(), e1);
-			projects.setInput(["Error retrieving projects from hale connect."]);
+			projects.setInput([
+				"Error retrieving projects from hale connect."
+			]);
 		}
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/BasePathManager.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/BasePathManager.java
@@ -15,6 +15,16 @@
 
 package eu.esdihumboldt.hale.io.haleconnect;
 
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.BUCKET_SERVICE;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_BASE_URL_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_PATH_CLIENT_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_PATH_DATA_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_PATH_PROJECTS_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.HALE_CONNECT_PATH_USERS_DEFAULT;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.PROJECT_STORE;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.USER_SERVICE;
+import static eu.esdihumboldt.hale.io.haleconnect.HaleConnectServices.WEB_CLIENT;
+
 /**
  * Interface for hale connect base path managers.
  * 
@@ -31,4 +41,26 @@ public interface BasePathManager extends BasePathResolver {
 	 * @param basePath Base path to set
 	 */
 	void setBasePath(String service, String basePath);
+
+	/**
+	 * Set the base URL for a hale connect installation, assuming it uses the
+	 * default paths for services.
+	 * 
+	 * @param baseUrl the base URL for the installation, e.g.
+	 *            {@value HaleConnectServices#HALE_CONNECT_BASE_URL_DEFAULT}
+	 */
+	default void setBaseUrl(String baseUrl) {
+		setBasePath(USER_SERVICE, baseUrl + HALE_CONNECT_PATH_USERS_DEFAULT);
+		setBasePath(BUCKET_SERVICE, baseUrl + HALE_CONNECT_PATH_DATA_DEFAULT);
+		setBasePath(PROJECT_STORE, baseUrl + HALE_CONNECT_PATH_PROJECTS_DEFAULT);
+		setBasePath(WEB_CLIENT, baseUrl + HALE_CONNECT_PATH_CLIENT_DEFAULT);
+	}
+
+	/**
+	 * Set the default base paths for using haleconnect.com
+	 */
+	default void setDefaults() {
+		setBaseUrl(HALE_CONNECT_BASE_URL_DEFAULT);
+	}
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectServices.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectServices.java
@@ -46,4 +46,54 @@ public interface HaleConnectServices {
 	 * Project service
 	 */
 	public static String PROJECT_SERVICE = "project-service";
+
+	/**
+	 * Default base URL of hale connect
+	 */
+	public static final String HALE_CONNECT_BASE_URL_DEFAULT = "https://haleconnect.com";
+
+	/**
+	 * Default path of the hale connect user service
+	 */
+	public static final String HALE_CONNECT_PATH_USERS_DEFAULT = "/accounts/v1";
+
+	/**
+	 * Default path of the hale connect project store
+	 */
+	public static final String HALE_CONNECT_PATH_PROJECTS_DEFAULT = "/store/projects";
+
+	/**
+	 * Default path of the hale connect bucket service
+	 */
+	public static final String HALE_CONNECT_PATH_DATA_DEFAULT = "/store/data";
+
+	/**
+	 * Default path of the hale connect web client
+	 */
+	public static final String HALE_CONNECT_PATH_CLIENT_DEFAULT = "/#";
+
+	/**
+	 * Default base path of the hale connect user service
+	 */
+	public static final String HALE_CONNECT_BASEPATH_USERS_DEFAULT = HALE_CONNECT_BASE_URL_DEFAULT
+			+ HALE_CONNECT_PATH_USERS_DEFAULT;
+
+	/**
+	 * Default base path of the hale connect project store
+	 */
+	public static final String HALE_CONNECT_BASEPATH_PROJECTS_DEFAULT = HALE_CONNECT_BASE_URL_DEFAULT
+			+ HALE_CONNECT_PATH_PROJECTS_DEFAULT;
+
+	/**
+	 * Default base path of the hale connect bucket service
+	 */
+	public static final String HALE_CONNECT_BASEPATH_DATA_DEFAULT = HALE_CONNECT_BASE_URL_DEFAULT
+			+ HALE_CONNECT_PATH_DATA_DEFAULT;
+
+	/**
+	 * Default base path of the hale connect web client
+	 */
+	public static final String HALE_CONNECT_BASEPATH_CLIENT_DEFAULT = HALE_CONNECT_BASE_URL_DEFAULT
+			+ HALE_CONNECT_PATH_CLIENT_DEFAULT;
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/HaleConnectServiceImpl.groovy
@@ -78,6 +78,17 @@ public class HaleConnectServiceImpl implements HaleConnectService, BasePathManag
 	private HaleConnectSession session;
 
 	/**
+	 * Default constructor.
+	 */
+	public HaleConnectServiceImpl() {
+		super();
+
+		// store default values for base paths
+		// in the UI will this will be overridden in HaleConnectUIPlugin
+		getBasePathManager().setDefaults();
+	}
+
+	/**
 	 * @see eu.esdihumboldt.hale.io.haleconnect.HaleConnectService#addListener(eu.esdihumboldt.hale.io.haleconnect.HaleConnectServiceListener)
 	 */
 	@Override


### PR DESCRIPTION
Moved the constants for default values from UI components to HaleConnectServices and ensure the
HaleConnectService instance is created with the default settings. Also extended BasePathManager w/
convenience methods for setting a base URL and the default settings.