### PR TITLE
Inline transformations: Improve caching of Groovy scripts and fix exception when used in CLI

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/impl/ProjectTransformationEnvironment.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/impl/ProjectTransformationEnvironment.java
@@ -34,7 +34,9 @@ import eu.esdihumboldt.hale.common.align.service.TransformationFunctionService;
 import eu.esdihumboldt.hale.common.align.service.impl.AlignmentFunctionService;
 import eu.esdihumboldt.hale.common.align.service.impl.AlignmentTransformationFunctionService;
 import eu.esdihumboldt.hale.common.align.transformation.service.TransformationSchemas;
+import eu.esdihumboldt.hale.common.align.transformation.service.TransformationService;
 import eu.esdihumboldt.hale.common.codelist.service.CodeListRegistry;
+import eu.esdihumboldt.hale.common.core.HalePlatform;
 import eu.esdihumboldt.hale.common.core.io.HaleIO;
 import eu.esdihumboldt.hale.common.core.io.IOAdvisor;
 import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
@@ -211,6 +213,10 @@ public class ProjectTransformationEnvironment implements TransformationEnvironme
 			addService(ProjectInfoService.class, new FixedProjectInfoService(project, location));
 			// make code lists available
 			addService(CodeListRegistry.class, advisor.getCodeListRegistry());
+			// Make transformation service available, e.g. for inline
+			// transformations
+			addService(TransformationService.class,
+					HalePlatform.getService(TransformationService.class));
 
 			init(project);
 		}


### PR DESCRIPTION
The method of storing compiled scripts in the `ExecutionContext` of either the `TransformationFunction` or the `Cell` does not work in the case of inline transformations. If a property is mapped by an inline
transformation, a separate transformer instance is instantiated for every property value. As the `ConceptualSchemaTransformer` itself is stateless, the cached scripts do not get passed on and are recompiled for every property value, causing a significant slowdown (as reported in #575).

This new simple thread-local cache avoids this problem as long as the CSTs for the inline property transformations are all executed within the same thread.

A possible drawback is the increased memory usage as, over the course of a transformation run, every Groovy script will be cached. If this turns out to be a problem, it can be mitigated by using a more sophisticated cache implementantion with e.g. an upper memory limit.

@stempler Do you see any problems with this approach, especially not storing the cached script in the execution context but (thread-)globally?