### PR TITLE
fix: fix property determination in case a group is present

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/instance/GroupUtil.java
@@ -389,11 +389,7 @@ public class GroupUtil {
 
 		// check cardinality of children
 		for (ChildDefinition<?> childDef : children) {
-			if (isValidCardinality(currentGroup, childDef)) { // XXX is this
-																// correct?!
-																// should it be
-																// !isValid...
-																// instead?
+			if (!isValidCardinality(currentGroup, childDef)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This fixes the check whether a group may be closed. If a group is not closed although it would be ok to do so, hale will try to find subsequently read properties in that group instead of the parent.

https://github.com/halestudio/hale/issues/764