### PR TITLE
feat: transparently replace old JTS package name in Groovy scripts

### DIFF
--- a/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/DefaultGroovyService.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/DefaultGroovyService.java
@@ -159,9 +159,15 @@ public class DefaultGroovyService implements GroovyService {
 		}
 	}
 
+	private String preprocessScript(String script) {
+		// Replace all occurrences of the old JTS base package
+		// "com.vividsolutions.jts" with its new name.
+		return script.replaceAll("com\\.vividsolutions\\.jts", "org.locationtech.jts");
+	}
+
 	@Override
 	public Script parseScript(String script, Binding binding) {
-		return createShell(binding).parse(script);
+		return createShell(binding).parse(preprocessScript(script));
 	}
 
 	@Override

--- a/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/DefaultGroovyService.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/DefaultGroovyService.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
@@ -33,6 +34,9 @@ public class DefaultGroovyService implements GroovyService {
 	 * Extension point ID.
 	 */
 	private static final String ID = "eu.esdihumboldt.util.groovy.sandbox";
+
+	private static final Pattern JTS_OLD_BASE_PACKAGE = Pattern
+			.compile("com\\.vividsolutions\\.jts");
 
 	private final CopyOnWriteArraySet<GroovyServiceListener> listeners = new CopyOnWriteArraySet<GroovyServiceListener>();
 
@@ -162,7 +166,7 @@ public class DefaultGroovyService implements GroovyService {
 	private String preprocessScript(String script) {
 		// Replace all occurrences of the old JTS base package
 		// "com.vividsolutions.jts" with its new name.
-		return script.replaceAll("com\\.vividsolutions\\.jts", "org.locationtech.jts");
+		return JTS_OLD_BASE_PACKAGE.matcher(script).replaceAll("org.locationtech.jts");
 	}
 
 	@Override

--- a/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/GroovyService.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/GroovyService.java
@@ -1,10 +1,10 @@
 package eu.esdihumboldt.util.groovy.sandbox;
 
+import javax.annotation.Nullable;
+
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import groovy.lang.Script;
-
-import javax.annotation.Nullable;
 
 /**
  * Groovy sandbox service interface.


### PR DESCRIPTION
Groovy scripts created with pre-4.0 hale studio releases that explicitly use
classes from JTS fail to compile after the upgrade of GeoTools as the
base package name changed from `com.vividsolutions.jts` to
`org.locationtech.jts`.

This adds a transparent replacement of occurrences of the old base package name
by the new one.

https://github.com/halestudio/hale/issues/821