### PR TITLE
Prevent duplicate imports of the same schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
         - sleep 10
         - sudo systemctl status docker.service
         # Pull Docker images required for integration tests
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - docker pull kartoza/postgis
         - ./build.sh integrationStage
         # Killing background sleep loop


### PR DESCRIPTION
Patch to prevent duplicate import of the same schema when the schema locations differ only in the scheme part, e.g. `http://example.org/a.xsd` and `https://example.org/a.xsd`.

Also fix up the Travis CI build to also log into Docker when running the integration stage.