### PR TITLE
Support joins of float and integer properties

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance.index/src/eu/esdihumboldt/hale/common/instance/index/InstanceIndexUtil.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.index/src/eu/esdihumboldt/hale/common/instance/index/InstanceIndexUtil.java
@@ -69,6 +69,20 @@ public abstract class InstanceIndexUtil {
 				// use string representation for integer numbers
 				value = value.toString();
 			}
+			else if (value instanceof Double) {
+				Double d = (Double) value;
+				if (isInteger(d)) {
+					// use string representation for integer double
+					value = Integer.toString(d.intValue());
+				}
+			}
+			else if (value instanceof Float) {
+				Float f = (Float) value;
+				if (isInteger(f)) {
+					// use string representation for integer float
+					value = Integer.toString(f.intValue());
+				}
+			}
 			else if (value instanceof BigDecimal) {
 				BigDecimal v = (BigDecimal) value;
 				if (v.scale() <= 0) {
@@ -88,4 +102,11 @@ public abstract class InstanceIndexUtil {
 		return value;
 	}
 
+	private static boolean isInteger(Double d) {
+		return Math.floor(d) == d && !Double.isNaN(d) && !Double.isInfinite(d);
+	}
+
+	private static boolean isInteger(Float f) {
+		return Math.floor(f) == f && !Float.isNaN(f) && !Float.isInfinite(f);
+	}
 }

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/internal/ConceptualSchemaTransformerTest.java
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/internal/ConceptualSchemaTransformerTest.java
@@ -333,6 +333,17 @@ public class ConceptualSchemaTransformerTest extends DefaultTransformationTest {
 		testTransform(TransformationExamples.getExample(TransformationExamples.PROPERTY_JOIN_2));
 	}
 
+	/**
+	 * Test based on a join w/ a comparison between an integer and a float
+	 * 
+	 * @throws Exception if an error occurs executing the test
+	 */
+	@Test
+	public void testPropertyJoinIntFloat() throws Exception {
+		testTransform(
+				TransformationExamples.getExample(TransformationExamples.PROPERTY_JOIN_INT_FLOAT));
+	}
+
 	@Override
 	protected List<Instance> transformData(TransformationExample example) throws Exception {
 		ConceptualSchemaTransformer transformer = new ConceptualSchemaTransformer();

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/test/TransformationExamples.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/test/TransformationExamples.groovy
@@ -33,6 +33,7 @@ abstract class TransformationExamples {
 	public static final String DUPE_ASSIGN = 'dupeassign'
 	public static final String PROPERTY_JOIN = 'propjoin'
 	public static final String PROPERTY_JOIN_2 = 'propjoin2'
+	public static final String PROPERTY_JOIN_INT_FLOAT = 'propjoin_int_float'
 	public static final String JOIN_MULTI_COND_1 = 'join_multi_cond_1'
 	public static final String MERGE = 'merge'
 	public static final String MERGE2 = 'merge2'
@@ -122,6 +123,7 @@ abstract class TransformationExamples {
 		(DUPE_ASSIGN): defaultExample(DUPE_ASSIGN),
 		(PROPERTY_JOIN): defaultExample(PROPERTY_JOIN),
 		(PROPERTY_JOIN_2): defaultExample(PROPERTY_JOIN_2),
+		(PROPERTY_JOIN_INT_FLOAT): defaultExample(PROPERTY_JOIN_INT_FLOAT),
 		(JOIN_MULTI_COND_1): defaultExample(JOIN_MULTI_COND_1),
 		(SIMPLE_MERGE): defaultExample(SIMPLE_MERGE),
 		(MERGE): defaultExample(MERGE),

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/instance1.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/instance1.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:collection xmlns:tns="http://www.example.org/t1/"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.example.org/t1/ t1.xsd">
+	<tns:person id="0">
+        <name>Tom Builder</name>
+        <details>
+            <age>30</age>
+            <income>6000</income>
+            <addressId>0</addressId>
+            <addressId>1.0</addressId>
+        </details>
+    </tns:person>
+	<tns:address id="0">
+        <street>Main Street</street>
+        <zip>10463</zip>
+	</tns:address>
+	<tns:address id="1">
+        <street>Cathedral</street>
+        <zip>10463</zip>
+	</tns:address>
+	<tns:city>
+		<name>Kingsbridge</name>
+		<zip>10463</zip>
+	</tns:city>
+	<tns:person id="1">
+        <name>Chester Lampwick</name>
+        <details>
+            <age>103</age>
+            <income>10</income>
+        </details>
+    </tns:person>
+</tns:collection>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/instance2.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/instance2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:collection xmlns:tns="http://www.example.org/t2/"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.example.org/t2/ t2.xsd">
+	<tns:person id="0">
+        <name>Tom Builder</name>
+        <details>
+            <age>30</age>
+            <income>6000</income>
+            <address>
+        		<street>Main Street</street>
+        		<city>Kingsbridge</city>
+        		<zip>10463</zip>
+			</address>
+			<address>
+        		<street>Cathedral</street>
+        		<city>Kingsbridge</city>
+        		<zip>10463</zip>
+			</address>
+        </details>
+    </tns:person>
+	<tns:person id="1">
+        <name>Chester Lampwick</name>
+        <details>
+            <age>103</age>
+            <income>10</income>
+        </details>
+    </tns:person>
+</tns:collection>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1.xsd
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.example.org/t1/" targetNamespace="http://www.example.org/t1/">
+    <complexType name="PersonType">
+    	<sequence>
+    		<element name="name" type="string"></element>
+    		<element name="details" maxOccurs="1" minOccurs="0">
+    			<complexType>
+    				<sequence>
+    					<element name="age" type="int"></element>
+    					<element name="income" type="double"></element>
+    					<element name="addressId" type="float" maxOccurs="unbounded" minOccurs="0"></element>
+    				</sequence>
+    			</complexType>
+    		</element>
+    	</sequence>
+    	<attribute name="id" type="int"></attribute>
+    </complexType>
+
+    <element name="person" type="tns:PersonType"></element>
+
+    <complexType name="AddressType">
+    	<sequence>
+    		<element name="street" type="string"></element>
+    		<element name="zip" type="int"></element>
+    	</sequence>
+		<attribute name="id" type="int"></attribute>
+    </complexType>
+
+    <element name="address" type="tns:AddressType"></element>
+
+    <complexType name="CityType">
+    	<sequence>
+    		<element name="name" type="string"></element>
+    		<element name="zip" type="int"></element>
+    	</sequence>
+    </complexType>
+
+    <element name="city" type="tns:CityType"></element>
+
+	<element name="collection" type="tns:CollectionType"></element>
+    
+    <complexType name="CollectionType">
+    	<choice maxOccurs="unbounded" minOccurs="0">
+    		<element ref="tns:person"></element>
+    		<element ref="tns:address"></element>
+    		<element ref="tns:city"></element>
+    	</choice>
+    </complexType>
+</schema>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hale-project version="3.5.0.release">
+    <name>Property Join w/ comparison of int and float</name>
+    <author>Florian Esser</author>
+    <created>2019-06-06T09:33:48.653+02:00</created>
+    <modified>2019-06-06T09:37:08.454+02:00</modified>
+    <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
+        <setting name="charset">UTF-8</setting>
+        <setting name="projectFiles.separate">false</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
+        <setting name="target">file:/C:/src/git/halestudio/hale/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex</setting>
+    </save-config>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
+        <setting name="charset">UTF-8</setting>
+        <setting name="onlyElementsMappable">true</setting>
+        <setting name="resourceId">e28225b5-d8c8-487a-bffa-39a407a2e89e</setting>
+        <setting name="source">file:/C:/src/git/halestudio/hale/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1.xsd</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
+    </resource>
+    <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.xml.reader">
+        <setting name="charset">UTF-8</setting>
+        <setting name="resourceId">356c58cc-7691-4def-b98b-d8a14a28e47c</setting>
+        <setting name="source">file:/C:/src/git/halestudio/hale/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/instance1.xml</setting>
+        <setting name="interpolation.maxError">0.1</setting>
+        <setting name="interpolation.algorithm">segment</setting>
+        <setting name="ignoreNamespaces">false</setting>
+        <setting name="paginateRequest">true</setting>
+        <setting name="featuresPerWfsRequest">1000</setting>
+        <setting name="ignoreRoot">true</setting>
+        <setting name="ignoreNumberMatched">false</setting>
+        <setting name="interpolation.grid.moveAllToGrid">false</setting>
+        <setting name="strict">false</setting>
+        <setting name="contentType">org.eclipse.core.runtime.xml</setting>
+    </resource>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
+        <setting name="charset">UTF-8</setting>
+        <setting name="onlyElementsMappable">true</setting>
+        <setting name="resourceId">18974a01-b703-49b3-8403-fe5b972cb579</setting>
+        <setting name="source">file:/C:/src/git/halestudio/hale/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t2.xsd</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
+    </resource>
+    <file name="alignment.xml" location="t1t2.halex.alignment.xml"/>
+    <file name="styles.sld" location="t1t2.halex.styles.sld"/>
+</hale-project>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex.alignment.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex.alignment.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alignment xmlns="http://www.esdi-humboldt.eu/hale/alignment">
+    <cell relation="eu.esdihumboldt.hale.align.join" id="C8d35c1f3-2245-4efe-858e-4925f1c2a183" priority="normal">
+        <source name="types">
+            <class>
+                <type name="PersonType" ns="http://www.example.org/t1/"/>
+            </class>
+        </source>
+        <source name="types">
+            <class>
+                <type name="AddressType" ns="http://www.example.org/t1/"/>
+            </class>
+        </source>
+        <source name="types">
+            <class>
+                <type name="CityType" ns="http://www.example.org/t1/"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+            </class>
+        </target>
+        <complexParameter name="join">
+            <jp:join-parameter xmlns:jp="http://www.esdi-humboldt.eu/hale/join">
+                <class>
+                    <type name="PersonType" ns="http://www.example.org/t1/"/>
+                </class>
+                <class>
+                    <type name="AddressType" ns="http://www.example.org/t1/"/>
+                </class>
+                <class>
+                    <type name="CityType" ns="http://www.example.org/t1/"/>
+                </class>
+                <jp:condition>
+                    <property>
+                        <type name="AddressType" ns="http://www.example.org/t1/"/>
+                        <child name="zip"/>
+                    </property>
+                    <property>
+                        <type name="CityType" ns="http://www.example.org/t1/"/>
+                        <child name="zip"/>
+                    </property>
+                </jp:condition>
+                <jp:condition>
+                    <property>
+                        <type name="PersonType" ns="http://www.example.org/t1/"/>
+                        <child name="details"/>
+                        <child name="addressId"/>
+                    </property>
+                    <property>
+                        <type name="AddressType" ns="http://www.example.org/t1/"/>
+                        <child name="id"/>
+                    </property>
+                </jp:condition>
+            </jp:join-parameter>
+        </complexParameter>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C67dab3ed-ac22-45de-a4d7-cdf0e3490d16" priority="normal">
+        <source>
+            <property>
+                <type name="CityType" ns="http://www.example.org/t1/"/>
+                <child name="name"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="details"/>
+                <child name="address"/>
+                <child name="city"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cbdf3c532-e145-46a2-a789-4dc9e07c765d" priority="normal">
+        <source>
+            <property>
+                <type name="AddressType" ns="http://www.example.org/t1/"/>
+                <child name="street"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="details"/>
+                <child name="address"/>
+                <child name="street"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C64aaeb7e-09c9-48db-88cd-acc73c8fd600" priority="normal">
+        <source>
+            <property>
+                <type name="CityType" ns="http://www.example.org/t1/"/>
+                <child name="zip"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="details"/>
+                <child name="address"/>
+                <child name="zip"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C0999b56a-9dac-4c71-ae12-cf6c3ac27395" priority="normal">
+        <source>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t1/"/>
+                <child name="details"/>
+                <child name="age"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="details"/>
+                <child name="age"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C26bca44a-6ffe-4160-8528-6f863d644a51" priority="normal">
+        <source>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t1/"/>
+                <child name="details"/>
+                <child name="income"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="details"/>
+                <child name="income"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C1cd5041e-f4ca-4f25-8a4e-21d0ee8d1dde" priority="normal">
+        <source>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t1/"/>
+                <child name="id"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="id"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C3a807cb3-bc2e-4cf4-83b3-e56b9ea99fa5" priority="normal">
+        <source>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t1/"/>
+                <child name="name"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="PersonType" ns="http://www.example.org/t2/"/>
+                <child name="name"/>
+            </property>
+        </target>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+</alignment>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex.styles.sld
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t1t2.halex.styles.sld
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:UserStyle xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc">
+  <sld:Name>Default Styler</sld:Name>
+  <sld:FeatureTypeStyle>
+    <sld:Name>name</sld:Name>
+  </sld:FeatureTypeStyle>
+</sld:UserStyle>

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t2.xsd
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/testdata/propjoin_int_float/t2.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.example.org/t2/" targetNamespace="http://www.example.org/t2/">
+    <complexType name="PersonType">
+    	<sequence>
+    		<element name="name" type="string"></element>
+    		<element name="details" maxOccurs="1" minOccurs="0">
+    			<complexType>
+    				<sequence>
+    					<element name="age" type="int"></element>
+    					<element name="income" type="double"></element>
+    					<element name="address"
+    						type="tns:AddressType" maxOccurs="unbounded" minOccurs="0">
+    					</element>
+    				</sequence>
+    			</complexType>
+    		</element>
+    	</sequence>
+    	<attribute name="id" type="string"></attribute>
+    </complexType>
+
+    <element name="person" type="tns:PersonType"></element>
+
+    <complexType name="AddressType">
+    	<sequence>
+    		<element name="street" type="string"></element>
+    		<element name="city" type="string"></element>
+			<element name="zip" type="int"></element>
+    	</sequence>
+    </complexType>
+
+	<element name="collection" type="tns:CollectionType"></element>
+    
+    <complexType name="CollectionType">
+    	<sequence>
+    		<element ref="tns:person" maxOccurs="unbounded" minOccurs="0"></element>
+    	</sequence>
+    </complexType>
+</schema>


### PR DESCRIPTION
This patch adds the same behaviour to the processing of double and
float values that already existed for BigDecimals. In particular,
double and float values that are in fact integers (e.g. `2.0`) are
now serialized without the trailing `.0` during value processing.

This allows the mixed use of float/double and integer/string properties
in Joins.

https://github.com/halestudio/hale/issues/737