### PR TITLE
Fix PostgreSQL integration tests

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/MultiDimensionalArraysIT.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/MultiDimensionalArraysIT.groovy
@@ -77,6 +77,7 @@ class MultiDimensionalArraysIT extends AbstractDBTest {
 		checkBindingAndSqlType(schema, [
 			INT: Integer.class, //
 			SERIAL: Integer.class, //
+			BIGSERIAL: Long.class, //
 			INT4: Integer.class, //
 			_INT4: Integer.class, // XXX currently array as multi-occurrence property
 			BOOL: Boolean.class, //

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/MultiDimensionalArraysIT.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/MultiDimensionalArraysIT.groovy
@@ -85,6 +85,7 @@ class MultiDimensionalArraysIT extends AbstractDBTest {
 			NUMERIC: BigDecimal.class, //
 			VARCHAR: String.class, //
 			_VARCHAR: String.class, // XXX currently array as multi-occurrence property
+			TEXT: String.class, //
 			FLOAT8: Double.class, //
 		]);
 

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/OneDimensionalArraysIT.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/OneDimensionalArraysIT.groovy
@@ -79,6 +79,7 @@ class OneDimensionalArraysIT extends AbstractDBTest {
 		checkBindingAndSqlType(schema, [
 			INT: Integer.class, //
 			SERIAL: Integer.class, //
+			BIGSERIAL: Long.class, //
 			INT4: Integer.class, //
 			_INT4: Integer.class, // Array as multi-occurrence property
 			BOOL: Boolean.class, //

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/OneDimensionalArraysIT.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/OneDimensionalArraysIT.groovy
@@ -90,6 +90,7 @@ class OneDimensionalArraysIT extends AbstractDBTest {
 			_NUMERIC: BigDecimal.class, // Array as multi-occurrence property
 			VARCHAR: String.class, //
 			_VARCHAR: String.class, // Array as multi-occurrence property
+			TEXT: String.class, //
 			FLOAT8: Double.class, //
 		]);
 

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/PostDataTypesIT.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.postgresql.test/src/eu/esdihumboldt/hale/io/jdbc/postgresql/test/PostDataTypesIT.groovy
@@ -178,10 +178,10 @@ public class PostDataTypesIT extends AbstractDBTest {
 		Map<String, Class<?>> m = new HashMap<String, Class<?>>();
 		m.put("INT", Integer.class);
 		m.put("SERIAL", Integer.class);
+		m.put("BIGSERIAL", Long.class);
 		m.put("MONEY", BigDecimal.class);
 		m.put("FLOAT", Float.class);
 		m.put("INT4", Integer.class);
-		m.put("INT8", Long.class);
 		m.put("INT8", Long.class);
 		m.put("FLOAT8", Double.class);
 		m.put("BYTEA", byte[].class);


### PR DESCRIPTION
PR https://github.com/halestudio/hale/pull/787 appears to have broken the PostgreSQL integration tests. This adds binding checks for `BIGSERIAL`  and `TEXT` data types.

Examples for failing builds:
https://builds.wetransform.to/job/hale/job/hale%7Epublish(master)/480/console
https://builds.wetransform.to/job/hale/job/hale%7Ebuild(staging)/27/console