### PR TITLE
feat: be lenient about missing time zone information when parsing timestamps

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.convert.core/src/eu/esdihumboldt/hale/common/convert/core/StringToInstantConverter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.convert.core/src/eu/esdihumboldt/hale/common/convert/core/StringToInstantConverter.java
@@ -16,6 +16,7 @@
 package eu.esdihumboldt.hale.common.convert.core;
 
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 
 import org.springframework.core.convert.converter.Converter;
 
@@ -31,7 +32,19 @@ public class StringToInstantConverter implements Converter<String, Instant> {
 		if (source == null) {
 			return null;
 		}
-		return Instant.parse(source);
-	}
 
+		Instant result;
+		try {
+			result = Instant.parse(source);
+		} catch (DateTimeParseException e) {
+			// Be lenient about missing time zone information
+			try {
+				result = Instant.parse(source + "Z");
+			} catch (Throwable t) {
+				throw e;
+			}
+		}
+
+		return result;
+	}
 }


### PR DESCRIPTION
When a timestamp string that is to be converted to java.time.Instant
causes a `DateTimeParseExcpetion`, try to reparse it with an added `Z`.
This allows to be lenient about ISO 8601 timestamps from GeoPackages that
are missing the time zone information.

https://github.com/halestudio/hale/issues/887