### PR TITLE
feat: enable selecting more than one file when loading schema or data

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/ImportProvider.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/ImportProvider.java
@@ -16,8 +16,10 @@
 
 package eu.esdihumboldt.hale.common.core.io;
 
+import java.io.IOException;
 import java.io.InputStream;
 
+import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier;
 
 /**
@@ -62,5 +64,27 @@ public interface ImportProvider extends IOProvider {
 	 *         was not executed yet
 	 */
 	public String getResourceIdentifier();
+
+	/**
+	 * This method executes the I/O provider. It is a special case of
+	 * <code>IOProvider.execute(ProgressIndicator progress)</code> and used when
+	 * importing multiple schemas or instances. The method is overloaded with
+	 * resourceIdentifier because for every file selected by the user a new
+	 * resource identifier has to be generated so that every schema
+	 * in @link{SchemaServiceImpl} gets a new ID for the selected schema.
+	 * 
+	 * @param progress the progress indicator, may be <code>null</code>
+	 * @param resourceIdentifier identifier of the provided resource. Null if a
+	 *            new resource id needs to be generated.
+	 * @return the execution report
+	 * 
+	 * @throws IOProviderConfigurationException if the I/O provider was not
+	 *             configured properly
+	 * @throws IOException if an I/O operation fails
+	 * @throws UnsupportedOperationException if the operation to load multiple
+	 *             files is not supported.
+	 */
+	public IOReport execute(ProgressIndicator progress, String resourceIdentifier)
+			throws IOProviderConfigurationException, IOException, UnsupportedOperationException;
 
 }

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/impl/AbstractImportProvider.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/impl/AbstractImportProvider.java
@@ -75,6 +75,21 @@ public abstract class AbstractImportProvider extends AbstractIOProvider implemen
 	}
 
 	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.impl.AbstractIOProvider#execute(eu.esdihumboldt.hale.common.core.io.ProgressIndicator,
+	 *      java.lang.String)
+	 */
+	@SuppressWarnings("javadoc")
+	@Override
+	public IOReport execute(ProgressIndicator progress, String resourceIdentifier)
+			throws IOProviderConfigurationException, IOException, UnsupportedOperationException {
+
+		if (resourceIdentifier == null) {
+			this.resourceIdentifier = generateResourceId();
+		}
+		return super.execute(progress);
+	}
+
+	/**
 	 * Generate the unique resource identifier.
 	 * 
 	 * @return the generated resource identifier

--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/supplier/FilesIOSupplier.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/io/supplier/FilesIOSupplier.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.core.io.supplier;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import eu.esdihumboldt.util.io.InputSupplier;
+import eu.esdihumboldt.util.io.OutputSupplier;
+
+/**
+ * I/O supplier based on a {@link File} and used when importing multiple schemas
+ * or instances.
+ * 
+ * @author Kapil Agnihotri
+ */
+public class FilesIOSupplier
+		implements LocatableInputSupplier<InputStream>, LocatableOutputSupplier<OutputStream> {
+
+	private final File file;
+	private final List<File> files;
+	private final List<URI> usedURILocations;
+	private final URI usedURI;
+
+	/**
+	 * Create a file I/O supplier.
+	 * 
+	 * @param file the file
+	 */
+	public FilesIOSupplier(File file) {
+		this(file, file.toURI());
+	}
+
+	/**
+	 * Create a file I/O supplier, which may return a relative URI on
+	 * {@link #getLocation()}.
+	 * 
+	 * @param absoluteFile the file
+	 * 
+	 * @param usedURI the (relative) URI to use
+	 * 
+	 */
+	public FilesIOSupplier(File absoluteFile, URI usedURI) {
+		this(Arrays.asList(absoluteFile), Arrays.asList(usedURI));
+	}
+
+	/**
+	 * Create a file I/O supplier, which may return a relative URI on
+	 * {@link #getLocation()}.
+	 * 
+	 * @param files list of files
+	 * @param uris list of the (relative) URI to use
+	 * 
+	 */
+	public FilesIOSupplier(List<File> files, List<URI> uris) {
+		super();
+		this.file = files.get(0);
+		this.usedURI = uris.get(0);
+		this.files = files;
+		this.usedURILocations = uris;
+	}
+
+	/**
+	 * @see InputSupplier#getInput()
+	 */
+	@Override
+	public InputStream getInput() throws IOException {
+		return new BufferedInputStream(new FileInputStream(file));
+	}
+
+	/**
+	 * @see OutputSupplier#getOutput()
+	 */
+	@Override
+	public OutputStream getOutput() throws IOException {
+		return new BufferedOutputStream(new FileOutputStream(file));
+	}
+
+	/**
+	 * @see Locatable#getLocation()
+	 */
+	@Override
+	public URI getLocation() {
+		return file.toURI();
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((file == null) ? 0 : file.hashCode());
+		return result;
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		FilesIOSupplier other = (FilesIOSupplier) obj;
+		if (file == null) {
+			if (other.file != null)
+				return false;
+		}
+		else if (!file.equals(other.file))
+			return false;
+		return true;
+	}
+
+	@Override
+	public URI getUsedLocation() {
+		return usedURI;
+	}
+
+	/**
+	 * Getter
+	 * 
+	 * @return the list of files
+	 */
+	public List<File> getFiles() {
+		return files;
+	}
+
+	/**
+	 * Method to get a list of all the locations selected by the user during
+	 * multiple import.
+	 * 
+	 * @return list of URIs.
+	 */
+	public List<URI> getUsedLocations() {
+		return usedURILocations;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/reader/internal/SpatiaLiteInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/reader/internal/SpatiaLiteInstanceReader.java
@@ -16,11 +16,15 @@
 package eu.esdihumboldt.hale.io.jdbc.spatialite.reader.internal;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 
+import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
+import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
 import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.supplier.DefaultInputSupplier;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier;
 import eu.esdihumboldt.hale.common.instance.io.util.InstanceReaderDecorator;
@@ -75,6 +79,19 @@ public class SpatiaLiteInstanceReader extends InstanceReaderDecorator<JDBCInstan
 	public void setSource(LocatableInputSupplier<? extends InputStream> source) {
 		this.source = source;
 		internalProvider.setSource(new SpatiaLiteJdbcIOSupplier(new File(source.getLocation())));
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.ImportProvider#execute(eu.esdihumboldt.hale.common.core.io.ProgressIndicator,
+	 *      java.lang.String)
+	 */
+	@Override
+	public IOReport execute(ProgressIndicator progress, String resourceIdentifier)
+			throws IOProviderConfigurationException, IOException, UnsupportedOperationException {
+		// for now loading multiple instances from SpatiaLite DB is not
+		// supported.
+		throw new UnsupportedOperationException(
+				"The operation is not supported for SpatiaLite DB multiple files!");
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/reader/internal/SpatiaLiteSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.jdbc.spatialite/src/eu/esdihumboldt/hale/io/jdbc/spatialite/reader/internal/SpatiaLiteSchemaReader.java
@@ -16,11 +16,15 @@
 package eu.esdihumboldt.hale.io.jdbc.spatialite.reader.internal;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 
+import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
+import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
 import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.supplier.DefaultInputSupplier;
 import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier;
 import eu.esdihumboldt.hale.common.schema.io.util.SchemaReaderDecorator;
@@ -75,5 +79,17 @@ public class SpatiaLiteSchemaReader extends SchemaReaderDecorator<JDBCSchemaRead
 	public void setSource(LocatableInputSupplier<? extends InputStream> source) {
 		this.source = source;
 		internalProvider.setSource(new SpatiaLiteJdbcIOSupplier(new File(source.getLocation())));
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.common.core.io.IOProvider#execute(eu.esdihumboldt.hale.common.core.io.ProgressIndicator,
+	 *      java.lang.String)
+	 */
+	@Override
+	public IOReport execute(ProgressIndicator progress, String resourceIdentifier)
+			throws IOProviderConfigurationException, IOException, UnsupportedOperationException {
+		// for now loading multiple schemas from SpatiaLite DB is not supported.
+		throw new UnsupportedOperationException(
+				"The operation is not supported for SpatiaLite DB multiple files!");
 	}
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.shp.ui/src/eu/esdihumboldt/hale/io/shp/ui/TypeSelectionPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp.ui/src/eu/esdihumboldt/hale/io/shp/ui/TypeSelectionPage.java
@@ -26,6 +26,8 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -63,6 +65,12 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage
 	private TypeDefinition lastType;
 
 	private Button matchShortPropertyNames;
+
+	/**
+	 * Button to enable auto detection of the schemas. Useful when importing
+	 * multiple source data for multiple schema files.
+	 */
+	private Button autoDetect;
 
 	private Composite page;
 
@@ -117,6 +125,30 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage
 					GridDataFactory.fillDefaults().grab(false, false).span(2, 1).create());
 			matchShortPropertyNames.setText(
 					"Match shortened property names in Shapefile to target type properties");
+
+			autoDetect = new Button(page, SWT.CHECK);
+			autoDetect.setLayoutData(
+					GridDataFactory.fillDefaults().grab(false, false).span(2, 1).create());
+			autoDetect.setText("Ignore Schema type selection and auto detect types");
+
+			autoDetect.addSelectionListener(new SelectionListener() {
+
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					if (autoDetect.getSelection()) {
+						selector.getControl().setEnabled(false);
+					}
+					else {
+						selector.getControl().setEnabled(true);
+					}
+				}
+
+				@Override
+				public void widgetDefaultSelected(SelectionEvent e) {
+					// default selection is false.
+					selector.getControl().setEnabled(true);
+				}
+			});
 
 			page.layout();
 			page.pack();
@@ -225,8 +257,11 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage
 		if (selector.getSelectedObject() != null) {
 			QName name = selector.getSelectedObject().getName();
 			provider.setParameter(PARAM_TYPENAME, Value.of(name.toString()));
+
 			provider.setParameter(PARAM_MATCH_SHORT_PROPERTY_NAMES,
 					Value.of(matchShortPropertyNames.getSelection()));
+			provider.setParameter(PARAM_AUTO_DETECT_SCHEMA_TYPES,
+					Value.of(autoDetect.getSelection()));
 		}
 		else {
 			return false;

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/ShapefileConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/ShapefileConstants.java
@@ -58,6 +58,12 @@ public interface ShapefileConstants {
 	public static final String PARAM_TYPENAME = "typename";
 
 	/**
+	 * Name of the parameter for {@link ShapeInstanceReader} to auto detect
+	 * schema types when selecting instances for multiple schemas.
+	 */
+	public static final String PARAM_AUTO_DETECT_SCHEMA_TYPES = "autoDetectSchemaTypes";
+
+	/**
 	 * Name of the parameter for {@link ShapeInstanceReader} to activate
 	 * matching of Shapefile property names to schema property names by checking
 	 * if there is exactly one schema property whose name starts with the

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/io/ExtendedFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/io/ExtendedFileFieldEditor.java
@@ -18,8 +18,10 @@ package eu.esdihumboldt.hale.ui.util.io;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jface.preference.FileFieldEditor;
@@ -37,7 +39,7 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 
 	private String[] names;
 
-	private int style;
+	private final int style;
 
 	/**
 	 * Create a file field editor
@@ -115,12 +117,22 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 		if (!f.exists()) {
 			f = null;
 		}
-		File d = getFile(f);
+		List<File> d = getFiles(f);
 		if (d == null) {
 			return null;
 		}
 
-		return d.getAbsolutePath();
+		StringBuffer absolutePaths = new StringBuffer();
+		if (d.size() == 1) {
+			absolutePaths.append(d.get(0).getAbsolutePath());
+		}
+		else {
+			d.forEach(file -> {
+				absolutePaths.append(file.getAbsolutePath());
+				absolutePaths.append("\n");
+			});
+		}
+		return absolutePaths.toString();
 	}
 
 	/**
@@ -153,6 +165,44 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 	}
 
 	/**
+	 * Helper to open the file chooser dialog to select multiple files.
+	 * 
+	 * @param startingDirectory the directory to open the dialog on.
+	 * @return File List of file(s) the user selected or <code>Empty list</code>
+	 *         if they do not.
+	 */
+	protected List<File> getFiles(File startingDirectory) {
+
+		FileDialog dialog = new FileDialog(getShell(), style);
+		if (startingDirectory != null) {
+			dialog.setFileName(startingDirectory.getPath());
+		}
+		if (extensions != null) {
+			dialog.setFilterExtensions(extensions);
+		}
+		if (names != null) {
+			dialog.setFilterNames(names);
+		}
+
+		List<File> files = new ArrayList<>();
+		if (dialog.open() != null) {
+			String[] fileNames = dialog.getFileNames();
+			String filterPath = dialog.getFilterPath();
+
+			Arrays.asList(fileNames).forEach(file -> {
+				if (file != null) {
+					file = file.trim();
+					if (file.length() > 0) {
+						files.add(new File(filterPath + File.separator + file));
+					}
+				}
+			});
+		}
+
+		return files;
+	}
+
+	/**
 	 * Sets this file field editor's file extension filter.
 	 * 
 	 * @param extensions a list of file extension, or <code>null</code> to set
@@ -181,6 +231,10 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 	 * @param types the content types
 	 */
 	public void setContentTypes(Set<IContentType> types) {
+
+		/**
+		 * when loading for instance then enable multi selection for csv too.
+		 */
 		List<String> filters = new ArrayList<String>();
 		List<String> extensions = new ArrayList<String>();
 		for (IContentType type : types) {
@@ -211,7 +265,7 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 			}
 		}
 
-		if ((style & SWT.OPEN) != 0) {
+		if (((style & SWT.OPEN) != 0) || ((style & SWT.MULTI) != 0)) {
 			// insert filter for all supported files
 			if (extensions.size() > 1) {
 				StringBuffer supportedExtensions = new StringBuffer();
@@ -236,6 +290,15 @@ public class ExtendedFileFieldEditor extends FileFieldEditor {
 
 		setFileExtensions(extensions.toArray(new String[extensions.size()]));
 		setFilterNames(filters.toArray(new String[filters.size()]));
+	}
+
+	public List<String> getStringValues() {
+		String stringValue = getStringValue();
+		String[] split = stringValue.split("\n");
+
+		List<String> collect = Arrays.asList(split).stream().filter(s -> !s.isEmpty())
+				.collect(Collectors.toList());
+		return collect;
 	}
 
 }

--- a/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/io/OpenFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.util/src/eu/esdihumboldt/hale/ui/util/io/OpenFileFieldEditor.java
@@ -52,6 +52,15 @@ public class OpenFileFieldEditor extends ExtendedFileFieldEditor {
 	}
 
 	/**
+	 * @see ExtendedFileFieldEditor#ExtendedFileFieldEditor(String, String,
+	 *      boolean, int, Composite, int )
+	 */
+	public OpenFileFieldEditor(String name, String labelText, boolean enforceAbsolute,
+			int validationStrategy, Composite parent, int style) {
+		super(name, labelText, enforceAbsolute, validationStrategy, parent, style);
+	}
+
+	/**
 	 * @see FileFieldEditor#FileFieldEditor(String, String, Composite)
 	 */
 	public OpenFileFieldEditor(String name, String labelText, Composite parent) {

--- a/ui/plugins/eu.esdihumboldt.hale.ui/plugin.xml
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/plugin.xml
@@ -907,6 +907,24 @@
             priority="-10">
       </source>
       <source
+            class="eu.esdihumboldt.hale.ui.io.source.MultipleSchemaFilesSource"
+            description="Load a resource from a file applicable for schema reader"
+            icon="icons/file_obj.gif"
+            id="eu.esdihumboldt.hale.ui.io.source.multiplefiles"
+            name="multiple files"
+            priority="-6"
+            providerType="eu.esdihumboldt.hale.common.schema.io.SchemaReader">
+      </source>
+      <source
+            class="eu.esdihumboldt.hale.ui.io.source.MultipleInstanceFilesSource"
+            description="Load a resource from a file applicable for instance reader"
+            icon="icons/file_obj.gif"
+            id="eu.esdihumboldt.hale.ui.io.source.multiplefilesforinstance"
+            name="multiple files"
+            priority="-6"
+            providerType="eu.esdihumboldt.hale.common.instance.io.InstanceReader">
+      </source>
+      <source
             class="eu.esdihumboldt.hale.ui.io.source.URLSource"
             description="Load a resource from the web"
             icon="icons/discovery.gif"

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSource.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSource.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.PlatformUI;
+
+import eu.esdihumboldt.hale.common.core.io.HaleIO;
+import eu.esdihumboldt.hale.common.core.io.IOProvider;
+import eu.esdihumboldt.hale.common.core.io.ImportProvider;
+import eu.esdihumboldt.hale.common.core.io.extension.IOProviderDescriptor;
+import eu.esdihumboldt.hale.common.core.io.supplier.FilesIOSupplier;
+import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier;
+import eu.esdihumboldt.hale.ui.io.ImportSource;
+import eu.esdihumboldt.hale.ui.service.project.ProjectService;
+import eu.esdihumboldt.util.io.IOUtils;
+
+/**
+ * Abstract class to have common functionality to import multiple files at once.
+ * 
+ * @param <P> the supported {@link IOProvider} type
+ * 
+ * @author Kapil Agnihotri
+ */
+public abstract class AbstractMultipleFilesSource<P extends ImportProvider>
+		extends AbstractProviderSource<P> {
+
+	/**
+	 * The file field editor for the source file
+	 */
+	private AbstractMultipleFilesSourceFileFieldEditor sourceFile;
+
+	/**
+	 * The set of supported content types
+	 */
+	private Set<IContentType> supportedTypes;
+
+	private URI projectLocation;
+
+	/**
+	 * @return the projectLocation
+	 */
+	public URI getProjectLocation() {
+		return projectLocation;
+	}
+
+	/**
+	 * @param projectLocation the projectLocation to set
+	 */
+	public void setProjectLocation(URI projectLocation) {
+		this.projectLocation = projectLocation;
+	}
+
+	/**
+	 * @param parent parent
+	 * @param projectLocation location the current project was loaded from. May
+	 *            be <code>null</code>.
+	 * @return
+	 */
+	abstract public AbstractMultipleFilesSourceFileFieldEditor getSourceFile(Composite parent,
+			URI projectLocation);
+
+	/**
+	 * @see ImportSource#createControls(Composite)
+	 */
+	@Override
+	public void createControls(Composite parent) {
+		parent.setLayout(new GridLayout(4, false));
+
+		ProjectService ps = PlatformUI.getWorkbench().getService(ProjectService.class);
+		projectLocation = ps.getLoadLocation() == null ? null : ps.getLoadLocation();
+		boolean projectLocAvailable = projectLocation != null
+				&& "file".equals(projectLocation.getScheme());
+
+		sourceFile = getSourceFile(parent, projectLocation);
+
+		sourceFile.setEmptyStringAllowed(false);
+		sourceFile.setPage(getPage());
+
+		// set content types for file field
+		Collection<IOProviderDescriptor> factories = getConfiguration().getFactories();
+		supportedTypes = new HashSet<IContentType>();
+		for (IOProviderDescriptor factory : factories) {
+			supportedTypes.addAll(factory.getSupportedTypes());
+		}
+
+		sourceFile.setContentTypes(supportedTypes);
+		sourceFile.setPropertyChangeListener(new IPropertyChangeListener() {
+
+			@Override
+			public void propertyChange(PropertyChangeEvent event) {
+				if (event.getProperty().equals(FieldEditor.IS_VALID)) {
+					sourceFile.getStringValues().forEach(k -> updateState(true));
+				}
+				else if (event.getProperty().equals(FieldEditor.VALUE)) {
+					sourceFile.getStringValues().forEach(k -> updateState(true));
+				}
+			}
+
+		});
+
+		Label providerLabel = new Label(parent, SWT.NONE);
+		providerLabel.setText("Import as");
+		// create provider combo
+		ComboViewer providers = createProviders(parent);
+		providers.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1));
+
+		final Button relativeCheck = new Button(parent, SWT.CHECK);
+		String text = "Use relative paths if possible.";
+		relativeCheck.setText("Use relative paths if possible.");
+		relativeCheck.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				sourceFile.setUseRelativeIfPossible(relativeCheck.getSelection());
+			}
+		});
+		if (!projectLocAvailable) {
+			relativeCheck.setEnabled(false);
+			text += " Only available once the project is saved to a file.";
+		}
+		relativeCheck.setText(text);
+		relativeCheck.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false, 4, 1));
+
+		// initial state update
+		updateState(true);
+	}
+
+	/**
+	 * @see AbstractProviderSource#updateContentType()
+	 */
+	@Override
+	protected void updateContentType() {
+
+		if (sourceFile.isValid()) {
+			// determine content type
+			LocatableInputSupplier<? extends InputStream> source = getSource();
+			Collection<IContentType> filteredTypes = HaleIO.findContentTypesFor(supportedTypes,
+					source, sourceFile.getStringValues().get(0));
+			IContentType contentType = null;
+			if (!filteredTypes.isEmpty()) {
+				contentType = filteredTypes.iterator().next();
+			}
+
+			getConfiguration().setContentType(contentType);
+			if (contentType != null) {
+				getPage().setMessage(contentType.getName(), DialogPage.INFORMATION);
+			}
+			else {
+				getPage().setMessage(null);
+			}
+
+			super.updateContentType();
+		}
+	}
+
+	/**
+	 * @see AbstractProviderSource#isValidSource()
+	 */
+	@Override
+	protected boolean isValidSource() {
+		return sourceFile.isValid();
+	}
+
+	/**
+	 * @see AbstractSource#onActivate()
+	 */
+	@Override
+	public void onActivate() {
+		sourceFile.setFocus();
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.source.AbstractProviderSource#getSource()
+	 */
+	@Override
+	protected LocatableInputSupplier<? extends InputStream> getSource() {
+		List<String> stringValues = sourceFile.getStringValues();
+		List<File> files = new ArrayList<File>();
+		List<URI> uris = new ArrayList<>();
+		File file = new File(stringValues.get(0));
+		if (file.isAbsolute()) {
+			for (String s : stringValues) {
+				files.add(new File(s));
+				uris.add(new File(s).toURI());
+			}
+		}
+		else {
+			for (String s : stringValues) {
+				files.add(new File(s));
+				uris.add(IOUtils.relativeFileToURI(new File(s)));
+			}
+		}
+		FilesIOSupplier filesIOSupplier = new FilesIOSupplier(files, uris);
+		return filesIOSupplier;
+	}
+
+	/**
+	 * Update the provider selector when the content type has changed. This is
+	 * based on the content type stored in the source configuration.
+	 */
+	@Override
+	protected void updateProvider() {
+		IContentType contentType = getConfiguration().getContentType();
+		if (contentType != null) {
+			IOProviderDescriptor lastSelected = null;
+			ISelection provSel = getProviders().getSelection();
+			if (!provSel.isEmpty() && provSel instanceof IStructuredSelection) {
+				lastSelected = (IOProviderDescriptor) ((IStructuredSelection) provSel)
+						.getFirstElement();
+			}
+
+			List<IOProviderDescriptor> supported = HaleIO
+					.filterFactories(getConfiguration().getFactories(), contentType);
+			getProviders().setInput(supported);
+
+			if (lastSelected != null && supported.contains(lastSelected)) {
+				// reuse old selection
+				getProviders().setSelection(new StructuredSelection(lastSelected), true);
+			}
+			else if (!supported.isEmpty()) {
+				// select first provider
+				getProviders().setSelection(new StructuredSelection(supported.get(0)), true);
+			}
+
+			getProviders().getControl().setEnabled(supported.size() > 1);
+		}
+		else {
+			getProviders().setInput(null);
+			getProviders().getControl().setEnabled(false);
+		}
+
+	}
+
+	/**
+	 * Update the page state. This includes setting a provider factory on the
+	 * wizard if applicable and setting the complete state of the page.<br>
+	 * <br>
+	 * This should be called in {@link #createControls(Composite)} to initialize
+	 * the page state.
+	 * 
+	 * @param updateContentType if <code>true</code> the content type and the
+	 *            supported providers will be updated before updating the page
+	 *            state
+	 */
+	@Override
+	protected void updateState(boolean updateContentType) {
+		if (updateContentType) {
+			updateContentType();
+		}
+
+		// update provider factory
+		ISelection provSel = getProviders().getSelection();
+		if (!provSel.isEmpty() && provSel instanceof IStructuredSelection) {
+			getConfiguration().setProviderFactory(
+					(IOProviderDescriptor) ((IStructuredSelection) provSel).getFirstElement());
+		}
+		else {
+			getConfiguration().setProviderFactory(null);
+		}
+
+		getPage().setPageComplete(isValidSource() && getConfiguration().getContentType() != null
+				&& getConfiguration().getProviderFactory() != null);
+	}
+
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSourceFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSourceFileFieldEditor.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+
+import eu.esdihumboldt.hale.ui.common.CommonSharedImages;
+import eu.esdihumboldt.hale.ui.service.project.RecentProjectsMenu;
+import eu.esdihumboldt.hale.ui.service.project.RecentResources;
+import eu.esdihumboldt.hale.ui.util.io.ExtendedFileFieldEditor;
+import eu.esdihumboldt.hale.ui.util.io.OpenFileFieldEditor;
+import eu.esdihumboldt.util.Pair;
+import eu.esdihumboldt.util.io.IOUtils;
+
+/**
+ * Abstract class to have common functionalities for the implementation of
+ * {@link OpenFileFieldEditor} with support for relative URIs with regard to the
+ * current project's location. Applicable when importing multiple files.
+ * 
+ * @author Kapil Agnihotri
+ */
+public abstract class AbstractMultipleFilesSourceFileFieldEditor extends OpenFileFieldEditor {
+
+	private final URI projectURI;
+	private boolean useRelative;
+	private Button historyButton;
+	private Text textField;
+	private final int validationStrategy;
+
+	/**
+	 * @see ExtendedFileFieldEditor#ExtendedFileFieldEditor(String, String,
+	 *      boolean, int, Composite, int )
+	 */
+	@SuppressWarnings("javadoc")
+	public AbstractMultipleFilesSourceFileFieldEditor(String name, String labelText,
+			int validationStrategy, Composite parent, URI projectURI, int style) {
+		super(name, labelText, false, validationStrategy, parent, style);
+		this.validationStrategy = validationStrategy;
+		this.projectURI = projectURI;
+	}
+
+	/**
+	 * Sets the editor to allow relative values. The projectURI has to be
+	 * supplied during construction to support this feature.
+	 * 
+	 * @param useRelative the new value
+	 */
+	public void setUseRelativeIfPossible(boolean useRelative) {
+		if (this.useRelative && !useRelative) {
+			File f = new File(getTextControl().getText());
+			f = resolve(f);
+			if (f != null)
+				getTextControl().setText(f.getAbsolutePath());
+			this.useRelative = false;
+		}
+		else if (!this.useRelative && useRelative && projectURI != null) {
+			this.useRelative = true;
+			File f = new File(getTextControl().getText());
+			URI absoluteSelected = f.toURI();
+			URI relativeSelected = IOUtils.getRelativePath(absoluteSelected, projectURI);
+			if (!relativeSelected.isAbsolute())
+				f = new File(relativeSelected.toString());
+			getTextControl().setText(f.getPath());
+		}
+	}
+
+	/**
+	 * @see FileFieldEditor#changePressed()
+	 */
+	@Override
+	protected String changePressed() {
+		String filepaths = getTextControl().getText();
+		List<String> filepathsAsList = getFilepathsAsList(filepaths);
+		File f = null;
+		if (filepathsAsList != null && filepathsAsList.size() > 0) {
+			f = new File(filepaths);
+			f = resolve(f);
+		}
+		List<File> d = getFiles(f);
+		StringBuffer sb = new StringBuffer();
+		List<String> processedFiles = processFiles(d);
+		if (processedFiles.size() == 1) {
+			sb.append(processedFiles.get(0));
+		}
+		else {
+			processedFiles.forEach(k -> sb.append(k).append("\n"));
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Process a selected file and produce the path to use.
+	 * 
+	 * @param files List of files to be processed.
+	 * 
+	 * @return the list of paths.
+	 */
+	protected List<String> processFiles(List<File> files) {
+		if (files == null) {
+			return null;
+		}
+		List<String> paths = new ArrayList<String>();
+		if (useRelative) {
+			files.forEach(k -> {
+				File d = k.getAbsoluteFile();
+				URI absoluteSelected = d.toURI();
+				URI relativeSelected = IOUtils.getRelativePath(absoluteSelected, projectURI);
+				if (!relativeSelected.isAbsolute()) {
+					File file = new File(relativeSelected.toString());
+					paths.add(file.getAbsolutePath());
+				}
+			});
+		}
+		else {
+			files.forEach(k -> {
+				File d = k.getAbsoluteFile();
+				paths.add(d.getPath());
+			});
+		}
+		return paths;
+	}
+
+	@Override
+	protected boolean checkState() {
+		String msg = null;
+
+		String path = getTextControl().getText();
+		if (path != null) {
+			path = path.trim();
+		}
+		else {
+			path = "";//$NON-NLS-1$
+		}
+		if (path.length() == 0) {
+			if (!isEmptyStringAllowed()) {
+				msg = getErrorMessage();
+			}
+		}
+		else {
+			String errorMsg = restrictExtensions(path);
+			if (errorMsg != null && !errorMsg.isEmpty()) {
+				showErrorMessage(errorMsg);
+				return false;
+			}
+			Optional<String> findAny = getFilepathsAsList(path).stream()
+					.filter(k -> ((new File(k)) == null) || !(new File(k)).isFile()).findAny();
+			if (findAny.isPresent()) {
+				msg = getErrorMessage();
+			}
+		}
+
+		if (msg != null) { // error
+			showErrorMessage(msg);
+			return false;
+		}
+
+		if (doCheckState()) { // OK!
+			clearErrorMessage();
+			return true;
+		}
+		msg = getErrorMessage(); // subclass might have changed it in the
+									// #doCheckState()
+		if (msg != null) {
+			showErrorMessage(msg);
+		}
+		return false;
+	}
+
+	/**
+	 * Method to restrict files with specific extensions.
+	 * 
+	 * @param path file path.
+	 * @return response message based on the checks.
+	 */
+	protected String restrictExtensions(String path) {
+		String msg = null;
+		List<String> filepaths = getFilepathsAsList(path);
+
+		// check if the selected files are with different extensions.
+		Set<String> allSelectedFileExtensions = filepaths.stream()
+				.map(p -> p.substring(p.lastIndexOf("."))).collect(Collectors.toSet());
+		if (allSelectedFileExtensions.size() > 1) {
+			msg = "All files must be of the same format!";
+			return msg;
+		}
+		return msg;
+
+	}
+
+	/**
+	 * Resolve a files existence.
+	 * 
+	 * @param f file.
+	 * @return null if file does not exists else the file.
+	 */
+	private File resolve(File f) {
+		// first find absolute
+		File resolved;
+		if (f.isAbsolute())
+			resolved = f;
+		else if (useRelative)
+			resolved = new File(projectURI.resolve(IOUtils.relativeFileToURI(f)));
+		else
+			resolved = null;
+
+		// then check existence
+		if (resolved != null && resolved.exists())
+			return resolved;
+		else
+			return null;
+	}
+
+	// recent resources support
+
+	@Override
+	protected void adjustForNumColumns(int numColumns) {
+		((GridData) getTextControl().getLayoutData()).horizontalSpan = numColumns - 2;
+	}
+
+	@Override
+	protected void doFillIntoGrid(Composite parent, int numColumns) {
+		super.doFillIntoGrid(parent, numColumns - 1);
+	}
+
+	@Override
+	public Text getTextControl(Composite parent) {
+		// ensure resource control is added before the text control
+		historyButton = new Button(parent, SWT.PUSH | SWT.FLAT);
+		historyButton.setToolTipText("Choose from recent files");
+		historyButton.setImage(
+				CommonSharedImages.getImageRegistry().get(CommonSharedImages.IMG_HISTORY));
+		historyButton.setEnabled(false);
+
+		if (textField == null) {
+			textField = new Text(parent, SWT.MULTI | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
+			textField.setFont(parent.getFont());
+
+			switch (validationStrategy) {
+			case VALIDATE_ON_KEY_STROKE:
+				textField.addKeyListener(new KeyAdapter() {
+
+					@Override
+					public void keyReleased(KeyEvent e) {
+						valueChanged();
+					}
+				});
+				textField.addFocusListener(new FocusAdapter() {
+
+					// Ensure that the value is checked on focus loss in case we
+					// missed a keyRelease or user hasn't released key.
+					// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=214716
+					@Override
+					public void focusLost(FocusEvent e) {
+						valueChanged();
+					}
+				});
+
+				break;
+			case VALIDATE_ON_FOCUS_LOST:
+				textField.addKeyListener(new KeyAdapter() {
+
+					@Override
+					public void keyPressed(KeyEvent e) {
+						clearErrorMessage();
+					}
+				});
+				textField.addFocusListener(new FocusAdapter() {
+
+					@Override
+					public void focusGained(FocusEvent e) {
+						refreshValidState();
+					}
+
+					@Override
+					public void focusLost(FocusEvent e) {
+						valueChanged();
+					}
+				});
+				break;
+			default:
+				Assert.isTrue(false, "Unknown validate strategy");//$NON-NLS-1$
+			}
+			textField.addDisposeListener(event -> textField = null);
+			textField.setTextLimit(UNLIMITED);
+
+		}
+		else {
+			checkParent(textField, parent);
+		}
+
+		return textField;
+	}
+
+	@Override
+	public void setContentTypes(Set<IContentType> types) {
+		super.setContentTypes(types);
+
+		RecentResources rr = PlatformUI.getWorkbench().getService(RecentResources.class);
+		if (rr != null) {
+			final List<Pair<URI, IContentType>> files = rr.getRecent(types, true);
+
+			if (!files.isEmpty()) {
+				historyButton.addSelectionListener(new SelectionAdapter() {
+
+					@Override
+					public void widgetSelected(SelectionEvent e) {
+						Menu filesMenu = new Menu(historyButton);
+						for (Pair<URI, IContentType> pair : files) {
+							final File file;
+							try {
+								file = new File(pair.getFirst());
+								if (file.exists()) {
+									// only offer existing files
+
+									MenuItem item = new MenuItem(filesMenu, SWT.PUSH);
+									item.setText(RecentProjectsMenu.shorten(file.toString(), 80,
+											file.getName().length()));
+									item.addSelectionListener(new SelectionAdapter() {
+
+										@Override
+										public void widgetSelected(SelectionEvent e) {
+											List<String> texts = processFiles(Arrays.asList(file));
+											if (texts != null) {
+												textField.append(texts.get(0));
+												textField.append("\n");
+												textField.setFocus();
+												valueChanged();
+											}
+										}
+									});
+								}
+							} catch (Exception e1) {
+								// ignore
+							}
+						}
+
+						Point histLoc = historyButton.getParent()
+								.toDisplay(historyButton.getLocation());
+						filesMenu.setLocation(histLoc.x, histLoc.y + historyButton.getSize().y);
+						filesMenu.setVisible(true);
+					}
+				});
+				historyButton.setEnabled(true);
+			}
+		}
+	}
+
+	@Override
+	public int getNumberOfControls() {
+		return super.getNumberOfControls() + 1;
+	}
+
+	/**
+	 * @return the historyButton
+	 */
+	public Button getHistoryButton() {
+		return historyButton;
+	}
+
+	/**
+	 * // * Method to return list of filepaths from filepath string delimited by
+	 * "\n".
+	 * 
+	 * @param filepaths file path string, delimited by \n.
+	 * @return list of file paths after splitting.
+	 */
+	protected List<String> getFilepathsAsList(String filepaths) {
+		String stringValue = getStringValue();
+		String[] split = stringValue.split("\n");
+
+		List<String> collect = Arrays.asList(split).stream().filter(s -> !s.isEmpty())
+				.collect(Collectors.toList());
+		return collect;
+
+	}
+
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleInstanceFilesSource.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleInstanceFilesSource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.net.URI;
+
+import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+import eu.esdihumboldt.hale.common.core.io.ImportProvider;
+import eu.esdihumboldt.hale.common.instance.io.InstanceReader;
+
+/**
+ * File import source for importing multiple instance files.
+ * 
+ * @author Kapil Agnihotri
+ */
+public class MultipleInstanceFilesSource<P extends ImportProvider>
+		extends AbstractMultipleFilesSource<InstanceReader> {
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.source.AbstractMultipleFilesSource#getSourceFile(org.eclipse.swt.widgets.Composite,
+	 *      java.net.URI)
+	 */
+	@Override
+	public AbstractMultipleFilesSourceFileFieldEditor getSourceFile(Composite parent,
+			URI projectLocation) {
+		return new MultipleInstanceFilesSourceFileFieldEditor("sourceFile", "Source files:",
+				FileFieldEditor.VALIDATE_ON_KEY_STROKE, parent, projectLocation,
+				SWT.MULTI | SWT.SHEET);
+	}
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleInstanceFilesSourceFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleInstanceFilesSourceFileFieldEditor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.swt.widgets.Composite;
+
+import eu.esdihumboldt.hale.ui.util.io.ExtendedFileFieldEditor;
+
+/**
+ * Implementation of {@link AbstractMultipleFilesSourceFileFieldEditor} for
+ * importing multiple instances with support for relative URIs with regard to
+ * the current project's location.
+ * 
+ * @author Kapil Agnihotri
+ */
+public class MultipleInstanceFilesSourceFileFieldEditor
+		extends AbstractMultipleFilesSourceFileFieldEditor {
+
+	/**
+	 * @see ExtendedFileFieldEditor#ExtendedFileFieldEditor(String, String,
+	 *      boolean, int, Composite, int )
+	 */
+	@SuppressWarnings("javadoc")
+	public MultipleInstanceFilesSourceFileFieldEditor(String name, String labelText,
+			int validationStrategy, Composite parent, URI projectURI, int style) {
+		super(name, labelText, validationStrategy, parent, projectURI, style);
+	}
+
+	/**
+	 * @see eu.esdihumboldt.hale.ui.io.source.AbstractMultipleFilesSourceFileFieldEditor#restrictExtensions(java.lang.String)
+	 */
+	@Override
+	protected String restrictExtensions(String path) {
+		// return an empty string as for now as all the extensions are allowed
+		// for reading multiple instances at once.
+
+		List<String> filepaths = getFilepathsAsList(path);
+
+		// check if the selected files are with different extensions.
+		Set<String> allSelectedFileExtensions = filepaths.stream()
+				.map(p -> p.substring(p.lastIndexOf("."))).collect(Collectors.toSet());
+		if (allSelectedFileExtensions.size() > 1) {
+			return "All files must be of the same format!";
+		}
+
+		// return empty string if everything is perfect. Cannot return null as
+		// it will be returned from the
+		// MultipleSchemaFilesSourceFileFieldEditor.
+		return "";
+	}
+
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleSchemaFilesSource.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleSchemaFilesSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.net.URI;
+
+import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+import eu.esdihumboldt.hale.common.core.io.IOProvider;
+import eu.esdihumboldt.hale.common.core.io.ImportProvider;
+import eu.esdihumboldt.hale.common.schema.io.SchemaReader;
+
+/**
+ * File import source to import multiple schema files.
+ * 
+ * @param <P> the supported {@link IOProvider} type
+ * 
+ * @author Kapil Agnihotri
+ */
+public class MultipleSchemaFilesSource<P extends ImportProvider>
+		extends AbstractMultipleFilesSource<SchemaReader> {
+
+	/**
+	 * 
+	 * @see eu.esdihumboldt.hale.ui.io.source.AbstractMultipleFilesSource#getSourceFile(org.eclipse.swt.widgets.Composite,
+	 *      java.net.URI)
+	 */
+	@Override
+	public AbstractMultipleFilesSourceFileFieldEditor getSourceFile(Composite parent,
+			URI projectLocation) {
+		return new MultipleSchemaFilesSourceFileFieldEditor("sourceFile", "Source files:",
+				FileFieldEditor.VALIDATE_ON_KEY_STROKE, parent, projectLocation,
+				SWT.MULTI | SWT.SHEET);
+	}
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleSchemaFilesSourceFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/MultipleSchemaFilesSourceFileFieldEditor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.ui.io.source;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.swt.widgets.Composite;
+
+import eu.esdihumboldt.hale.ui.util.io.ExtendedFileFieldEditor;
+
+/**
+ * Implementation of {@link AbstractMultipleFilesSourceFileFieldEditor} for
+ * importing multiple Schema(s).
+ * 
+ * @author Kapil Agnihotri
+ */
+public class MultipleSchemaFilesSourceFileFieldEditor
+		extends AbstractMultipleFilesSourceFileFieldEditor {
+
+	/**
+	 * @see ExtendedFileFieldEditor#ExtendedFileFieldEditor(String, String,
+	 *      boolean, int, Composite, int )
+	 */
+	@SuppressWarnings("javadoc")
+	public MultipleSchemaFilesSourceFileFieldEditor(String name, String labelText,
+			int validationStrategy, Composite parent, URI projectURI, int style) {
+		super(name, labelText, validationStrategy, parent, projectURI, style);
+	}
+
+	/**
+	 * 
+	 * @see eu.esdihumboldt.hale.ui.io.source.AbstractMultipleFilesSourceFileFieldEditor#restrictExtensions(java.lang.String)
+	 */
+	@Override
+	protected String restrictExtensions(String path) {
+		String msg = null;
+
+		List<String> filepaths = getFilepathsAsList(path);
+		// check if the selected files are with different extensions.
+		Set<String> allSelectedFileExtensions = filepaths.stream()
+				.map(p -> p.substring(p.lastIndexOf("."))).collect(Collectors.toSet());
+		if (allSelectedFileExtensions.size() > 1) {
+			msg = "All files must be of the same format!";
+			return msg;
+		}
+
+		// check if selected files are of the extensions that doesn't allow
+		// multiple schema imports.
+		List<String> extensions = Arrays.asList(".csv", ".xml");
+		long count = filepaths.stream().filter(p -> extensions.stream().anyMatch(p::contains))
+				.count();
+		if (filepaths.size() > 1 && count > 1) {
+			msg = String.format("Cannot import multiple files of %s extension.",
+					allSelectedFileExtensions.iterator().next());
+		}
+		return msg;
+	}
+
+}

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/schema/internal/AbstractSchemaService.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/schema/internal/AbstractSchemaService.java
@@ -97,7 +97,7 @@ public abstract class AbstractSchemaService implements SchemaService {
 	 */
 	protected void notifySchemaRemoved(SchemaSpaceID spaceID) {
 		for (SchemaServiceListener listener : listeners) {
-			listener.schemasCleared(spaceID);
+			listener.schemaRemoved(spaceID);
 		}
 	}
 


### PR DESCRIPTION
This commit adds functionality to import multiple source
files for schema import and also enables to import several
 data files for the source data import.
It provides some restriction like all the selected files
should be of same format (e.g. all .shp) and does not
allow the selection of multiple csv and xml files for
schema import. However, the user can select multiple
files of same format for source data import.
This also adds auto detect functionality for importing
multiple shape files for multiple shape schemas.