### PR TITLE
fix: use correct preferred bundle when loading geometry types

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/type/factory/GeometryTypeFactory.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema/src/eu/esdihumboldt/hale/common/schema/model/constraint/type/factory/GeometryTypeFactory.java
@@ -45,18 +45,16 @@ public class GeometryTypeFactory implements ValueConstraintFactory<GeometryType>
 	@Override
 	public GeometryType restore(Value value, Definition<?> definition, TypeResolver typeIndex,
 			ClassResolver resolver) throws Exception {
-		Class<?> binding = resolver.loadClass(value.as(String.class), "org.locationtech.jts");
+		String className = value.as(String.class);
+		if (className.contains("com.vividsolutions.jts")) {
+			className = className.replace("com.vividsolutions.jts", "org.locationtech.jts");
+		}
+
+		Class<?> binding = resolver.loadClass(className, "org.locationtech.jts.jts-core");
 
 		if (binding == null) {
-			String s = value.as(String.class);
-			binding = resolver.loadClass(
-					s.replace("com.vividsolutions.jts", "org.locationtech.jts"),
-					"org.locationtech.jts");
-
-			if (binding == null) {
-				throw new IllegalStateException(
-						"Could not resolve geometry type " + value.as(String.class));
-			}
+			throw new IllegalStateException(
+					"Could not resolve geometry type " + value.as(String.class));
 		}
 
 		return GeometryType.get((Class<? extends Geometry>) binding);


### PR DESCRIPTION
As part of the upgrade to GeoTools 21, a wrong bundle name was used as the
preferred bundle when loading geometry types. The wrong bundle name causes
significant delays when loading schemas with geometries as hale tried to
locate the non-existing bundle for every geometry element in the schema.

The correct bundle name is `org.locationtech.jts.jts-core`. In addition,
replacing the old GeoTools package name in the class name is now done
before trying to load geometry class.

https://github.com/halestudio/hale/issues/861