### PR TITLE
build: temporarily use build-artifacts mirror instead of GitLab

### DIFF
--- a/build/build.gradle
+++ b/build/build.gradle
@@ -156,8 +156,9 @@ ext {
 	]
 
 	// URL to the directory containing mirrored artifacts (Maven, JRE, ...)
-	artifactsCommit = '6589f561a36b8a6fe4cd6a115fdc892bbf812c68'
-	artifactsMirrorUrl = "https://gitlab.wetransform.to/hale/hale-build-support/raw/${artifactsCommit}"
+	//artifactsCommit = '6589f561a36b8a6fe4cd6a115fdc892bbf812c68'
+	//artifactsMirrorUrl = "https://gitlab.wetransform.to/hale/hale-build-support/raw/${artifactsCommit}"
+	artifactsMirrorUrl = "http://build-artifacts.wetransform.to/hale-build-support"
 
     // Names of zip files containing Java Runtimes (sorted by their respective platform)
     jreArtifacts = [


### PR DESCRIPTION
The reachability of the GitLab instance is currently shaky. Switch to S3 mirror temporarily to allow builds.