### PR TITLE
fix: don't append time zone information when writing xmlDate

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
@@ -84,7 +84,17 @@ public class SimpleTypeUtil {
 		if (simpleType != null) {
 			try {
 				XmlAnySimpleType simpleTypeValue = conversionService.convert(value, simpleType);
-				if (simpleTypeValue instanceof XmlDateTime) {
+				if (simpleTypeValue instanceof XmlDate) {
+					XmlDate xmlDate = (XmlDate) simpleTypeValue;
+					Calendar calendar = xmlDate.getCalendarValue();
+					GDateBuilder builder = new GDateBuilder(calendar);
+					// remove time zone as value contains no time information
+					builder.clearTimeZone();
+					GDate gdate = builder.toGDate();
+
+					xmlDate.setGDateValue(gdate);
+				}
+				else if (simpleTypeValue instanceof XmlDateTime) {
 					XmlDateTime xmlDateTime = (XmlDateTime) simpleTypeValue;
 
 					// use Zulu time to have a reproducable result
@@ -100,6 +110,7 @@ public class SimpleTypeUtil {
 
 					xmlDateTime.setGDateValue(gdate);
 				}
+
 				if (simpleTypeValue != null) {
 					return simpleTypeValue.getStringValue();
 				}


### PR DESCRIPTION
Prevents that time zone information is added to the GML output when
writing an `xmlDate`. Before, a date-only target property would
get serialized as e.g.

    <xplan:genehmigungsDatum>2020-08-02+02:00</xplan:genehmigungsDatum>

with the actual time zone suffix `+02:00` depending on the system time zone.

With this fix, the above example gets serialized as

    <xplan:genehmigungsDatum>2020-08-02</xplan:genehmigungsDatum>

instead.

https://github.com/halestudio/hale/issues/316