### PR TITLE
fix(ui): use IProxyService to apply proxy configuration in the UI

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.util/META-INF/MANIFEST.MF
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 4.1.0.qualifier
 Bundle-Activator: eu.esdihumboldt.hale.ui.util.internal.UIUtilitiesPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.jface.text;bundle-version="3.7.1"
+ org.eclipse.jface.text;bundle-version="3.7.1",
+ org.eclipse.core.net;bundle-version="1.3.800"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: eu.esdihumboldt.hale.ui.util,
@@ -31,8 +32,9 @@ Export-Package: eu.esdihumboldt.hale.ui.util,
  eu.esdihumboldt.hale.ui.util.wizard
 Import-Package: com.google.common.base;version="11.0.1",
  com.google.common.util.concurrent;version="15.0.0",
- de.fhg.igd.slf4jplus,
  de.fhg.igd.osgi.util;version="1.0.0",
+ de.fhg.igd.slf4jplus,
+ eu.esdihumboldt.hale.common.core,
  eu.esdihumboldt.util,
  eu.esdihumboldt.util.http,
  org.apache.http,

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/proxy/preferences/ProxyPreferencePage.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/proxy/preferences/ProxyPreferencePage.java
@@ -16,6 +16,7 @@
 
 package eu.esdihumboldt.hale.ui.util.proxy.preferences;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -27,6 +28,8 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.hale.ui.util.components.PasswordFieldEditor;
 import eu.esdihumboldt.hale.ui.util.internal.Messages;
 import eu.esdihumboldt.hale.ui.util.internal.UIUtilitiesPlugin;
@@ -37,10 +40,10 @@ import eu.esdihumboldt.hale.ui.util.proxy.ProxySettings;
  * 
  * @author Michel Kraemer
  */
-public class ProxyPreferencePage extends FieldEditorPreferencePage implements
-		IWorkbenchPreferencePage {
+public class ProxyPreferencePage extends FieldEditorPreferencePage
+		implements IWorkbenchPreferencePage {
 
-//	private static final ALogger _log = ALoggerFactory.getLogger(ProxyPreferencePage.class);
+	private static final ALogger log = ALoggerFactory.getLogger(ProxyPreferencePage.class);
 
 	/**
 	 * Default constructor
@@ -95,7 +98,12 @@ public class ProxyPreferencePage extends FieldEditorPreferencePage implements
 			return false;
 		}
 
-		ProxySettings.applyCurrentSettings();
+		try {
+			ProxySettings.applyCurrentSettings();
+		} catch (CoreException e) {
+			log.userError("Proxy settings could not be applied", e);
+			return false;
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Replaces the direct setting of proxy-related system properties by calls to the
proxy interface exposed by the Eclipse `IProxyService`.

This also allows the proxy settings to be applied to RCP components that are
used within hale»studio, like the software installation dialog to install
plugins.

https://github.com/halestudio/hale/issues/727
SVC-881