### PR TITLE
feat: add helper function to parse JSON data

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.groovy.helpers/plugin.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.groovy.helpers/plugin.xml
@@ -22,6 +22,13 @@
             category="context"
             class="eu.esdihumboldt.cst.functions.groovy.helpers.ContextHelpers">
       </helper>
+      <category
+            path="json">
+      </category>
+      <helper
+            category="json"
+            class="eu.esdihumboldt.cst.functions.groovy.helpers.JsonHelpers">
+      </helper>
    </extension>
    <extension
          point="eu.esdihumboldt.util.groovy.sandbox">
@@ -32,6 +39,10 @@
       <import
             class="eu.esdihumboldt.cst.functions.groovy.helpers.util.Collector">
       </import>
+      <allow
+            allowAll="true"
+            class="groovy.json.internal.LazyMap">
+      </allow>
    </extension>
 
 </plugin>

--- a/cst/plugins/eu.esdihumboldt.cst.functions.groovy.helpers/src/eu/esdihumboldt/cst/functions/groovy/helpers/JsonHelpers.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.groovy.helpers/src/eu/esdihumboldt/cst/functions/groovy/helpers/JsonHelpers.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.cst.functions.groovy.helpers
+
+import eu.esdihumboldt.cst.functions.groovy.helper.spec.SpecBuilder
+import groovy.json.*
+
+/**
+ * Helper functions for using JSON data.
+ * @author Johanna Ott
+ */
+class JsonHelpers {
+
+	/**
+	 * Specification for the parseJson function
+	 */
+	public static final eu.esdihumboldt.cst.functions.groovy.helper.spec.Specification _parseJson_spec = SpecBuilder.newSpec( //
+	description: 'Parse a text representation of a JSON data structure and returns a data structure of lists and maps', //
+	result: 'A data structure of lists and maps.') {
+		//
+		json('The JSON data structure that should be parsed.')
+	}
+
+	static Object _parseJson(String json) {
+		def slurper = new JsonSlurper()
+		slurper.parseText(json)
+	}
+}


### PR DESCRIPTION
As the JsonSlurper class was not whitelisted and should not (as it has
broad access to the file system), a wrapper function is created for it.