### PR TITLE
refactor(ui): activate XML pretty printing by default

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlWriterSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.ui/src/eu/esdihumboldt/hale/io/gml/ui/GmlWriterSettingsPage.java
@@ -123,7 +123,7 @@ public class GmlWriterSettingsPage
 		prettyPrint = new Button(xml, SWT.CHECK);
 		prettyPrint.setText("Pretty print XML");
 		// default
-		prettyPrint.setSelection(false);
+		prettyPrint.setSelection(true);
 
 		Group geom = new Group(page, SWT.NONE);
 		geom.setLayout(new GridLayout(1, false));


### PR DESCRIPTION
Check the option `Pretty print XML` by default in the writer settings dialog page when exporting XML/GML.