### PR TITLE
build: fix URL of OSGeo repository

### DIFF
--- a/build/gradle/deployArtifacts.gradle
+++ b/build/gradle/deployArtifacts.gradle
@@ -229,7 +229,7 @@ repositories {
 	}
 	jcenter()
 	maven {
-		url 'http://download.osgeo.org/webdav/geotools/'
+		url 'https://repo.osgeo.org/repository/release/'
 	}
 }
 


### PR DESCRIPTION
Updates the repository URL needed to validate artifacts.

https://github.com/halestudio/hale/issues/821