### PR TITLE
build: login to Docker Hub before building products

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ jobs:
       script:
         # Output something every minute lest Travis kills the job
         - while sleep 1m; do echo "=====[ still running after $SECONDS seconds... ]====="; done &
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - mkdir -p build/target
         - ./build.sh product -a ${ARCH} -o ${PLATFORM} ${ADDITIONAL_FLAGS} ${PRODUCT}
         # Killing background sleep loop


### PR DESCRIPTION
Log into Docker Hub before starting  a product build to prevent hitting [rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) for anonymous users.