### PR TITLE
fix(hsd): don't log error if constraint type can't be recreated

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/JsonToSchema.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/JsonToSchema.groovy
@@ -76,6 +76,15 @@ public class JsonToSchema {
 		}
 	}
 
+	protected void warn(String message, Throwable t = null) {
+		if (reporter) {
+			reporter.warn(new IOMessageImpl(message, t))
+		}
+		else {
+			log.warn(message, t)
+		}
+	}
+
 	/**
 	 * Read schemas from the given reader.
 	 * 
@@ -197,11 +206,11 @@ public class JsonToSchema {
 						Object constraint = desc.getFactory().restore(config, definition, typeProvider, classResolver)
 						definition.setConstraint(constraint)
 					} catch (Exception e) {
-						reporter.error(new IOMessageImpl("Failed to restore constraint of type $id", e))
+						error("Failed to restore constraint of type $id", e)
 					}
 				}
 				else {
-					reporter.error(new IOMessageImpl("Could not find factory for constraint with type $id"))
+					warn("Could not find factory for constraint with type $id")
 				}
 			}
 			else {


### PR DESCRIPTION
Sometimes a constraint in a hale schema definition cannot be recreated, e.g. because the plugin that defines the constraint is unavailable. To allow loading the HSD anyway, the message level is reduced to a warning.

https://github.com/halestudio/hale/issues/707