### PR TITLE
#762 Add support for MongoDB URI scheme

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/PathUpdate.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/PathUpdate.java
@@ -130,8 +130,8 @@ public class PathUpdate {
 	 */
 	public URI findLocation(URI uri, boolean tryFallback, boolean allowResource,
 			boolean keepRelative) {
-		if ("jdbc".equals(uri.getScheme())) {
-			// not possible to update JDBC URLs or test the stream
+		if ("jdbc".equals(uri.getScheme()) || "mongodb".equals(uri.getScheme())) {
+			// not possible to update JDBC \ mongo URLs or test the stream
 			return uri;
 		}
 


### PR DESCRIPTION
Adds MongoDB URI schema support on PathUpdate class, same as JDBC scheme.

Related issue:
https://github.com/halestudio/hale/issues/762