### PR TITLE
fix(io): prevent bad IOConfiguration paths after hale connect export

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ShareProjectWizard.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ShareProjectWizard.java
@@ -31,6 +31,7 @@ import org.eclipse.ui.PlatformUI;
 
 import de.fhg.igd.slf4jplus.ALogger;
 import de.fhg.igd.slf4jplus.ALoggerFactory;
+import eu.esdihumboldt.hale.common.core.io.project.ProjectWriter.ProjectWriterMode;
 import eu.esdihumboldt.hale.io.haleconnect.project.HaleConnectProjectWriter;
 import eu.esdihumboldt.hale.ui.io.ExportWizard;
 import eu.esdihumboldt.hale.ui.io.IOWizard;
@@ -45,14 +46,11 @@ public class ShareProjectWizard extends ExportWizard<HaleConnectProjectWriter> {
 
 	private static final ALogger log = ALoggerFactory.getLogger(ShareProjectWizard.class);
 
-//	private final HaleConnectService haleConnect;
-
 	/**
 	 * Create the wizard
 	 */
 	public ShareProjectWizard() {
 		super(HaleConnectProjectWriter.class);
-//		this.haleConnect = HaleUI.getServiceProvider().getService(HaleConnectService.class);
 	}
 
 	@Override
@@ -67,6 +65,8 @@ public class ShareProjectWizard extends ExportWizard<HaleConnectProjectWriter> {
 
 	@Override
 	public boolean performFinish() {
+		getProvider().setWriterMode(ProjectWriterMode.EXPORT);
+
 		boolean result = super.performFinish();
 
 		if (result) {

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/project/HaleConnectProjectWriter.groovy
@@ -24,7 +24,9 @@ import eu.esdihumboldt.hale.common.core.HalePlatform;
 import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
 import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
 import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.common.core.io.project.ProjectWriter.ProjectWriterMode
 import eu.esdihumboldt.hale.common.core.io.project.impl.ArchiveProjectWriter;
+import eu.esdihumboldt.hale.common.core.io.project.model.IOConfiguration
 import eu.esdihumboldt.hale.common.core.io.project.model.Project;
 import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
@@ -192,6 +194,13 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		getProject().getProperties().put(HaleConnectProjectReader.HALECONNECT_URN_PROPERTY,
 				Value.of(projectUrn.toString()));
 
+		// save current IO configurations
+		List<IOConfiguration> oldResources = new ArrayList<IOConfiguration>();
+		for (IOConfiguration config : getProject().getResources()) {
+			// clone all IO configurations to work on different objects
+			oldResources.add(config.clone());
+		}
+
 		// redirect project archive to temporary local file
 		File projectArchive = Files.createTempFile("hc-arc", ".zip").toFile();
 		IOReport report;
@@ -199,6 +208,12 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 		if (!report.isSuccess()) {
 			// exit when creating project archive failed
 			return report;
+		}
+
+		// Restore previous IO configurations if we are in EXPORT mode
+		if (writerMode == ProjectWriterMode.EXPORT) {
+			getProject().getResources().clear()
+			getProject().getResources().addAll(oldResources);
 		}
 
 		String projectId = HaleConnectUrnBuilder.extractProjectId(projectUrn);
@@ -277,6 +292,15 @@ public class HaleConnectProjectWriter extends ArchiveProjectWriter {
 	@Override
 	public ProjectWriterMode getLastWriterMode() {
 		return writerMode;
+	}
+
+	/**
+	 * Set the writer mode to be used in the next operation
+	 * 
+	 * @param mode Writer mode to use
+	 */
+	public void setWriterMode(ProjectWriterMode mode) {
+		this.writerMode = mode;
 	}
 
 	/**


### PR DESCRIPTION
When exporting a project to hale connect, the resource URIs in the `IOConfiguration` would point to the temporary location where the project archive for the hc upload was assembled. These temporary paths would then be persisted if the project was subsequently saved locally. It would also lose all source data configurations if the hc upload did not contain source data.

This patch prevents this by restoring the `IOConfiguration`s if the project is exported to hale connect (i.e. `HaleConnectProjectWriter` is run in `EXPORT` mode).

#642