### PR TITLE
Add options to include feature collections and abstract types in deegree config export

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.deegree.ui/src/eu/esdihumboldt/hale/io/deegree/ui/BasicMappingConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree.ui/src/eu/esdihumboldt/hale/io/deegree/ui/BasicMappingConfigurationPage.java
@@ -63,6 +63,8 @@ public class BasicMappingConfigurationPage
 			new Config());
 
 	private Button useIntegerIDs;
+	private Button includeAbstractTypes;
+	private Button includeFeatureCollections;
 	private Button useNamespacePrefix;
 	private Text connId;
 
@@ -151,6 +153,9 @@ public class BasicMappingConfigurationPage
 		mappingConfig.setUseNamespacePrefixForTableNames(useNamespacePrefix.getSelection());
 
 		mappingConfig.setUseIntegerIDs(useIntegerIDs.getSelection());
+
+		mappingConfig.setIncludeAbstractTypes(includeAbstractTypes.getSelection());
+		mappingConfig.setIncludeFeatureCollections(includeFeatureCollections.getSelection());
 
 		ISelection idPrefixSel = idPrefix.getSelection();
 		IDPrefixMode idPrefix = GenericMappingConfiguration.DEFAULT_ID_PREFIX_MODE;
@@ -299,6 +304,15 @@ public class BasicMappingConfigurationPage
 		useIntegerIDs = new Button(database, SWT.CHECK);
 		useIntegerIDs.setText("Use integer IDs for GML IDs");
 		GridDataFactory.swtDefaults().span(3, 1).applyTo(useIntegerIDs);
+
+		// Include feature collections / abstract types
+		includeFeatureCollections = new Button(database, SWT.CHECK);
+		includeFeatureCollections.setText("Include feature collection types");
+		GridDataFactory.swtDefaults().span(3, 1).applyTo(includeFeatureCollections);
+
+		includeAbstractTypes = new Button(database, SWT.CHECK);
+		includeAbstractTypes.setText("Include abstract types");
+		GridDataFactory.swtDefaults().span(3, 1).applyTo(includeAbstractTypes);
 
 		// CRS group
 

--- a/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/MappingWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/MappingWriter.java
@@ -324,7 +324,7 @@ public class MappingWriter {
 						ModelHelper.withPrefix(prefixGenerator.apply(ftm), ftm.getFidMapping()),
 						ftm);
 			});
-		});
+		}, config.includeFeatureCollections(), config.includeAbstractTypes());
 	}
 
 	/**
@@ -346,8 +346,8 @@ public class MappingWriter {
 			@Override
 			public List<FeatureType> getFeatureTypes(String namespace, boolean includeCollections,
 					boolean includeAbstracts) {
-				List<FeatureType> fts = super.getFeatureTypes(namespace, includeCollections,
-						includeAbstracts);
+				List<FeatureType> fts = super.getFeatureTypes(namespace,
+						config.includeFeatureCollections(), config.includeAbstractTypes());
 
 				return fts.stream().filter(ft -> {
 					// only accept types that are part of the mapped-to

--- a/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/MappingWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/MappingWriter.java
@@ -224,6 +224,10 @@ public class MappingWriter {
 						.getSetting(CodeListAssociations.KEY_ASSOCIATIONS)
 						.as(CodeListAssociations.class);
 
+				if (associations == null) {
+					return null;
+				}
+
 				return associations.getAssociations().keySet().stream().map(e -> {
 					List<QName> names = e.getNames();
 					if (names.size() > 1) {

--- a/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/config/GenericMappingConfiguration.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/config/GenericMappingConfiguration.java
@@ -38,6 +38,9 @@ public class GenericMappingConfiguration implements MappingConfiguration {
 		PostGIS;
 	}
 
+	public static final String KEY_INCLUDE_FEATURE_COLLECTIONS = "mapping.includeFeatureCollections";
+	public static final String KEY_INCLUDE_ABSTRACT_TYPES = "mapping.includeAbstractTypes";
+
 	public static final String KEY_JDBC_CONNECTION_ID = "database.connectionId";
 	public static final String KEY_DATABASE_MAX_NAME_LENGTH = "database.names.maxLength";
 
@@ -57,6 +60,8 @@ public class GenericMappingConfiguration implements MappingConfiguration {
 	public static final String KEY_CRS_DIMENSION = "featureStore.crs.dimension";
 	public static final String KEY_CRS_SRID = "featureStore.crs.srid";
 
+	public static final boolean DEFAULT_INCLUDE_FEATURE_COLLECTIONS = false;
+	public static final boolean DEFAULT_INCLUDE_ABSTRACT_TYPES = false;
 	public static final DatabaseType DEFAULT_DATABASE_TYPE = DatabaseType.PostGIS;
 	public static final MappingMode DEFAULT_MAPPING_MODE = MappingMode.relational;
 	public static final IDPrefixMode DEFAULT_ID_PREFIX_MODE = IDPrefixMode.deegree;
@@ -108,6 +113,9 @@ public class GenericMappingConfiguration implements MappingConfiguration {
 
 		setUseIntegerIDs(DEFAULT_INTEGER_IDS);
 		setUseNamespacePrefixForTableNames(DEFAULT_NAMESPACE_PREFIX_FOR_TABLE_NAMES);
+
+		setIncludeAbstractTypes(DEFAULT_INCLUDE_ABSTRACT_TYPES);
+		setIncludeFeatureCollections(DEFAULT_INCLUDE_FEATURE_COLLECTIONS);
 	}
 
 	@Override
@@ -295,6 +303,26 @@ public class GenericMappingConfiguration implements MappingConfiguration {
 
 	public void setUseIntegerIDs(boolean enabled) {
 		config.set(KEY_INTEGER_IDS, enabled);
+	}
+
+	@Override
+	public boolean includeFeatureCollections() {
+		return config.get(KEY_INCLUDE_FEATURE_COLLECTIONS, Boolean.class)
+				.orElse(DEFAULT_INCLUDE_FEATURE_COLLECTIONS);
+	}
+
+	public void setIncludeFeatureCollections(boolean includeCollections) {
+		config.set(KEY_INCLUDE_FEATURE_COLLECTIONS, includeCollections);
+	}
+
+	@Override
+	public boolean includeAbstractTypes() {
+		return config.get(KEY_INCLUDE_ABSTRACT_TYPES, Boolean.class)
+				.orElse(DEFAULT_INCLUDE_ABSTRACT_TYPES);
+	}
+
+	public void setIncludeAbstractTypes(boolean includeAbstracts) {
+		config.set(KEY_INCLUDE_ABSTRACT_TYPES, includeAbstracts);
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/config/MappingConfiguration.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/config/MappingConfiguration.java
@@ -95,6 +95,23 @@ public interface MappingConfiguration {
 	boolean useIntegerIDs();
 
 	/**
+	 * Specifies whether feature types that deegree identifies as feature
+	 * collections should be included in the mapping.
+	 * 
+	 * @return <code>true</code> if feature collections should be included,
+	 *         <code>false</code> otherwise
+	 */
+	boolean includeFeatureCollections();
+
+	/**
+	 * Specifies whether abstract types should be included in the mapping.
+	 * 
+	 * @return <code>true</code> if abstract types should be included,
+	 *         <code>false</code> otherwise
+	 */
+	boolean includeAbstractTypes();
+
+	/**
 	 * Validate the configuration.
 	 * 
 	 * @throws Exception on a validation error

--- a/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/model/MappedAppSchemaCopy.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.deegree/src/eu/esdihumboldt/hale/io/deegree/mapping/model/MappedAppSchemaCopy.java
@@ -15,11 +15,13 @@
 
 package eu.esdihumboldt.hale.io.deegree.mapping.model;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.deegree.feature.persistence.sql.FeatureTypeMapping;
 import org.deegree.feature.persistence.sql.MappedAppSchema;
+import org.deegree.feature.types.FeatureType;
 
 /**
  * Copy class for {@link MappedAppSchema}.
@@ -27,6 +29,9 @@ import org.deegree.feature.persistence.sql.MappedAppSchema;
  * @author Simon Templer
  */
 public class MappedAppSchemaCopy extends MappedAppSchema {
+
+	private boolean includeFeatureCollections = false;
+	private boolean includeAbstractTypes = false;
 
 	/**
 	 * Creates a copy of a {@link MappedAppSchema}.
@@ -57,6 +62,32 @@ public class MappedAppSchemaCopy extends MappedAppSchema {
 						.toArray(i -> new FeatureTypeMapping[i]),
 				ms.getBBoxMapping(), ms.getBlobMapping(), ms.getGeometryParams(), true,
 				ms.getRelationalModel(), ms.getGmlObjectTypes(), ms.getGeometryToSuperType());
+	}
+
+	/**
+	 * Creates a copy of a {@link MappedAppSchema} where all feature type
+	 * mappings can be adapted.
+	 * 
+	 * @param ms the original mapped schema
+	 * @param adaptMappings the function to adapt the mappings
+	 * @param includeFeatureCollections whether to include feature collections
+	 *            in the mapping
+	 * @param includeAbstracts whether to include abstract types in the mapping
+	 */
+	public MappedAppSchemaCopy(MappedAppSchema ms,
+			Function<Stream<? extends FeatureTypeMapping>, Stream<? extends FeatureTypeMapping>> adaptMappings,
+			boolean includeFeatureCollections, boolean includeAbstracts) {
+		this(ms, adaptMappings);
+
+		this.includeFeatureCollections = includeFeatureCollections;
+		this.includeAbstractTypes = includeAbstracts;
+	}
+
+	@Override
+	public List<FeatureType> getFeatureTypes(String namespace, boolean includeCollections,
+			boolean includeAbstracts) {
+		return super.getFeatureTypes(namespace, this.includeFeatureCollections,
+				this.includeAbstractTypes);
 	}
 
 }


### PR DESCRIPTION
This adds two new options to the deegree configuration exporter, allowing to include both abstract types and feature types that deegree identifies as feature collections to the generated mapping.

Including feature collections is sometimes necessary when deegree falsely identifies a feature type as a feature collection (happens e.g. for `OM_Observation`).

SVC-310