### PR TITLE
feat: add END-related schemas to presets

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.test/Tests.product
+++ b/common/plugins/eu.esdihumboldt.hale.common.test/Tests.product
@@ -251,6 +251,7 @@
       <plugin id="eu.esdihumboldt.util.orient.embedded.test"/>
       <plugin id="eu.esdihumboldt.util.resource"/>
       <plugin id="eu.esdihumboldt.util.resource.schemas.citygml"/>
+      <plugin id="eu.esdihumboldt.util.resource.schemas.end"/>
       <plugin id="eu.esdihumboldt.util.resource.schemas.inspire"/>
       <plugin id="eu.esdihumboldt.util.resource.schemas.inspire.annex1"/>
       <plugin id="eu.esdihumboldt.util.resource.schemas.opengis.net"/>

--- a/util/features/eu.esdihumboldt.util.feature.resource/feature.xml
+++ b/util/features/eu.esdihumboldt.util.feature.resource/feature.xml
@@ -32,4 +32,11 @@
          install-size="0"
          version="0.0.0"/>
 
+   <plugin
+         id="eu.esdihumboldt.util.resource.schemas.end"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/util/plugins/eu.esdihumboldt.util.resource.schemas.end/.project
+++ b/util/plugins/eu.esdihumboldt.util.resource.schemas.end/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>eu.esdihumboldt.util.resource.schemas.end</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/util/plugins/eu.esdihumboldt.util.resource.schemas.end/.settings/org.eclipse.jdt.core.prefs
+++ b/util/plugins/eu.esdihumboldt.util.resource.schemas.end/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/util/plugins/eu.esdihumboldt.util.resource.schemas.end/META-INF/MANIFEST.MF
+++ b/util/plugins/eu.esdihumboldt.util.resource.schemas.end/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundled Environmental Noise Directive (END) Schemas
+Bundle-SymbolicName: eu.esdihumboldt.util.resource.schemas.end;singleton:=true
+Bundle-Version: 4.1.0.qualifier
+Automatic-Module-Name: eu.esdihumboldt.util.resource.schemas.end
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: eu.esdihumboldt.hale.common.schema.presets

--- a/util/plugins/eu.esdihumboldt.util.resource.schemas.end/build.properties
+++ b/util/plugins/eu.esdihumboldt.util.resource.schemas.end/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               plugin.xml

--- a/util/plugins/eu.esdihumboldt.util.resource.schemas.end/plugin.xml
+++ b/util/plugins/eu.esdihumboldt.util.resource.schemas.end/plugin.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="eu.esdihumboldt.hale.ui.schema.presets">
+      <category
+            id="eu.esdihumboldt.util.resource.schemas.end.category"
+            name="European Noise Directive">
+      </category>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF1_5 Agglomeration Source"
+            id="eu.esdihumboldt.util.resource.schemas.presets.end.df1-5.agg"
+            name="END DF1_5 Agglomeration Source"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF1_5/AgglomerationSource/AgglomerationSource.hsd.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF1_5 Major Airport Source"
+            id="eu.esdihumboldt.util.resource.schemas.end.df1-5.mas"
+            name="END DF1_5 Major Airport Source"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF1_5/MajorAirportSource/MajorAirportSource.hsd.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF1_5 Major Railway Source"
+            id="eu.esdihumboldt.util.resource.schemas.end.schema.df1-5.mrails"
+            name="END DF1_5 Major Railway Source"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF1_5/MajorRailwaySource/MajorRailwaySource.hsd.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF1_5 Major Road Source"
+            id="eu.esdihumboldt.util.resource.schemas.end.schema.df1-5.mroads"
+            name="END DF1_5 Major Road Source"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF1_5/MajorRoadSource/MajorRoadSource.hsd.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF4_8 Agglomerations"
+            id="eu.esdihumboldt.util.resource.schemas.end.df4-8.agg"
+            name="END DF4_8 Agglomerations"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF4_8/Agglomerations/DF4_8-Agglomerations.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF4_8 Major Airports"
+            id="eu.esdihumboldt.util.resource.schemas.end.df4-8.mair"
+            name="END DF4_8 Major Airports"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF4_8/MajorAirports/DF4_8-MajorAirports.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF4_8 Major Railways"
+            id="eu.esdihumboldt.util.resource.schemas.end.df4-8.mrail"
+            name="END DF4_8 Major Railways"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF4_8/MajorRailways/DF4_8-MajorRailways.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF4_8 Major Roads"
+            id="eu.esdihumboldt.util.resource.schemas.end.df4-8.mroads"
+            name="END DF4_8 Major Roads"
+            version="1.0">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF4_8/MajorRoads/DF4_8-MajorRoads.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF7_10 Noise Action Plan Coverage Area"
+            id="eu.esdihumboldt.util.resource.schemas.end.df7-10.nap"
+            name="END DF7_10 Noise Action Plan Coverage Area"
+            version="beta">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF7_10/NoiseActionPlans/NoiseActionPlan-CoverageArea.hsd.json">
+         </uri>
+      </schema>
+      <schema
+            category="eu.esdihumboldt.util.resource.schemas.end.category"
+            description="Geopackage European Noise Directive Application Schema for DF7_10 Quiet Areas"
+            id="eu.esdihumboldt.util.resource.schemas.end.df7-10.qa"
+            name="END DF7_10 Quiet Areas"
+            version="beta">
+         <uri
+               value="https://raw.githubusercontent.com/wetransform-os/geopackage-end/018d8207556dac0f0e4977cbe2a2206cf9094d9c/DF7_10/QuietAreas/QuietAreas.hsd.json">
+         </uri>
+      </schema>
+   </extension>
+
+</plugin>


### PR DESCRIPTION
This commit provides support for
adding END related schemas to
the presets tab for source and target
schemas.
The schemas are directly used from
the GitHub urls.

ING 2970