### PR TITLE
fix(io): List binding: trim whitespace before splitting

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
@@ -144,7 +144,7 @@ public class SimpleTypeUtil {
 													// binding?
 			// we are dealing with a simple type list
 			// items separated by whitespace
-			String[] elements = value.split("\\s+");
+			String[] elements = value.trim().split("\\s+");
 			ElementType elementType = type.getConstraint(ElementType.class);
 
 			Class<? extends XmlAnySimpleType> elementSimpleType = null;


### PR DESCRIPTION
Make sure that leading and trailing whitespace is removed before splitting
the value of an element bound to `java.util.List` at whitespace.

The old behaviour lead to three list entries (an empty one followed by the one
for each of the actual values) being created for the `pos` element value from
the following snippet:

```
	<gml:Point srsName="EPSG:25832" gml:id="GML-f">
		<gml:pos>
			540465.8278 5802259.4572
		</gml:pos>
	</gml:Point>
```

However, the snippet above should have the same semantics as

```
	<gml:Point srsName="EPSG:25832" gml:id="GML-f">
		<gml:pos>540465.8278 5802259.4572</gml:pos>
	</gml:Point>
```

Therefore, leading and trailing whitespace is now removed before the split.

https://github.com/halestudio/hale/issues/808

Thanks @JohannaOtt for reporting the bug and helping find a fix.