### PR TITLE
fix(hc): handle cases where user/org information is unavailable

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/ChooseHaleConnectProjectWizardPage.groovy
@@ -328,7 +328,7 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 							Owner owner = ((HaleConnectProjectInfo) element).getOwner();
 							if (owner.isUser()) {
 								try {
-									HaleConnectUserInfo user = haleConnect.getUserInfo(owner.getId());
+									HaleConnectUserInfo user = element.getUser()
 									if (!StringUtils.isEmpty(user.getFullName())) {
 										return user.getFullName();
 									}
@@ -344,12 +344,7 @@ public class ChooseHaleConnectProjectWizardPage extends ConfigurationWizardPage<
 								}
 							}
 							else if (owner.isOrganisation()) {
-								try {
-									return haleConnect.getOrganisationInfo(owner.getId()).getName();
-								} catch (HaleConnectException e) {
-									log.error(e.getMessage(), e);
-									return MessageFormat.format("<organisation {0}>", owner.getId());
-								}
+								return element.getOrganisation()
 							}
 							else {
 								return "<unknown owner type> ID: " + owner.getId();

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect.ui/src/eu/esdihumboldt/hale/io/haleconnect/ui/projects/HaleConnectTarget.java
@@ -559,8 +559,7 @@ public class HaleConnectTarget extends AbstractTarget<HaleConnectProjectWriter> 
 
 								// As a fallback, display dummy value that
 								// contains the orgId
-								organisations.add(new HaleConnectOrganisationInfo(orgId,
-										MessageFormat.format("<Organisation {0}>", orgId)));
+								organisations.add(HaleConnectOrganisationInfo.dummyForId(orgId));
 							}
 						}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectOrganisationInfo.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectOrganisationInfo.groovy
@@ -27,4 +27,14 @@ import groovy.transform.*
 class HaleConnectOrganisationInfo {
 	String id
 	String name
+
+	/**
+	 * Create a dummy organisation info object
+	 * 
+	 * @param orgId ID of the organisation
+	 * @return dummy info object
+	 */
+	static HaleConnectOrganisationInfo dummyForId(String orgId) {
+		new HaleConnectOrganisationInfo(id: orgId, name: "<Organisation ${orgId}>");
+	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectProjectInfo.groovy
@@ -51,6 +51,9 @@ public class HaleConnectProjectInfo {
 		this.id = id;
 		this.user = user;
 		this.organisation = organisation;
+		if (this.user == null && this.organisation == null) {
+			throw new IllegalArgumentException("Invalid owner information: both user and organisation are null");
+		}
 		this.name = name;
 		this.author = author;
 		this.lastModified = lastModified;

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectUserInfo.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/HaleConnectUserInfo.groovy
@@ -28,4 +28,14 @@ class HaleConnectUserInfo {
 	String userId
 	String screenName
 	String fullName
+
+	/**
+	 * Create a dummy user info object
+	 * 
+	 * @param userId ID of the user
+	 * @return dummy info object
+	 */
+	static HaleConnectUserInfo dummyForId(String userId) {
+		new HaleConnectUserInfo(userId: userId, screenName: "___user${userId}___", fullName: "<User ${userId}>")
+	}
 }


### PR DESCRIPTION
This adds handling for cases where user or organisation info is queried via the hale connect API, but the information is cannot be obtained (e.g. because the user/org was deleted in the meantime or because of missing authorization).

Previously, failure to retrieve user/org information could lead to errors in the UI.

https://github.com/halestudio/hale/issues/752