### PR TITLE
fix: fix wrong call when reporting error

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/XmlToSchema.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/XmlToSchema.groovy
@@ -181,7 +181,7 @@ public class XmlToSchema implements HaleSchemaConstants {
 					}
 				}
 				else {
-					reporter.error(new IOMessageImpl("Could not find factory for constraint with type $id"))
+					reporter.error("Could not find factory for constraint with type $id")
 				}
 			}
 			else {


### PR DESCRIPTION
The IOMessageImpl(String) constructor does not exist.