### PR TITLE
fix(headless): also filter OInstances when object to match is decorated

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/transform/Transformation.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/transform/Transformation.java
@@ -67,6 +67,7 @@ import eu.esdihumboldt.hale.common.instance.model.Filter;
 import eu.esdihumboldt.hale.common.instance.model.Instance;
 import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
 import eu.esdihumboldt.hale.common.instance.model.impl.FilteredInstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.impl.InstanceDecorator;
 import eu.esdihumboldt.hale.common.instance.model.impl.MultiInstanceCollection;
 import eu.esdihumboldt.hale.common.instance.orient.OInstance;
 import eu.esdihumboldt.hale.common.instance.orient.storage.BrowseOrientInstanceCollection;
@@ -365,8 +366,12 @@ public class Transformation {
 
 						@Override
 						public boolean match(Instance instance) {
-							if (instance instanceof OInstance) {
-								return ((OInstance) instance).isInserted();
+							Instance inst = (instance instanceof InstanceDecorator)
+									? InstanceDecorator.getRoot(instance)
+									: instance;
+
+							if (inst instanceof OInstance) {
+								return ((OInstance) inst).isInserted();
 							}
 							return true;
 						}


### PR DESCRIPTION
With this patch not-inserted instances are also filtered out if the matched object is decorated. This is the case e.g. when the instance was created by an `InlineTransformation`. Such instances were not filtered out before and were written twice in GML serialization.

#575 