### PR TITLE
fix: allow filtering LimboInstanceSink instance collection

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/transform/LimboInstanceSink.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.headless/src/eu/esdihumboldt/hale/common/headless/transform/LimboInstanceSink.java
@@ -26,6 +26,7 @@ import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
 import eu.esdihumboldt.hale.common.instance.model.InstanceReference;
 import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
 import eu.esdihumboldt.hale.common.instance.model.impl.DefaultInstance;
+import eu.esdihumboldt.hale.common.instance.model.impl.FilteredInstanceCollection;
 import eu.esdihumboldt.hale.common.instance.model.impl.PseudoInstanceReference;
 import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
 
@@ -230,12 +231,9 @@ public class LimboInstanceSink extends AbstractTransformationSink {
 			return false;
 		}
 
-		/**
-		 * @see eu.esdihumboldt.hale.common.instance.model.InstanceCollection#select(eu.esdihumboldt.hale.common.instance.model.Filter)
-		 */
 		@Override
 		public InstanceCollection select(Filter filter) {
-			throw new UnsupportedOperationException();
+			return FilteredInstanceCollection.applyFilter(this, filter);
 		}
 
 	}


### PR DESCRIPTION
Not sure why this was not implemented before - it should be OK just
retrieving specific instances, even if it is not possible to iterate
over the collection more than once. This just means that there might be
instances coming out of the transformation that are not
handled/exported.

The previous behavior would prevent instance to be written with a CSV or
Excel writer in case the LimboInstanceSink was used, as it only processes
instances of a specific type (depending on configuration).