### PR TITLE
doc: Aligned name consistency for hale»studio - Finalized

### DIFF
--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/contributors.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/contributors.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Contributors</h1>
-	<p>Thanks to all who contributed to make <i>hale studio</i> what it is!</p>
+	<p>Thanks to all who contributed to make <i>hale»studio</i> what it is!</p>
 	<div>
 		<table class="contributors">
 			<tr>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/cql_filter.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/cql_filter.html
@@ -8,8 +8,8 @@
 	<h1>CQL Filter</h1>
 	<p>
 		The Common Query Language (CQL) is used to define expressions
-		and filters in several parts of <i>hale studio</i>. It can be used to define
-		conditions on schema elements or to filter instances. <i>hale studio</i> also 
+		and filters in several parts of <i>hale製tudio</i>. It can be used to define
+		conditions on schema elements or to filter instances. <i>hale製tudio</i> also 
 		supports the extended CQL (ECQL) syntax as defined by Geotools. 
 	</p>
 
@@ -218,7 +218,7 @@
 		project provided in the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with hale studio</a> guide, using the
+			alt="command link">Get started with hale製tudio</a> guide, using the
 		<a href="../views/transformed_data.html">Transformed Data view</a>.
 	</p>
 	<h3>Comparisons</h3>
@@ -234,7 +234,7 @@
 	<p class="Code">details.address.city IS NOT NULL</p>
 	<h2>Supported filter operations</h2>
 	<p>Following is a list of filter operations that have been tested
-		with hale:</p>
+		with hale製tudio:</p>
 		
 	<h3>Equal (=)</h3>
 	<div style="margin-left: 12px;">
@@ -334,7 +334,7 @@
 			literals defined must rely on source data having a specific reference
 			system that is previously known.</p>
 		<p>Note that spatial CQL filters only work on attributes that are
-			marked as geometry attributes in hale. It is right now not possible
+			marked as geometry attributes in hale製tudio. It is right now not possible
 			to apply them to parent attributes of geometry attributes directly.</p>
 		<h4>Examples</h4>
 		<p class="Code">CONTAINS(areaAttr, POINT(2 0))</p>
@@ -420,7 +420,7 @@
 
 	<h3>Unsupported operations</h3>
 	
-	<p>These are CQL filter operations that have been verified to not work with hale:</p>
+	<p>These are CQL filter operations that have been verified to not work with hale製tudio:</p>
 	<ul>
 		<li><strong>EXISTS</strong> - use <code>IS NOT NULL</code> instead if possible</li>
 		<li><strong>DOES-NOT-EXIST</strong> - use <code>IS NULL</code> instead if possible</li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/html_mapping.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/html_mapping.html
@@ -15,7 +15,7 @@
 		the example project from the <a class="command-link"
 			href='javascript:executeCommand("org.eclipse.ui.cheatsheets.openCheatSheet(cheatSheetId=eu.esdihumboldt.hale.ui.firststeps.firststepsCS)")'>
 			<img src="PLUGINS_ROOT/org.eclipse.help/command_link.png"
-			alt="command link">Get started with hale studio</a>
+			alt="command link">Get started with hale»studio</a>
 		guide is provided as an <a href="sample_documentation.html">example</a>.
 	</p>
 	<p>To create the mapping documentation for your project, export the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/jdbc.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/jdbc.html
@@ -6,10 +6,10 @@
 </head>
 <body>
 	<h1>Database Export</h1>
-	<p><i>hale studio</i> writes to databases using JDBC. hale studio
+	<p><i>hale製tudio</i> writes to databases using JDBC. hale製tudio
 		offers support for PostgreSQL and PostGIS databases out of the box,
 		support for other databases can be added through plug-ins.</p>
-	<p class="Note">The database export in this version of <i>hale studio</i> is
+	<p class="Note">The database export in this version of <i>hale製tudio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a database export feature.
 		However, within its limits it is functional and may be useful to you.</p>
@@ -26,7 +26,7 @@
 			identifier assigned during transformation will be replaced by the
 			auto-generated value.</li>
 	</ul>
-	<p>When storing geometries in PostGIS, <i>hale studio</i> will try to detect the
+	<p>When storing geometries in PostGIS, <i>hale製tudio</i> will try to detect the
 		spatial reference system associated to the target column and transform
 		them appropriately.</p>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/mssql.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/mssql.html
@@ -7,15 +7,15 @@
 <body>
 	<h1>MsSQL Server Export</h1>
 	<p>
-		Support for MsSQL Server in <i>hale studio</i> is based on the generic <a
+		Support for MsSQL Server in <i>hale»studio</i> is based on the generic <a
 			href="jdbc.html">Database export</a> based on JDBC, and thus has the
-		same limitations. For instance <i>hale studio</i> needs the database schema to
+		same limitations. For instance <i>hale»studio</i> needs the database schema to
 		already exist in SQL server, thus you can only write to database that have 
 		already been prepared and loaded as target schema.
 	</p>
 	
 	<p>
-		<i>hale studio</i> supports writing both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
+		<i>hale»studio</i> supports writing both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
 		of MsSQL Server but if any objects does not contain spatial reference system then 
 		<b>(EPSG:4326)</b> will be used as a default reference system. 
 		However, within this limit it is functional and may be useful to you.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/sqlite.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/sqlite.html
@@ -7,13 +7,13 @@
 <body>
 	<h1>SQLite and SpatiaLite Export</h1>
 	<p>
-		Support for SQLite and SpatiaLite in <i>hale studio</i> is based on the generic <a
+		Support for SQLite and SpatiaLite in <i>hale»studio</i> is based on the generic <a
 			href="jdbc.html">Database export</a> based on JDBC, and thus has the
-		same limitations. For instance <i>hale studio</i> needs the database schema to
+		same limitations. For instance <i>hale»studio</i> needs the database schema to
 		already exist, thus you can only write to files that have already been
 		prepared and loaded as target schema.
 	</p>
-	<p class="Note">The database export in this version of <i>hale studio</i> is
+	<p class="Note">The database export in this version of <i>hale»studio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a database export feature.
 		However, within its limits it is functional and may be useful to you.</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/wfs.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/wfs.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Transactional WFS</h1>
-	<p><i>hale studio</i> supports publishing your transformed GML data to a WFS with
+	<p><i>hale製tudio</i> supports publishing your transformed GML data to a WFS with
 		support for transactions. Currently supported are Transactional Web
 		Feature Services following the OGC WFS 1.1.0 or WFS 2.0.0
 		specifications. There are two different providers for publishing to
@@ -25,7 +25,7 @@
 				<li>
 					<strong>Keep instances that reference each other together</strong>:
 					This is the default behaviour that used in previous versions of
-					<em>hale studio</em>. The partitioning is done based on the references 
+					<em>hale製tudio</em>. The partitioning is done based on the references 
 					between features. Features that are connected are kept together so the 
 					WFS-T is able to retain those references.
 				</li>
@@ -37,7 +37,7 @@
 			</ul>
 		</li>
 	</ul>
-	<p class="Note">The publishing to WFS in this version of <i>hale studio</i> is
+	<p class="Note">The publishing to WFS in this version of <i>hale製tudio</i> is
 		deemed experimental. This means it does not have the full
 		functionality we want to provide for a WFS publishing feature.
 		However, within its limits it is functional and may be useful to you.</p>
@@ -49,15 +49,15 @@
 			messages in the transformation and export reports. There is no
 			automatic recovery, features may have to be deleted manually if they
 			are not desired to be published.<br>
-		<br><i>hale studio</i> behaves like this because both transformation and GML
+		<br><i>hale製tudio</i> behaves like this because both transformation and GML
 			export aim to provide you a result even if there are small errors or
 			inconsistencies.<br><br>
 		</li>
-		<li><i>hale studio</i> will not check the WFS Capabilities if the WFS
+		<li><i>hale製tudio</i> will not check the WFS Capabilities if the WFS
 			supports any of the provided GML feature types.</li>
 	</ul>
 	<p>Target location for the WFS-T export is the POST URL for the
-		WFS Transaction operation. The <i>hale studio</i> user interface provides a helper to
+		WFS Transaction operation. The <i>hale製tudio</i> user interface provides a helper to
 		determine that URL from the WFS capabilities.</p>
 	
 	<br>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/xml_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/export/xml_data.html
@@ -25,7 +25,7 @@
 		<img src="images/xml_export_root.png" title="Specify root element" class="fit">
 	</div>
 	<p>
-		When writing the transformed data, <i>hale studio</i> will try to find a
+		When writing the transformed data, <i>hale»studio</i> will try to find a
 		valid XML path to write each of the transformed instances. If there
 		are geometry objects contained in an instance, they are written as a
 		GML geometry if possible.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/csv.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/csv.html
@@ -7,12 +7,12 @@
 <body>
 	<h1>CSV Import</h1>
 	<p>
-		Comma separated value (CSV) files can be used as a data source in <i>hale studio</i>,
+		Comma separated value (CSV) files can be used as a data source in <i>hale»studio</i>,
 		with the schema definition also being derived from the CSV file.
 	</p>
 	<h2>General CSV Import Options</h2>
 	<p>
-		When loading a CSV file, <i>hale studio</i> will try to auto-detect the
+		When loading a CSV file, <i>hale»studio</i> will try to auto-detect the
 		settings for reading the file, i.e. which character is used to
 		separate the values and what the quote and escape characters should
 		be. You can correct the settings manually by choosing other characters

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/geopackage.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/geopackage.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>GeoPackage Data Import</h1>
 	<p>
-		<i>hale studio</i> supports the import of GeoPackages.
+		<i>hale»studio</i> supports the import of GeoPackages.
 		The GeoPackage first needs to be imported as schema, and then as data.
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_data.html
@@ -21,7 +21,7 @@
 
 	<h2>Load data from a WFS</h2>
 	<p>
-		<i>hale studio</i> offers the possibility to load data based on a WFS <i>GetFeature</i>
+		<i>hale»studio</i> offers the possibility to load data based on a WFS <i>GetFeature</i>
 		KVP request. You can specify the request URL manually or use the <i>...</i>
 		button to launch a wizard assisting you in building the URL from the service capabilities.
 	</p>
@@ -35,7 +35,7 @@
 	<div>
 		<img src="images/wfs_data_bb.png" class="fit"></img>
 	</div>
-	<p>When loading from WFS sources, <i>hale studio</i> supports request pagination, a capability that
+	<p>When loading from WFS sources, <i>hale»studio</i> supports request pagination, a capability that
 	    was introduced with the WFS 2.0 standard. You can activate or deactivate request
 	    pagination on the <i>XML/GML settings</i> page. If activated, the number of features 
 	    that will be retrieved per request can also be set.
@@ -43,7 +43,7 @@
 		<p>Even though pagination was introduced in the WFS 2.0 standard, there are
 		WFS server implementations available that support this feature for WFS 1.1.0 
 		requests as well. If you know that the queried WFS supports this and activate 
-		pagination, <i>hale studio</i> will paginate the requests also for WFS 1.1.0 requests. 
+		pagination, <i>hale»studio</i> will paginate the requests also for WFS 1.1.0 requests. 
 		</p>
 	<div>
 		<img src="images/wfs_data_settings.png" class="fit"></img>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/gml_schema.html
@@ -17,7 +17,7 @@
 	</div>
 	<h2>Load a schema from a WFS</h2>
 	<p>
-		<i>hale studio</i> offers the possibility to load a schema based on a WFS <i>DescribeFeatureType</i>
+		<i>hale»studio</i> offers the possibility to load a schema based on a WFS <i>DescribeFeatureType</i>
 		KVP request. You can specify the request URL manually or use the <i>...</i>
 		button to launch a wizard assisting you in building the URL based on the service capabilities.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/jdbc.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/jdbc.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Database Import</h1>
-	<p>Database schemas and data are imported in <i>hale studio</i> using JDBC. hale studio
+	<p>Database schemas and data are imported in <i>hale»studio</i> using JDBC. hale»studio
 		offers support for Microsoft SQL Server, PostgreSQL and PostGIS databases out of the box,
 		support for other databases can be added through plug-ins.</p>
 	<p>The database import currently has the following known limitations:</p>
@@ -53,7 +53,7 @@
 		those types that are marked as mapping relevant. <br>Before
 		loading the data it is recommended to enable the selection of a
 		sub-set as sample data (<i>First n instances per type</i>), so a
-		potentially big database is not loaded completely into <i>hale studio</i> just for
+		potentially big database is not loaded completely into <i>hale»studio</i> just for
 		the analysis and mapping. This can be enabled in the tool bar or the
 		project's source data settings.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/mssql.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/mssql.html
@@ -7,12 +7,12 @@
 <body>
 	<h1>MsSQL Server Import</h1>
 	<p>
-		<i>hale studio</i> supports MsSQL Server database (tested version 2012 and 2014) import like generic 
+		<i>hale»studio</i> supports MsSQL Server database (tested version 2012 and 2014) import like generic 
 		<a href="jdbc.html">Database import</a> based on JDBC. Thus has the same limitations.
 	</p>
 	
 	<p>
-		<i>hale studio</i> supports both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
+		<i>hale»studio</i> supports both geometry and geography <a href="https://msdn.microsoft.com/en-us/library/bb933790(v=sql.110).aspx">spatial data types</a> 
 		of MsSQL Server but there are some limitations on curved <a href="https://msdn.microsoft.com/en-us/library/bb964711(v=sql.110).aspx#Anchor_1"> spatial data objects</a>. 
 	</p>
 	<p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/shapefile.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/shapefile.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Shapefile (SHP) Import</h1>
 	<p>
-		Shapefiles can be used as a data source in <i>hale studio</i>, with the
+		Shapefiles can be used as a data source in <i>hale»studio</i>, with the
 		schema definition also being derived from the Shapefile. Before
 		importing a Shapefile as source data, you have to import it as source
 		schema.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/sqlite.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/sqlite.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>SQLite and SpatiaLite Import</h1>
 	<p>
-		Support for SQLite and SpatiaLite in <i>hale studio</i> is based on the generic <a
+		Support for SQLite and SpatiaLite in <i>hale»studio</i> is based on the generic <a
 			href="jdbc.html">Database import</a> based on JDBC, and thus has the
 		same limitations. For convenience,
 		you can simply select a

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xls.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xls.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Excel File (XLS, XLSX) Import</h1>
 	<p>
-		Excel files can be used as a data source in <i>hale studio</i>. The 
+		Excel files can be used as a data source in <i>hale»studio</i>. The 
 		schema definition can/should also be derived from this excel file, 
 		by using a headline or user input to define attribute names.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xml_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xml_schema.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>XML Schema Import</h1>
 	<p>
-		<i>hale studio</i> supports loading schemas from XML Schema Definition (XSD)
+		<i>hale»studio</i> supports loading schemas from XML Schema Definition (XSD)
 		files. XML elements and types will be analyzed in a given schema file,
 		as well as in the included and imported additional schemas. Complex
 		properties are supported, as well as cycles, substitutions, groups and

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xplan_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/import/xplan_data.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>XPlanGML Data Import</h1>
 	<p>
-		The <i>hale studio</i> GML import supports XPlanGML. For more
+		The <i>hale»studio</i> GML import supports XPlanGML. For more
 		information please see the <a href="gml_data.html">GML Data Import</a>
 	</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/spatialite_common.xhtml
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/reference/spatialite_common.xhtml
@@ -11,18 +11,18 @@
 			To support SpatiaLite the
 			<code>mod_spatialite</code>
 			extension for SQLite must be available. For Windows users the
-			extension is provided together with hale studio, for other
+			extension is provided together with hale製tudio, for other
 			operating systems you may find it in your package manager or can
 			compile it yourself.
 		</p>
-		<p><i>hale studio</i> specifically supports version 3 and 4 of SpatiaLite, but
+		<p><i>hale製tudio</i> specifically supports version 3 and 4 of SpatiaLite, but
 			should also work with previous versions. Please let us know if you
 			experience any problems working with your files.</p>
 			
 		<h3>SpatiaLite on Windows</h3>
 		<p>
-			<i>hale studio</i> ships with the SQLite extension <code>mod_spatialite</code> (Version 4.2.0),
-			which is available as DLLs in the main <i>hale studio</i> directory. You can
+			<i>hale製tudio</i> ships with the SQLite extension <code>mod_spatialite</code> (Version 4.2.0),
+			which is available as DLLs in the main <i>hale製tudio</i> directory. You can
 			replace the library and its dependencies with different versions, e.g. as provided on
 			the <a href="http://www.gaia-gis.it/gaia-sins/" target="_blank">project
 				page</a>.

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/resources/resources_HALE.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/resources/resources_HALE.html
@@ -12,17 +12,17 @@
 	<a href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/getting_started/main_workflow.html"
 		target="_blank">Absolute beginners should start here</a>
 
-	<p>The <i>Getting Started</i> section contains instructions on how to use the hale studio help and how to navigate the UI. It also contains tutorial sections on core workflows in hale studio.</p><br>
+	<p>The <i>Getting Started</i> section contains instructions on how to use the hale製tudio help and how to navigate the UI. It also contains tutorial sections on core workflows in hale製tudio.</p><br>
 	</br>
 
 	<a href="http://help.halestudio.org/latest/index.jsp"
 		target="_blank">Search for free text in the online help</a>
 
-	<p>The hale studio help page offers free text search to help you find the information you are looking for.</p><br>
+	<p>The hale製tudio help page offers free text search to help you find the information you are looking for.</p><br>
 	</br>
 
-	<p>hale studio desktop software offers a number of example transformation projects that you can load directly. The example projects contain mappings which use a variety of the functions available in hale studio.
-	The example projects are a great way to gain familiarity with common use scenarios.The example projects can be accessed from the <i>Help</i> menu in hale studio.</p><br>
+	<p>hale製tudio desktop software offers a number of example transformation projects that you can load directly. The example projects contain mappings which use a variety of the functions available in hale製tudio.
+	The example projects are a great way to gain familiarity with common use scenarios.The example projects can be accessed from the <i>Help</i> menu in hale製tudio.</p><br>
 	</br>
 
 	<div>
@@ -47,7 +47,7 @@
 	<a href="https://www.wetransform.to/services/workshops/"
  	 target="_blank">Arrange an individual training (remote or on-premise)</a>
 
-	<p>Call us at +49 6151 6290890. Wetransform offers a wide range of trainings and workshops on various topics including INSPIRE, and advanced use of hale studio.</p><br>
+	<p>Call us at +49 6151 6290890. Wetransform offers a wide range of trainings and workshops on various topics including INSPIRE, and advanced use of hale製tudio.</p><br>
 	</br>
 
 	<a href="https://www.wetransform.to/services/support/"

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/define_custom_function.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/define_custom_function.html
@@ -6,9 +6,9 @@
 </head>
 <body>
 	<h1>Define a custom function</h1>
-	<p><i>hale studio</i> comes with a set of pre-defined transformation functions
+	<p><i>hale製tudio</i> comes with a set of pre-defined transformation functions
 		that cover most basic mapping cases. If you need other functionality
-		the easiest way is to define a custom function directly in hale studio. In a
+		the easiest way is to define a custom function directly in hale製tudio. In a
 		custom function you can use Groovy to determine the output, based on
 		input and parameters, similar to the Groovy script function. The main
 		difference to the Groovy script function is, that with a custom
@@ -93,7 +93,7 @@
 	</p>
 	
 	<h3>Function explanation</h3>
-	<p><i>hale studio</i> generates an explanation for mapping cells that reference specific
+	<p><i>hale製tudio</i> generates an explanation for mapping cells that reference specific
 		transformation functions. As a last step you have the opportunity to
 		specify how this explanation is created for your custom function.</p>
 	<p>The explanation can be a fixed text, or it can be a template
@@ -104,12 +104,12 @@
 	</div>
 	<p>
 		To support both text and HTML explanations with a single template,
-		<i>hale studio</i> provides Markdown support using the <a
+		<i>hale製tudio</i> provides Markdown support using the <a
 			href="https://github.com/sirthias/pegdown" target="_blank">pegdown</a>
 		Markdown processor.
 	</p>
 	<p>
-		To render the template <i>hale studio</i> uses the <a
+		To render the template <i>hale製tudio</i> uses the <a
 			href="http://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_gstringtemplateengine"
 			target="_blank">GStringTemplateEngine</a>. The variables available to
 		you in the template are the following:

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/mapping_schema_elem.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/mapping_schema_elem.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Mapping schema elements</h1>
 	<p>
-		The main purpose of <i>hale studio</i> is of course not to just inspect
+		The main purpose of <i>hale»studio</i> is of course not to just inspect
 		schemas, but to map the elements of these schemas with the goal of
 		transforming corresponding (geo)data sets.
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/type_relations.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/alignment/type_relations.html
@@ -90,13 +90,13 @@
 
 	<h2>Identify each type relation</h2>
 	<p>For the type correspondences as the next step you need to
-		identify how they can be expressed as relations in <i>hale</i>.</p>
+		identify how they can be expressed as relations in <i>hale»studio</i>.</p>
 	<p>
 		The most simple kind of relation is a 1:1 relation - a correspondence
 		between a single source and a single target type, where all
 		information needed to populate a target instance is present in a
 		single source instance - like in our <i>River/Watercourse</i> example.
-		This kind of relation is represented in <i>hale</i> by the <a
+		This kind of relation is represented in <i>hale»studio</i> by the <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.cst.doc.functions/functions/eu.esdihumboldt.hale.align.retype.html">Retype</a>
 		function.<br />
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/save_transformation.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/save_transformation.html
@@ -8,7 +8,7 @@
 	<h1>Save the transformation result</h1>
 	<p>
 		If you have defined a mapping and loaded source data in the
-		application, <i>hale studio</i> performs the transformation derived from the
+		application, <i>hale»studio</i> performs the transformation derived from the
 		mapping on the source data. This happens on every change to the
 		mapping, to instantly show the user what consequences his changes
 		have.
@@ -31,7 +31,7 @@
 		work based on a XML target schema.
 	</p>
 	<p>
-		Supported data export formats in <i>hale studio</i> are:
+		Supported data export formats in <i>hale»studio</i> are:
 	</p>
 	<ul>
 		<li><a href="../../reference/export/xml_data.html">XML</a></li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/transform_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/transform_data.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Transform external data</h1>
 	<p>To transform your data you don't need to load all of it into
-		hale studio. Usually it's a better practice to only load a representative
+		hale»studio. Usually it's a better practice to only load a representative
 		sample of your data, to help you verify the mapping and quickly get
 		feedback on its transformation. Once you have defined the mapping you
 		have the possibility to transform your data without loading it into

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/validate_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/validate_data.html
@@ -10,11 +10,11 @@
 		transformation result to not only follow the schema's structure, but
 		to also meet the other constraints defined by the schema, like
 		mandatory properties or restrictions on property values.</p>
-	<p>Validation of instances in <i>hale studio</i> currently is supported for XML
+	<p>Validation of instances in <i>hale製tudio</i> currently is supported for XML
 		based schemas. Validation can be done on the exported transformation
 		result or on the transformed instances currently available in the
 		application.</p>
-	<p>In addition to schema-based checks, <i>hale studio</i> supports validation of the
+	<p>In addition to schema-based checks, <i>hale製tudio</i> supports validation of the
 		exported transformation result with Schematron. To perform Schematron
 		validation, you can add the Schematron validator to the list of
 		validators and configure it when exporting the transformed instances.
@@ -35,7 +35,7 @@
 		produces a report about errors found during the validation and
 		informs you whether the file is valid or not.</p>
 
-	<h2>Validation inside hale studio</h2>
+	<h2>Validation inside hale製tudio</h2>
 	<p>If a mapping exists and source data is loaded, each mapping change will
 		trigger the live transformation (if activated).
 		When the transformed data changes, schema-based validation is started
@@ -73,10 +73,10 @@
 	<div>
 		<img src="images/validation_properties.png">
 	</div>
-	<p>This kind of validation inside <i>hale studio</i> is very convenient, but may
+	<p>This kind of validation inside <i>hale製tudio</i> is very convenient, but may
 		not be as accurate as the validation on export for some cases. This is
 		due to the fact that the export itself may change the result slightly
-		from what is available in hale studio. This could for instance be encodings
+		from what is available in hale製tudio. This could for instance be encodings
 		that are only replied when writing certain properties, or values like
 		identifiers that are generated when missing.</p>
 

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/working_source_data.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/data/working_source_data.html
@@ -8,12 +8,12 @@
 	<h1>Working with a source data set</h1>
 	<p>
 		The term <i>source data</i> refers to data according to the <i>source
-			schema</i> loaded in <i>hale studio</i>. Loading source data therefore always
+			schema</i> loaded in <i>hale製tudio</i>. Loading source data therefore always
 		requires that the corresponding source schema has already been
 		imported.
 	</p>
 	<p>
-		Loading source data in <i>hale studio</i> serves to provide feedback on the
+		Loading source data in <i>hale製tudio</i> serves to provide feedback on the
 		current mapping by transforming this data in the application. The <a
 			href="../../views/source_data.xhtml">Source Data view</a> can be used
 		to inspect the source data, while the <a
@@ -25,7 +25,7 @@
 	
 	<h2>Configuring a sample data set</h2>
 	<p>You have the possibility to load only a sub-set of your data in
-		hale studio, to use it as a sample for the data analysis and transformation
+		hale製tudio, to use it as a sample for the data analysis and transformation
 		debugging. You can enable it in the tool bar or the project's source
 		data settings. To open the settings use tool bar button highlighted
 		below:</p>
@@ -61,7 +61,7 @@
 		easily transform and export the complete data. Select <i>Transformation</i>&#8594;<i>Transform
 			project data...</i> from the menu to launch a wizard that will guide you
 		through the export configuration and launch the transformation. While
-		the transformation runs you can continue working in hale studio, as the
+		the transformation runs you can continue working in hale製tudio, as the
 		transformation works on a copy of your current mapping.
 	</p>
 
@@ -79,7 +79,7 @@
 		choose the one that applies.
 	</p>
 	<p>
-		Supported data import formats in <i>hale studio</i> are:
+		Supported data import formats in <i>hale製tudio</i> are:
 	</p>
 	<ul>
 		<li><a href="../../reference/import/xml_data.html">XML</a></li>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/account.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/account.html
@@ -2,12 +2,12 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>Accessing your <i>hale connect</i> account</title>
+<title>Accessing your <i>hale»connect</i> account</title>
 </head>
 <body>
 	<h1>Login</h1>
 	<p>
-		From hale studio you can login to your <i>hale connect</i> account
+		From hale»studio you can login to your <i>hale»connect</i> account
 		either via the File menu or the Welcome page. 
 	</p>
 	<div>
@@ -19,7 +19,7 @@
 		<i>Save credentials</i> checkbox. Your user name and password will 
 		be stored in a secure way. When you store your credentials for the 
 		first time, you will need to setup a master password for the secure 
-		storage to protect it against unauthorized use. <i>hale studio</i> 
+		storage to protect it against unauthorized use. <i>hale»studio</i> 
 		will query you for this password once every time the application is 
 		restarted as soon as the secure store is accessed for the first time.
 	</p>
@@ -29,11 +29,11 @@
 	<h1>Preferences</h1>
 	<p>
 		You can edit the stored user name and password in the application
-		preferences dialog under <i>hale connect</i>. The credentials
+		preferences dialog under <i>hale»connect</i>. The credentials
 		are saved by clicking <i>Apply</i> or closing the preferences
 		dialog with <i>OK</i>. By clicking  <i>Validate credentials</i> 
 		you can check whether the entered credentials are accepted by 
-		<i>hale connect</i>. To remove stored credentials press
+		<i>hale»connect</i>. To remove stored credentials press
 		<i>Clear credentials</i> or choose <i>Log out and clear credentials</i>
 		from the <i>File</i> menu. 
 	</p>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/loadproject.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/loadproject.html
@@ -2,22 +2,22 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>Accessing <i>hale connect</i> transformation projects</title>
+<title>Accessing <i>hale»connect</i> transformation projects</title>
 </head>
 <body>
-	<h1>Load a project from hale connect</h1>
+	<h1>Load a project from hale»connect</h1>
 	<p>
-		You can open <i>hale connect</i> transformation projects directly from
-		within <i>hale studio</i>. When you load a project from <i>hale connect</i>,
+		You can open <i>hale»connect</i> transformation projects directly from
+		within <i>hale»studio</i>. When you load a project from <i>hale»connect</i>,
 		you can also save any changes you make directly back there. When a 
-		project is loaded from <i>hale connect</i>, a <tt>[hale connect]</tt> label 
+		project is loaded from <i>hale»connect</i>, a <tt>[hale connect]</tt> label 
 		will be shown in the application title.
 	</p>  
 	<p>
-		To look for available projects online in <i>hale connect</i>, use the
+		To look for available projects online in <i>hale»connect</i>, use the
 		<i>File</i>&#8594;<i>Open Alignment Project</i> command and switch
-		to the <i>From hale connect</i> tab. In case you have not logged into
-		<i>hale connect</i> before, you can use the <i>Login</i> button on
+		to the <i>From hale»connect</i> tab. In case you have not logged into
+		<i>hale»connect</i> before, you can use the <i>Login</i> button on
 		the screen shown below to log in.
 	</p>
 	<div>
@@ -37,7 +37,7 @@
 	</div>
 	<p>
 		To continue, select the project you want to open from the list, and
-		press <i>Finish</i> twice to download the project into hale studio.
+		press <i>Finish</i> twice to download the project into hale»studio.
 	</p>
 </body>
 </html>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/shareproject.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/haleconnect/shareproject.html
@@ -9,23 +9,23 @@
 	<h1>Publishing a project</h1>
 	<p>
 		There are two ways to publish a transformation project on
-		<i>hale connect</i>:
+		<i>hale»connect</i>:
 		<ul>
 			<li>
 				By <b>sharing</b> the project with the
 				<i>File</i>&#8594;<i>Share project...</i> command. This
 				will export a snapshot of your current project to
-				<i>hale connect</i>.
+				<i>hale»connect</i>.
 			</li>
 			<li>
-				By <b>saving</b> the project to <i>hale connect</i>
+				By <b>saving</b> the project to <i>hale»connect</i>
 				just like you would save to a local project file
 				using <i>File</i>&#8594;<i>Save Alignment project as...</i>.
 			</li>
 		</ul>
 
 		In both cases you will be presented with the same wizard to complete
-		project details before the upload to <i>hale connect</i>.
+		project details before the upload to <i>hale»connect</i>.
 	</p>
 	<p>
 		On the first screen of the wizard you are asked to provide the project
@@ -33,21 +33,21 @@
 	</p>
 	<p>
 		On the next page you are requested to provide the export destination.
-		In case you have not logged into <i>hale connect</i> before, you can
+		In case you have not logged into <i>hale»connect</i> before, you can
 		use the <i>Login</i> button on the screen shown below to log in.
 	</p>
 	<div>
 		<img src="images/hale_connect_share_new.png" class="fit">
 	</div>
 	<p>
-		You can choose to either create a new project on <i>hale connect</i>
+		You can choose to either create a new project on <i>hale»connect</i>
 		or update an existing one. In case the currently opened project
-		was loaded from <i>hale connect</i>, updating the loaded project
+		was loaded from <i>hale»connect</i>, updating the loaded project
 		will be selected by default.
 	</p>
 	<p>
 		You must also choose whether you will be the owner of the uploaded
-		project on <i>hale connect</i> or one of your organizations. You must
+		project on <i>hale»connect</i> or one of your organizations. You must
 		select which of the organisations that you belong will own the uploaded
 		project via the dropdown. Note that only the first option is available
 		in cases where you are not allowed to add projects in the name of any of
@@ -61,11 +61,11 @@
 		</tr>
 		<tr>
 			<td><i>Enable versioning?</i></td>
-			<td>Enables versioning of the <i>hale connect</i> transformation project.</td>
+			<td>Enables versioning of the <i>hale»connect</i> transformation project.</td>
 		</tr>
 		<tr>
 			<td><i>Allow public access?</i></td>
-			<td>If selected, the created or updated project will be publicly available on <i>hale connect</i>.</td>
+			<td>If selected, the created or updated project will be publicly available on <i>hale»connect</i>.</td>
 		</tr>
 		<tr>
 			<td><i>Include web resources?</i></td>
@@ -74,7 +74,7 @@
 		<tr>
 			<td><i>Exclude source data?</i></td>
 			<td>
-				If selected, no source data will be uploaded to <i>hale connect</i>. This option is
+				If selected, no source data will be uploaded to <i>hale»connect</i>. This option is
 				enabled by default to prevent the inadvertent upload of large datasets.
 			</td>
 		</tr>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/save_project.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/save_project.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Saving your work</h1>
 	<p>
-		<i>hale studio</i> allows you to save your mapping, together with the
+		<i>hale»studio</i> allows you to save your mapping, together with the
 		configuration which schemas and source data sets are used in an
 		alignment project. The project also includes additional settings, e.g.
 		the list of mapping relevant types and the map styles. You can
@@ -40,7 +40,7 @@
 		</li>
 		<li>With a <b>hale connect transformation project</b> you can upload
 			your project including the alignment and all local resources to
-			the collaboration platform <a href="https://www.haleconnect.com">hale connect</a>.
+			the collaboration platform <a href="https://www.haleconnect.com">hale»connect</a>.
 		</li>
 	</ul>
 </body>

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/inspire_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/inspire_schema.html
@@ -12,13 +12,13 @@
 		exchange formats for INSPIRE. One application of those exchange
 		formats is the provision of data through INSPIRE Download services.</p>
 	<p>
-		To use an INSPIRE GML data model in <i>hale studio</i> all you have to do is
+		To use an INSPIRE GML data model in <i>hale製tudio</i> all you have to do is
 		loading the corresponding GML Application Schema as source or target
 		schema (see <a
 			href="PLUGINS_ROOT/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html">Loading
 			and browsing schemas</a>).<br> The GML Application Schemas are
 		provided by the European Commission. You can either use the schema
-		presets defined in <i>hale studio</i> (choose &quot;From preset&quot; when importing
+		presets defined in <i>hale製tudio</i> (choose &quot;From preset&quot; when importing
 		a schema) or the <a href="http://inspire.ec.europa.eu/schemas/"
 			target="_blank">schema repository</a> maintained by the JRC.
 	</p>
@@ -27,7 +27,7 @@
 			href="https://inspire.ec.europa.eu/data-specifications/2892"
 			target="_blank">https://inspire.ec.europa.eu/data-specifications/2892</a>
 	</p>
-	<p><i>hale studio</i> provides some pre-defined schema locations you can choose
+	<p><i>hale製tudio</i> provides some pre-defined schema locations you can choose
 		from - currently the INSPIRE schemas for Annex I, II and III in
 		versions 3.0 and 4.0 are listed:</p>
 	<div>
@@ -44,7 +44,7 @@
 			target="_blank">http://inspire.ec.europa.eu/draft-schemas/</a> (Draft
 		schemas)<br> <br> The schemas available there are not meant
 		for download - instead their URLs should be used to load them into
-		<i>hale studio</i> (e.g. by browsing the repository and using &quot;Copy Link
+		<i>hale製tudio</i> (e.g. by browsing the repository and using &quot;Copy Link
 		Location&quot; for a schema file to copy its URL to the clipboard and
 		further providing it in &quot;From URL&quot; when importing a schema).
 	</p>
@@ -53,7 +53,7 @@
 		The INSPIRE data models make heavy use of code lists. A lot of these
 		code lists are provided through the <a
 			href="http://inspire.ec.europa.eu/codelist/" target="_blank">INSPIRE
-			code list register</a>. With <i>hale studio</i> you can easily load them to use them
+			code list register</a>. With <i>hale製tudio</i> you can easily load them to use them
 		for a convenient selection from the available values. In the code list
 		import, select &quot;From INSPIRE registry&quot; to download the
 		current list of code lists and select a code list to load into the

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/schema/load_browse_schema.html
@@ -10,7 +10,7 @@
 		start with the creation of a mapping you have to determine what the
 		source and target schemas are.</p>
 	<p>
-		Loading a schema in <i>hale studio</i> provides you with the possibility to
+		Loading a schema in <i>hale»studio</i> provides you with the possibility to
 		browse the schema in the <a href="../../views/schema_explorer.html">Schema
 			Explorer</a> and to get detailed information on the defined types and
 		their properties.
@@ -50,7 +50,7 @@
 
 	<h2>Supported schema formats</h2>
 	<p>
-		<i>hale studio</i> supports the following formats for schema import:
+		<i>hale»studio</i> supports the following formats for schema import:
 	</p>
 	<ul>
 		<li><a href="../../reference/import/xml_schema.html">XML

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/tasks/transform_cli.html
@@ -7,9 +7,9 @@
 <body>
 	<h1>Transformation via the command line</h1>
 	<p>This help topic is about performing transformation of source
-		data using the command line interface provided by <i>hale studio</i>. It allows you
-		to execute transformations based on mappings defined in <i>hale studio</i>, without
-		having to use <i>hale studio</i> as desktop application, for instance to run the
+		data using the command line interface provided by <i>hale製tudio</i>. It allows you
+		to execute transformations based on mappings defined in <i>hale製tudio</i>, without
+		having to use <i>hale製tudio</i> as desktop application, for instance to run the
 		transformation automatically on a regular basis or to integrate it
 		with existing infrastructure.</p>
 	<p>The following are the basic things you need to use the command
@@ -21,33 +21,33 @@
 	</ol>
 
 	<h2>General usage</h2>
-	<p>You can run <i>hale studio</i> on the command line either using the <i>hale studio</i>
+	<p>You can run <i>hale製tudio</i> on the command line either using the <i>hale製tudio</i>
 		executable (i.e. HALE.exe) or using Java directly. Depending on the
 		operating system, behavior may be different, but in general it is
 		better to use Java directly (either use locally installed compatible
-		version of Java or the version shipped with <i>hale studio</i>), especially if you
+		version of Java or the version shipped with <i>hale製tudio</i>), especially if you
 		include the task in an automated process. The advantage of using the
-		<i>hale studio</i> executable is that it uses the Java version that is shipped with
-		<i>hale studio</i> automatically and sets some important system properties for you.
+		<i>hale製tudio</i> executable is that it uses the Java version that is shipped with
+		<i>hale製tudio</i> automatically and sets some important system properties for you.
 		The following are the commands to show the usage information of the
 		command line interface, with the executable or via Java, assuming your
-		working directory is the <i>hale studio</i> installation folder:</p>
-	<p>Running the <i>hale studio</i> executable:</p>
+		working directory is the <i>hale製tudio</i> installation folder:</p>
+	<p>Running the <i>hale製tudio</i> executable:</p>
 	<pre class="cli"><code><b>&gt;</b> <i>HALE -nosplash</i> -application hale.transform</code></pre>
 	<p>Running Java:</p>
 	<pre class="cli"><code><b>&gt;</b> <i>java -Xmx1024m -Dcache.level1.enabled=false -Dcache.level1.size=0 -Dcache.level2.enabled=false -Dcache.level2.size=0 -jar plugins\org.eclipse.equinox.launcher_1.3.0.v20140415-2008.jar</i> -application hale.transform</code></pre>
 	<p>Running the command above will show the usage information of the
 		transformation application. Please note that for the Java call, the
-		version of the launcher JAR file may change with new <i>hale studio</i> versions and
+		version of the launcher JAR file may change with new <i>hale製tudio</i> versions and
 		you should use a path delimiter appropriate for your system.</p>
 	<p>Additionally, the Java call specifies settings and system
 		properties for the Java VM. You cannot provide these settings to a
-		call to the <i>hale studio</i> executable - in that case you have to adapt the file
+		call to the <i>hale製tudio</i> executable - in that case you have to adapt the file
 		<code>HALE.ini</code>. Following is a short description of the most important
 		VM arguments:</p>
 	<ul>
 		<li style="padding-bottom: 16px;"><code>-Xmx1024m</code><br><br>This setting specifies the
-			<b>maximum heap memory</b> provided as working memory for <i>hale studio</i>. If you are
+			<b>maximum heap memory</b> provided as working memory for <i>hale製tudio</i>. If you are
 			with very large individual instances you may need to increase the
 			value. The example specifies a maximum heap space of 1024 MB.</li>
 		<li style="padding-bottom: 16px;"><code>-Dcache.level1.enabled=false
@@ -57,17 +57,17 @@
 			run into memory issues.</li>
 		<li style="padding-bottom: 16px;"><code>-Dlog.hale.level=INFO -Dlog.root.level=WARN</code><br><br>These
 			settings allow you to <b>configure the log level</b> for log events emitted
-			by <i>hale studio</i>. These log events may overlap with messages from the reports,
+			by <i>hale製tudio</i>. These log events may overlap with messages from the reports,
 			but are generally independent. <code>log.hale.level</code> controls
-			the log level for components of <i>hale studio</i>, while <code>log.root.level</code>
+			the log level for components of <i>hale製tudio</i>, while <code>log.root.level</code>
 			controls the log level for other code, such as third party libraries.
 			See the <a href="http://logback.qos.ch/manual/configuration.html"
 			target="_blank">logback documentation</a> for more information on
 			logging levels and other details about the logging configuration.</li>
-		<li style="padding-bottom: 16px;">If you need <i>hale studio</i> to <b>connect to the internet via a
+		<li style="padding-bottom: 16px;">If you need <i>hale製tudio</i> to <b>connect to the internet via a
 				proxy server</b>, you need to provide that information as system
 			properties as well. The command line interface will not read the
-			proxy settings you configured in the <i>hale studio</i> user interface.<br><br>
+			proxy settings you configured in the <i>hale製tudio</i> user interface.<br><br>
 			The following system properties can be provided to configure the proxy:
 			<ul>
 				<li><code>http.proxyHost</code> - the proxy host name or IP address</li>
@@ -96,7 +96,7 @@
 		is an <b>application argument</b>.
 	</p>
 	<p class="Note">
-		<b>Note:</b> As an alternative to using the <i>hale studio</i> application to
+		<b>Note:</b> As an alternative to using the <i>hale製tudio</i> application to
 		launch the CLI, you can use the dedicated <a
 			href="https://github.com/halestudio/hale-cli" target="_blank">hale-cli</a>.
 		With <i>hale-cli</i> a transformation is called like this:<br>
@@ -106,13 +106,13 @@
 	</p>
 	<p class="Note">
 		<b>Note:</b>
-		If using the <i>hale studio</i> executable on Windows you will probably want to add the <code>-console</code> launcher argument as well:
+		If using the <i>hale製tudio</i> executable on Windows you will probably want to add the <code>-console</code> launcher argument as well:
 		<code>HALE -nosplash -console -application hale.transform</code><br>
 		Otherwise you may get no feedback from the application (if you still get no feedback, launch via Java).
 	</p>
 	<p class="Note">
-		<b>Note:</b> If using a version of <i>hale studio</i> installed with the Windows
-		installer (or generally a version of <i>hale studio</i> that has no write access to
+		<b>Note:</b> If using a version of <i>hale製tudio</i> installed with the Windows
+		installer (or generally a version of <i>hale製tudio</i> that has no write access to
 		its directory) it is needed to specify a data location with the
 		additional launcher argument
 		<code>-data</code>
@@ -202,7 +202,7 @@
 		<code>-source</code>
 		argument for each.
 	</p>
-	<p><i>hale studio</i> will try to guess the file format and how to read it, so in
+	<p><i>hale製tudio</i> will try to guess the file format and how to read it, so in
 		most cases it will be enough to specify the location of the source
 		data. But you also have the possibility to control in detail which
 		hale data reader to use and how to configure it.</p>
@@ -213,7 +213,7 @@
 		kind of configuration options they offer.
 	</p>
 	<h4>Filtering source data</h4>
-	<p>By default <i>hale studio</i> uses all data passed in as sources for the
+	<p>By default <i>hale製tudio</i> uses all data passed in as sources for the
 		transformation. The filter options allow you to filter the source data
 		before it is passed to the transformation. This can be helpful for
 		selecting only objects actually needed for the transformation (e.g. to
@@ -284,9 +284,9 @@
 	</p>
 	<p>
 		The recommended approach is to use an export preset. You can easily
-		define it in <i>hale studio</i> with support through the UI, and save it as part of
+		define it in <i>hale製tudio</i> with support through the UI, and save it as part of
 		the project. An export preset essentially stores the configuration
-		information on how to save the data. Create it in <i>hale studio</i> via <i>File</i>&#8594;<i>Export</i>&#8594;<i>Create
+		information on how to save the data. Create it in <i>hale製tudio</i> via <i>File</i>&#8594;<i>Export</i>&#8594;<i>Create
 			custom data export...</i> in the main menu. Configure the export and
 		specify a name for the preset - this name is what you specify to use
 		the preset on the command line.
@@ -327,7 +327,7 @@
 			the validation. Use this option if you want to know in detail what
 			kind of warnings or errors may have occurred during the execution of
 			these tasks. If you find the file format hard to read, import the
-			report log into the <i>Report List</i> view in <i>hale studio</i>.
+			report log into the <i>Report List</i> view in <i>hale製tudio</i>.
 		</dd>
 		<dt><code>-stacktrace</code></dt>
 		<dd>Provide this flag to enable printing the stacktrace if

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/properties.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/properties.html
@@ -10,7 +10,7 @@
 		The properties view displays detailed information about the currently
 		selected object. Depending on the type of object, a different set of
 		properties is displayed. The object types for which this information
-		is available in <i>hale studio</i> are the following:
+		is available in <i>hale»studio</i> are the following:
 	</p>
 	<ul>
 		<li>Schema elements (e.g. selection from the <a

--- a/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html
+++ b/doc/plugins/eu.esdihumboldt.hale.doc.user/html/views/schema_explorer.html
@@ -19,7 +19,7 @@
 	<p>
 		The top level elements in the schema explorer are the classes/types
 		defined in the schema, which may be used in the mapping. When loading
-		a schema <i>hale studio</i> tries to determine this automatically, but you
+		a schema <i>hale»studio</i> tries to determine this automatically, but you
 		can also define manually, which types are relevant for your mapping.
 	</p>
 	<p>


### PR DESCRIPTION
For the remaining sections of the hale»studio help pages, the name consistency was checked and corrected were necessary to hale»studio. On all pages, hale»studio should appear correctly. 