### PR TITLE
fix(ui): Prevent possible ClassCastException in TypeSrsCodeFilter

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.views.properties/src/eu/esdihumboldt/hale/ui/views/properties/definition/typedefinition/geometry/TypeSrsCodeFilter.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.views.properties/src/eu/esdihumboldt/hale/ui/views/properties/definition/typedefinition/geometry/TypeSrsCodeFilter.java
@@ -36,8 +36,12 @@ public class TypeSrsCodeFilter extends DefaultDefinitionFilter {
 		if (input instanceof PropertyDefinition) {
 			def = ((PropertyDefinition) input).getPropertyType();
 		}
-		else {
+		else if (input instanceof TypeDefinition) {
 			def = (TypeDefinition) input;
+		}
+		else {
+			def = null;
+			// TODO Log?
 		}
 		if (def != null) {
 			GeometryMetadata gm = def.getConstraint(GeometryMetadata.class);


### PR DESCRIPTION
This patch prevents a `ClassCastException` in case `input` is a `GroupPropertyDefinition`.