### PR TITLE
Support creating a spatial index when writing GeoPackage files

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/META-INF/MANIFEST.MF
@@ -6,4 +6,8 @@ Bundle-Version: 4.1.0.qualifier
 Bundle-Vendor: wetransform GmbH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: eu.esdihumboldt.hale.ui,
- eu.esdihumboldt.hale.io.geopackage;bundle-version="4.0.0"
+ eu.esdihumboldt.hale.io.geopackage;bundle-version="4.0.0",
+ eu.esdihumboldt.hale.common.instance;bundle-version="4.0.0",
+ eu.esdihumboldt.hale.common.core;bundle-version="4.0.0",
+ org.eclipse.ui;bundle-version="3.116.0",
+ eu.esdihumboldt.hale.ui.util;bundle-version="4.0.0"

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/plugin.xml
@@ -10,6 +10,13 @@
                ref="eu.esdihumboldt.hale.io.geopackage.instance.writer">
          </provider>
       </configPage>
+      <configPage
+            class="eu.esdihumboldt.hale.io.geopackage.ui.GeopackageWriterSettingsPage"
+            order="1">
+         <provider
+               ref="eu.esdihumboldt.hale.io.geopackage.instance.writer">
+         </provider>
+      </configPage>
    </extension>
 
 </plugin>

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.geopackage.ui;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+
+import eu.esdihumboldt.hale.io.geopackage.GeopackageInstanceWriter;
+import eu.esdihumboldt.hale.io.geopackage.GeopackageSpatialIndexType;
+import eu.esdihumboldt.hale.ui.io.IOWizard;
+import eu.esdihumboldt.hale.ui.io.config.AbstractConfigurationPage;
+import eu.esdihumboldt.hale.ui.util.viewer.EnumContentProvider;
+
+/**
+ * Configuration page for {@link GeopackageInstanceWriter} settings.
+ * 
+ * @author Florian Esser
+ */
+public class GeopackageWriterSettingsPage extends
+		AbstractConfigurationPage<GeopackageInstanceWriter, IOWizard<GeopackageInstanceWriter>> {
+
+	private ComboViewer spatialIndexType;
+
+	/**
+	 * Default constructor
+	 */
+	public GeopackageWriterSettingsPage() {
+		super("gpkg.settings");
+
+		setTitle("GeoPackage Writer settings");
+		setDescription("Settings for the GeoPackage writer");
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.HaleWizardPage#onShowPage(boolean)
+	 */
+	@Override
+	protected void onShowPage(boolean firstShow) {
+		super.onShowPage(firstShow);
+		if (firstShow) {
+			spatialIndexType
+					.setSelection(new StructuredSelection(GeopackageSpatialIndexType.RTREE));
+		}
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.config.AbstractConfigurationPage#enable()
+	 */
+	@Override
+	public void enable() {
+		// do nothing
+
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.config.AbstractConfigurationPage#disable()
+	 */
+	@Override
+	public void disable() {
+		// do nothing
+
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.IOWizardPage#updateConfiguration(eu.esdihumboldt.hale.common.core.io.IOProvider)
+	 */
+	@Override
+	public boolean updateConfiguration(GeopackageInstanceWriter provider) {
+		setMessage("Settings for the GeoPackage writer");
+
+		GeopackageSpatialIndexType indexType = GeopackageSpatialIndexType.RTREE;
+		ISelection order = spatialIndexType.getSelection();
+		if (!order.isEmpty() && order instanceof IStructuredSelection) {
+			Object selected = ((IStructuredSelection) spatialIndexType.getSelection())
+					.getFirstElement();
+			if (selected instanceof GeopackageSpatialIndexType) {
+				indexType = (GeopackageSpatialIndexType) selected;
+			}
+		}
+		provider.setSpatialIndexType(indexType.getParameterValue());
+
+		return true;
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.HaleWizardPage#createContent(org.eclipse.swt.widgets.Composite)
+	 */
+	@Override
+	protected void createContent(Composite page) {
+		page.setLayout(new GridLayout(1, false));
+		GridDataFactory groupData = GridDataFactory.fillDefaults().grab(true, false);
+
+		Group spatialIndexGroup = new Group(page, SWT.NONE);
+		spatialIndexGroup.setText("Spatial index");
+		GridLayoutFactory.swtDefaults().numColumns(2).applyTo(spatialIndexGroup);
+		groupData.applyTo(spatialIndexGroup);
+
+		Label spatialIndexTypeLabel = new Label(spatialIndexGroup, SWT.NONE);
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).applyTo(spatialIndexTypeLabel);
+		spatialIndexTypeLabel.setText("Type of spatial index to create:");
+
+		spatialIndexType = new ComboViewer(spatialIndexGroup);
+		// TODO Replace by extension-based approach where index types are
+		// provided via an extension point, similar to the way
+		// InterpolationAlgorithm is handled
+		spatialIndexType.setContentProvider(EnumContentProvider.getInstance());
+		spatialIndexType.setLabelProvider(new LabelProvider() {
+
+			@Override
+			public String getText(Object element) {
+				if (element instanceof GeopackageSpatialIndexType) {
+					return ((GeopackageSpatialIndexType) element).getDescription();
+				}
+				return super.getText(element);
+			}
+		});
+		spatialIndexType.setInput(GeopackageSpatialIndexType.class);
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -64,6 +64,19 @@
                   sampleDescription="Reference systems can be defined either as code or WKT (preceded with code: or wkt: respectively)">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Type of spatial index to use when new tables are created in the target GeoPackage file"
+               label="Type of spatial index"
+               name="spatialindex.type"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.String">
+            </parameterBinding>
+            <valueDescriptor
+                  default="rtree"
+                  defaultDescription="By default, an RTree Spatial Index is created">
+            </valueDescriptor>
+         </providerParameter>
       </provider>
    </extension>
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -42,7 +42,7 @@
                ref="eu.esdihumboldt.hale.io.geopackage">
          </contentType>
          <providerParameter
-               description="Allows to provide a WHERE clause filter for tables in the GeoPackage. One WHERE clause per table can be defined. The syntax is &quot;&lt;table name 1&gt;|&lt;WHERE clause 1||&lt;table name 2&gt;|&lt;WHERE clause 2&gt;||...&quot;"
+               description="Allows to provide a WHERE clause filter for tables in the GeoPackage. One WHERE clause per table can be defined. The syntax is &quot;&amp;lt;table name 1&amp;gt;|&amp;lt;WHERE clause 1&amp;gt;||&amp;lt;table name 2&amp;gt;|&amp;lt;WHERE clause 2&amp;gt;||...&quot;"
                label="Filters for querying the GeoPackage database"
                name="queryFilter"
                optional="true">

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageSpatialIndexType.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageSpatialIndexType.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.geopackage;
+
+/**
+ * 
+ * Modes for determining which spatial index should be used when writing a new
+ * GeoPackage file.
+ * 
+ * TODO Replace by extension-based approach where index types are provided via
+ * an extension point, similar to the way InterpolationAlgorithm is handled
+ * 
+ * @author Florian Esser
+ */
+public enum GeopackageSpatialIndexType {
+
+	/**
+	 * RTree spatial index, see
+	 * http://www.geopackage.org/spec121/#extension_rtree
+	 */
+	RTREE("RTree Spatial Index", "rtree"),
+
+	/**
+	 * NGA Geometry Index, see
+	 * http://ngageoint.github.io/GeoPackage/docs/extensions/geometry-index.
+	 * html
+	 */
+	NGA("NGA Geometry Index", "nga"),
+
+	/**
+	 * No spatial index
+	 */
+	NONE("Disable index creation", "none");
+
+	private final String description;
+	private final String parameterValue;
+
+	GeopackageSpatialIndexType(String description, String parameterValue) {
+		this.description = description;
+		this.parameterValue = parameterValue;
+	}
+
+	@SuppressWarnings("javadoc")
+	public String getDescription() {
+		return description;
+	}
+
+	@SuppressWarnings("javadoc")
+	public String getParameterValue() {
+		return parameterValue;
+	}
+}


### PR DESCRIPTION
Add support for creating spatial indexes and create an RTree spatial index by default when creating new GeoPackage files.

refs #883 