### PR TITLE
fixup! feat: enable selecting more than one file when loading data

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSourceFileFieldEditor.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/source/AbstractMultipleFilesSourceFileFieldEditor.java
@@ -369,11 +369,14 @@ public abstract class AbstractMultipleFilesSourceFileFieldEditor extends OpenFil
 										public void widgetSelected(SelectionEvent e) {
 											List<String> texts = processFiles(Arrays.asList(file));
 											if (texts != null) {
-												textField.append(texts.get(0));
-												textField
+												StringBuffer selectedFiles = new StringBuffer(
+														getTextControl().getText());
+												selectedFiles.append(texts.get(0))
 														.append(System.getProperty(LINE_SEPARATOR));
-												textField.setFocus();
+												getTextControl().setText(selectedFiles.toString());
+												getTextControl().setFocus();
 												valueChanged();
+
 											}
 										}
 									});


### PR DESCRIPTION
Multiple files text box had invisible color
when the files were appended in the textbox
from the history button. Now the fix is provided
to append all the text in a StringBuffer and
setting it to the textbox using Text.settext

ING-2969