### PR TITLE
fix: prevent possible NPE in SnippetServiceImpl

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.groovy/src/eu/esdihumboldt/hale/io/groovy/snippets/impl/SnippetServiceImpl.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.groovy/src/eu/esdihumboldt/hale/io/groovy/snippets/impl/SnippetServiceImpl.java
@@ -42,15 +42,17 @@ public class SnippetServiceImpl implements SnippetService {
 	public SnippetServiceImpl(GroovyService gs) {
 		super();
 
-		gs.addListener(new GroovyServiceListener() {
+		if (gs != null) {
+			gs.addListener(new GroovyServiceListener() {
 
-			@Override
-			public void restrictionChanged(boolean restrictionActive) {
-				synchronized (snippets) {
-					snippets.values().forEach(snippet -> snippet.invalidate());
+				@Override
+				public void restrictionChanged(boolean restrictionActive) {
+					synchronized (snippets) {
+						snippets.values().forEach(snippet -> snippet.invalidate());
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 
 	@Override


### PR DESCRIPTION
In a headless environment the GroovyService may not be available. This
should not lead to an error as it is only needed to react to restriction
changes, which usually don't occur in a headless environment.