### PR TITLE
build: include AppSchema plugin update site by default

### DIFF
--- a/build/gradle/commitAndProductionStage.gradle
+++ b/build/gradle/commitAndProductionStage.gradle
@@ -942,6 +942,12 @@ task createProductFeature(dependsOn: [ generatePomFiles, makeProductFile, makePr
         into productFeaturePath
     }
 
+	new File("$productFeaturePath/HALE.p2.inf").text = '''
+instructions.configure=\
+  addRepository(location:http${#58}//hale-geoserver.geo-solutions.it/,type:0,name:GeoServer App-Schema Plug-in for hale studio,enabled:true);\
+  addRepository(location:http${#58}//hale-geoserver.geo-solutions.it/,type:1,name:GeoServer App-Schema Plug-in for hale studio,enabled:true);
+'''
+
     // remove platform-specific fragments from product
     // FIXME remove this once Tycho knows how to handle platform-specific
     // fragments on its own. See BUG 342890


### PR DESCRIPTION
Simple approach to add a `HALE.p2.inf` file with the AppSchema plugin update site

https://github.com/halestudio/hale/issues/715