### PR TITLE
build: use OpenJDK binaries instead of Oracle ones

### DIFF
--- a/build/build.gradle
+++ b/build/build.gradle
@@ -156,21 +156,20 @@ ext {
 	]
 
 	// URL to the directory containing mirrored artifacts (Maven, JRE, ...)
-	artifactsCommit = '18b78a2e5b480f152c0b7792463713d28bccde30'
+	artifactsCommit = '6589f561a36b8a6fe4cd6a115fdc892bbf812c68'
 	artifactsMirrorUrl = "https://gitlab.wetransform.to/hale/hale-build-support/raw/${artifactsCommit}"
 
     // Names of zip files containing Java Runtimes (sorted by their respective platform)
     jreArtifacts = [
         'win32': [
             'win32': [
-                'x86': 'jre-8u91-windows-i586.tar.gz',
-                'x86_64': 'jre-8u91-windows-x64.tar.gz'
+                'x86': 'OpenJDK8U-jre_x86-32_windows_hotspot_8u232b09.tar.gz',
+                'x86_64': 'OpenJDK8U-jre_x64_windows_hotspot_8u232b09.tar.gz'
             ]
         ],
         'linux': [
             'gtk': [
-                'x86': 'jre-8u91-linux-i586.tar.gz',
-                'x86_64': 'jre-8u91-linux-x64.tar.gz'
+                'x86_64': 'OpenJDK8U-jre_x64_linux_hotspot_8u232b09.tar.gz'
             ]
         ]/*, -- not available right now
         'macosx': [


### PR DESCRIPTION
This replaces the bundled Oracle JREs with OpenJDK JREs built by
AdoptOpenJDK:

https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/tag/jdk8u232-b09

Since there is currently no 32-bit OpenJDK build for Linux available
from AdoptOpenJDK, no JRE will be bundled with 32-bit Linux builds
anymore.

The corresponding update to `hale-build-support` was done in this
commit:

https://gitlab.wetransform.to/hale/hale-build-support/commit/6589f561a36b8a6fe4cd6a115fdc892bbf812c68

https://github.com/halestudio/hale/issues/758