### PR TITLE
fixup! docs:Added function examples

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.geometric/build.properties
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.geometric/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               icons/
+               icons/,\
+               help/


### PR DESCRIPTION
Add `help/` folder created in 3b43b45c899e0d8f59fa673b483ae8da591b8b72 to binary build