### PR TITLE
perf: improve GeoPackage reader performance

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/internal/GeopackageFeatureCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/internal/GeopackageFeatureCollection.java
@@ -44,11 +44,7 @@ public class GeopackageFeatureCollection implements InstanceCollection {
 
 		private final TableInstanceBuilder builder;
 
-		private static final int ROW_LIMIT = 100;
-
 		private UserResultSet<?, ?, ?> currentResults;
-
-		private int currentOffset = 0;
 
 		/**
 		 * States if the row at the current cursor position was already
@@ -62,8 +58,6 @@ public class GeopackageFeatureCollection implements InstanceCollection {
 		private boolean hasNext = false;
 
 		private boolean done = false;
-
-		private boolean checkNextChunk = false;
 
 		/**
 		 * Default constructor.
@@ -113,25 +107,14 @@ public class GeopackageFeatureCollection implements InstanceCollection {
 				}
 
 				if (currentResults != null && !hasNext) {
-					// currentResults has been completely processed
-
-					if (checkNextChunk) {
-						// increase offset
-						currentOffset += ROW_LIMIT;
-						currentResults = null;
-					}
-					else {
-						// set iterator to done
-						close();
-					}
+					close();
 				}
 
 				if (currentResults == null) {
 					consumed = true;
+
 					// retrieve result set
-					currentResults = features.queryForChunk(ROW_LIMIT, currentOffset);
-					// check next chunk later, if current chunk was "full"
-					checkNextChunk = features.count() > currentOffset + ROW_LIMIT;
+					currentResults = features.queryForAll();
 
 					proceedToNext();
 				}


### PR DESCRIPTION
This replaces the "chunked" read approach of the initial implementation with a "fetch everything" approach.

Calling `queryForChunk` and `features.count()` often versus calling `queryForAll` once comes with a significant performance penalty.

Caching `features.count()` cut the load time roughly by a third compared to the original approach.

By switching to `queryForAll`I was able to reduce the time required to read 10k features (5 types with 2000 features each) on my machine from 188 seconds to 36 seconds.

https://github.com/halestudio/hale/issues/795