### PR TITLE
fix(hc-api): fix connection problem when endpoint supports TLS 1.2 only

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ApiClientHelper.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ApiClientHelper.groovy
@@ -15,7 +15,12 @@
 
 package eu.esdihumboldt.hale.io.haleconnect.internal
 
+import static com.squareup.okhttp.CipherSuite.*
+
 import java.text.MessageFormat
+
+import com.squareup.okhttp.ConnectionSpec
+import com.squareup.okhttp.TlsVersion
 
 import eu.esdihumboldt.hale.io.haleconnect.BasePathResolver
 import eu.esdihumboldt.util.http.ProxyUtil
@@ -26,6 +31,39 @@ import eu.esdihumboldt.util.http.ProxyUtil
  * @author Florian Esser
  */
 class ApiClientHelper {
+
+	/**
+	 * {@link ConnectionSpec} that uses TLS v1.2 only and is limited to cipher
+	 * suites with perfect forward security (PFS) as specified in "Technische
+	 * Richtlinie TR-02102-2, Kryptographische Verfahren: Empfehlungen und
+	 * Schlüssellängen, Teil 2 - Verwendung von Transport Layer Security"
+	 * (version 2019-01) as published by the German Federal Office for
+	 * Information Security.
+	 */
+	public static final ConnectionSpec API_CONNECTION_SPEC = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+	.tlsVersions(TlsVersion.TLS_1_2)
+	.cipherSuites(
+	TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+	TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	/*TLS_ECDHE_ECDSA_WITH_AES_128_CCM,*/    // TODO not supported
+	/*TLS_ECDHE_ECDSA_WITH_AES_256_CCM,*/    // by OkHttp 2.7.5
+	TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+	TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+	TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+	TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+	TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+	TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+	TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+	TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+	/*TLS_DHE_RSA_WITH_AES_128_CCM,*/        // TODO not supported
+	/*TLS_DHE_RSA_WITH_AES_256_CCM*/)        // by OkHttp 2.7.5
+	.build();
 
 	/**
 	 * Sets common properties for an ApiClient. Since there is no common 
@@ -73,5 +111,23 @@ class ApiClientHelper {
 			apiClient.apiKey = apiKey
 			apiClient.apiKeyPrefix = "Bearer"
 		}
+	}
+
+	/**
+	 * Build a {@link ConnectionSpec} for {@link OkHttpClient}s that uses TLS v1.2 only and
+	 * is limited to cipher suites with perfect forward security (PFS) as specified in
+	 * "Technische Richtlinie TR-02102-2 Kryptographische Verfahren: Empfehlungen und
+	 * Schlüssellängen, Teil 2 - Verwendung von Transport Layer Security" (version 2019-01)
+	 * as published by the German Federal Office for Information Security.<br>
+	 * <br>
+	 * The result can be applied to the http client of the hale connect API clients like so:<br>
+	 * <pre>
+	 *     apiClient.getHttpClient().setConnectionSpecs(ApiClientHelper.buildConnectionSpec())
+	 * </pre>
+	 *
+	 * @return Singleton list containing the connection spec
+	 */
+	static List<ConnectionSpec> buildConnectionSpec() {
+		[API_CONNECTION_SPEC]
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/BucketServiceHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/BucketServiceHelper.java
@@ -37,6 +37,7 @@ public class BucketServiceHelper {
 		ApiClient apiClient = new ApiClient();
 		ApiClientHelper.setApiClientProperties(apiClient, HaleConnectServices.BUCKET_SERVICE,
 				resolver, apiKey);
+		apiClient.getHttpClient().setConnectionSpecs(ApiClientHelper.buildConnectionSpec());
 		return apiClient;
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ProjectServiceHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ProjectServiceHelper.java
@@ -37,6 +37,7 @@ public class ProjectServiceHelper {
 		ApiClient apiClient = new ApiClient();
 		ApiClientHelper.setApiClientProperties(apiClient, HaleConnectServices.BUCKET_SERVICE,
 				resolver, apiKey);
+		apiClient.getHttpClient().setConnectionSpecs(ApiClientHelper.buildConnectionSpec());
 		return apiClient;
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ProjectStoreHelper.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/ProjectStoreHelper.java
@@ -52,6 +52,7 @@ public class ProjectStoreHelper {
 		ApiClientHelper.setApiClientProperties(apiClient, HaleConnectServices.PROJECT_STORE,
 				resolver, apiKey);
 
+		apiClient.getHttpClient().setConnectionSpecs(ApiClientHelper.buildConnectionSpec());
 		return apiClient;
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/UserServiceHelper.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.haleconnect/src/eu/esdihumboldt/hale/io/haleconnect/internal/UserServiceHelper.groovy
@@ -62,6 +62,7 @@ public class UserServiceHelper {
 		ApiClient apiClient = new ApiClient();
 		ApiClientHelper.setApiClientProperties(apiClient, HaleConnectServices.USER_SERVICE,
 				resolver, apiKey);
+		apiClient.getHttpClient().setConnectionSpecs(ApiClientHelper.buildConnectionSpec());
 
 		return apiClient;
 	}


### PR DESCRIPTION
This limits the supported TLS version to v1.2 and the available cipher suites to
those that have perfect forward security (PFS) for all hale connect API
connections.

This also fixes the problem where hale studio / hale-cli were unable to connect
to deployments that have a strict SSL policy and support TLS 1.2/1.3 with
selected cipher suites only.

https://github.com/halestudio/hale/issues/758