### PR TITLE
fix: fix ArcString interpolation handling

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/data/arcstring/sample-arcstring-gml32.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/data/arcstring/sample-arcstring-gml32.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gml:FeatureCollection gml:id="fcollection"
+	xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:hale="eu:esdihumboldt:hale:test"
+	xsi:schemaLocation="eu:esdihumboldt:hale:test geom-gml32.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+	<gml:boundedBy>
+		<gml:Null></gml:Null>
+	</gml:boundedBy>
+  <gml:featureMember>
+		<hale:ArcStringProperty gml:id="ageom1">
+			<hale:geometry gml:id="LineString1" srsName="EPSG:25832">
+				<gml:posList>552400.131 5941061.830 552211.949 5941201.903 552048.407 5941370.089 551881.562 5941562.239 551735.790 5941770.827</gml:posList>
+			</hale:geometry>
+		</hale:ArcStringProperty>
+	</gml:featureMember>
+</gml:FeatureCollection>

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/data/gml/geom-gml32.xsd
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/data/gml/geom-gml32.xsd
@@ -91,6 +91,19 @@
 			</extension>
 		</complexContent>
 	</complexType>
+	
+	<element name="ArcStringProperty" substitutionGroup="gml:AbstractFeature"
+		type="hale:ArcStringPropertyType" />
+
+	<complexType name="ArcStringPropertyType">
+		<complexContent>
+			<extension base="gml:AbstractFeatureType">
+				<sequence>
+					<element name="geometry" type="gml:ArcStringType" />
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
 
 	<element name="PolygonProperty" substitutionGroup="gml:AbstractFeature"
 		type="hale:PolygonPropertyType" />

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/eu/esdihumboldt/hale/io/gml/geometry/handler/ArcStringHandlerTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/eu/esdihumboldt/hale/io/gml/geometry/handler/ArcStringHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.gml.geometry.handler;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+
+import eu.esdihumboldt.hale.common.instance.model.Instance;
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
+import eu.esdihumboldt.hale.io.gml.geometry.handler.internal.AbstractHandlerTest;
+
+/**
+ * Test for interpolating ArcString geometries
+ * 
+ * @author Johanna Ott
+ */
+public class ArcStringHandlerTest extends AbstractHandlerTest {
+
+	private Consumer<Geometry> checker;
+	private LineString reference;
+
+	@Override
+	public void init() {
+		super.init();
+
+		// define expected values
+		Coordinate start = new Coordinate(552400.131, 5941061.83);
+		Coordinate end = new Coordinate(551735.79, 5941770.827);
+		int coordinateCount = 16385;
+
+		checker = combine(startEndChecker(start, end, coordinateCount), noCoordinatePairs());
+
+	}
+
+	/**
+	 * Test linestring geometries read from a GML 2 file
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testArcStringGml32() throws Exception {
+		InstanceCollection instances = AbstractHandlerTest.loadXMLInstances(
+				getClass().getResource("/data/gml/geom-gml32.xsd").toURI(),
+				getClass().getResource("/data/arcstring/sample-arcstring-gml32.xml").toURI());
+
+		ResourceIterator<Instance> it = instances.iterator();
+		try {
+			assertTrue("ArcString is not interpolated correctly", it.hasNext());
+			Instance instance = it.next();
+			checkSingleGeometry(instance, checker);
+		} finally {
+			it.close();
+		}
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/eu/esdihumboldt/hale/io/gml/geometry/handler/internal/AbstractHandlerTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.geometry.test/src/eu/esdihumboldt/hale/io/gml/geometry/handler/internal/AbstractHandlerTest.java
@@ -171,6 +171,27 @@ public abstract class AbstractHandlerTest extends AbstractSVGPainterTest {
 	}
 
 	/**
+	 * Creates a geometry checker that checks for equality of the first and last
+	 * point and of the number of coordinates
+	 * 
+	 * @param start the starting point of the geometry
+	 * @param end the end point of the geometry
+	 * @param coordinateCount the number of coordinates contained in the
+	 *            geometry
+	 * @return the checker
+	 */
+	protected Consumer<Geometry> startEndChecker(Coordinate start, Coordinate end,
+			int coordinateCount) {
+		return (geom) -> {
+			assertEquals("Number of coordinates does not match", coordinateCount,
+					geom.getCoordinates().length);
+			assertTrue("Start coordinate does not match", geom.getCoordinates()[0].equals2D(start));
+			assertTrue("End coordinate does not match",
+					geom.getCoordinates()[coordinateCount - 1].equals2D(end));
+		};
+	}
+
+	/**
 	 * Check a single geometry contained in an instance (at an arbitrary path).
 	 * 
 	 * @param instance the geometry instance

--- a/io/plugins/eu.esdihumboldt.hale.io.gml.geometry/src/eu/esdihumboldt/hale/io/gml/geometry/handler/ArcStringHandler.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml.geometry/src/eu/esdihumboldt/hale/io/gml/geometry/handler/ArcStringHandler.java
@@ -80,7 +80,7 @@ public class ArcStringHandler extends LineStringHandler {
 					"Arc string must be defined by at least three points");
 		}
 		List<Arc> arcs = new ArrayList<>();
-		for (int i = 0; i < coords.length - 2; i += 3) {
+		for (int i = 0; i < coords.length - 2; i += 2) {
 			Arc arc = new ArcByPointsImpl(coords[i], coords[i + 1], coords[i + 2]);
 			arcs.add(arc);
 		}


### PR DESCRIPTION
When an ArcString object was devided in single Arc objects in order to
interpolate them before, the iterator was raised by 3 in every step. As
gml:ArcString objects consist of multiple arcs object and the endpoint
of one arc represents the start point of the next arc at the same time.
This means, if two arcs are contained in an ArcString object, the first
arc starts as coordinate 0 and the second one starts at coordinate 2 etc.
So the iterator for the starting point should only be raised by 2 in order
to access the next arc.

WGS-1215