### PR TITLE
feat: add option to specify leniency when using DateExtraction

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/plugin.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/plugin.xml
@@ -50,7 +50,7 @@
             </property>
          </targetProperties>
          <functionParameter
-               description="For example: yyyy-MM-dd HH:mm:ss;&#xA; see http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html for more details"
+               description="For example: yyyy-MM-dd HH:mm:ss. &#xA; See http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html for more details."
                label="Source date format"
                maxOccurrence="1"
                minOccurrence="1"
@@ -62,7 +62,7 @@
             </parameterBinding>
          </functionParameter>
          <functionParameter
-               description="Lenient parsing of dates; default is &quot;true&quot;;&#xA; see https://docs.oracle.com/javase/8/docs/api/java/text/DateFormat.html for more details"
+               description="Lenient parsing of dates, default is true.&#xA; See https://docs.oracle.com/javase/8/docs/api/java/text/DateFormat.html for more details"
                label="Leniency"
                maxOccurrence="1"
                minOccurrence="0"

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/plugin.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/plugin.xml
@@ -50,8 +50,8 @@
             </property>
          </targetProperties>
          <functionParameter
-               description="For example &quot;yyyy-MM-dd HH:mm:ss&quot;&#xA;(see http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html)"
-               label="Date format"
+               description="For example: yyyy-MM-dd HH:mm:ss;&#xA; see http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html for more details"
+               label="Source date format"
                maxOccurrence="1"
                minOccurrence="1"
                name="dateFormat">
@@ -60,6 +60,19 @@
                      class="eu.esdihumboldt.cst.functions.string.DateExtractionFormatValidator">
                </validator>
             </parameterBinding>
+         </functionParameter>
+         <functionParameter
+               description="Lenient parsing of dates; default is &quot;true&quot;;&#xA; see https://docs.oracle.com/javase/8/docs/api/java/text/DateFormat.html for more details"
+               label="Leniency"
+               maxOccurrence="1"
+               minOccurrence="0"
+               name="leniency">
+             <parameterBinding
+                   class="java.lang.Boolean">
+            </parameterBinding>
+             <valueDescriptor
+                   default="true">
+             </valueDescriptor>
          </functionParameter>
       </propertyFunction>
       <propertyFunction

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
@@ -66,13 +66,11 @@ public class DateExtraction extends AbstractSingleTargetPropertyTransformation<T
 		String sourceString = variables.values().iterator().next().getValueAs(String.class);
 		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
 
-		// by default setLenient(true)
+		// by default leniency is true
 		boolean leniency = getOptionalParameter(PARAMETER_LENIENCY, Value.of(true))
 				.as(Boolean.class);
 
-		if (leniency == false) {
-			sdf.setLenient(false);
-		}
+		sdf.setLenient(leniency);
 
 		try {
 			return sdf.parse(sourceString);

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
@@ -57,6 +57,12 @@ public class DateExtraction extends AbstractSingleTargetPropertyTransformation<T
 					.format("Mandatory parameter {0} not defined", PARAMETER_DATE_FORMAT));
 		}
 
+		if (getParameters() == null || getParameters().get(PARAMETER_LENIENCY) == null
+				|| getParameters().get(PARAMETER_LENIENCY).isEmpty()) {
+			throw new TransformationException(MessageFormat
+					.format("Mandatory parameter {0} not defined", PARAMETER_LENIENCY));
+		}
+
 		String dateFormat = getParameters().get(PARAMETER_DATE_FORMAT).get(0).as(String.class);
 
 		// replace transformation variables in date format
@@ -64,6 +70,13 @@ public class DateExtraction extends AbstractSingleTargetPropertyTransformation<T
 
 		String sourceString = variables.values().iterator().next().getValueAs(String.class);
 		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+
+		// default ....
+		String leniency = getParameters().get(PARAMETER_LENIENCY).get(0).as(String.class);
+		leniency = getExecutionContext().getVariables().replaceVariables(leniency);
+		if (leniency == "false") {
+			sdf.setLenient(false);
+		}
 
 		try {
 			return sdf.parse(sourceString);

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtraction.java
@@ -29,6 +29,7 @@ import eu.esdihumboldt.hale.common.align.transformation.function.PropertyValue;
 import eu.esdihumboldt.hale.common.align.transformation.function.TransformationException;
 import eu.esdihumboldt.hale.common.align.transformation.function.impl.AbstractSingleTargetPropertyTransformation;
 import eu.esdihumboldt.hale.common.align.transformation.report.TransformationLog;
+import eu.esdihumboldt.hale.common.core.io.Value;
 
 /**
  * Property date extraction function.
@@ -57,12 +58,6 @@ public class DateExtraction extends AbstractSingleTargetPropertyTransformation<T
 					.format("Mandatory parameter {0} not defined", PARAMETER_DATE_FORMAT));
 		}
 
-		if (getParameters() == null || getParameters().get(PARAMETER_LENIENCY) == null
-				|| getParameters().get(PARAMETER_LENIENCY).isEmpty()) {
-			throw new TransformationException(MessageFormat
-					.format("Mandatory parameter {0} not defined", PARAMETER_LENIENCY));
-		}
-
 		String dateFormat = getParameters().get(PARAMETER_DATE_FORMAT).get(0).as(String.class);
 
 		// replace transformation variables in date format
@@ -71,10 +66,11 @@ public class DateExtraction extends AbstractSingleTargetPropertyTransformation<T
 		String sourceString = variables.values().iterator().next().getValueAs(String.class);
 		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
 
-		// default ....
-		String leniency = getParameters().get(PARAMETER_LENIENCY).get(0).as(String.class);
-		leniency = getExecutionContext().getVariables().replaceVariables(leniency);
-		if (leniency == "false") {
+		// by default setLenient(true)
+		boolean leniency = getOptionalParameter(PARAMETER_LENIENCY, Value.of(true))
+				.as(Boolean.class);
+
+		if (leniency == false) {
 			sdf.setLenient(false);
 		}
 

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtractionFunction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtractionFunction.java
@@ -29,10 +29,13 @@ public interface DateExtractionFunction {
 	public static final String ID = "eu.esdihumboldt.cst.functions.string.dateextraction";
 
 	/**
-	 * Name of the parameter specifying the date format of the source entity.<br>
+	 * Name of the parameter specifying the date format of the source
+	 * entity.<br>
 	 * See the function definition on
 	 * <code>eu.esdihumboldt.hale.common.align</code>.
 	 */
 	public static final String PARAMETER_DATE_FORMAT = "dateFormat";
+
+	public static final String PARAMETER_LENIENCY = "leniency";
 
 }

--- a/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtractionFunction.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.string/src/eu/esdihumboldt/cst/functions/string/DateExtractionFunction.java
@@ -36,6 +36,14 @@ public interface DateExtractionFunction {
 	 */
 	public static final String PARAMETER_DATE_FORMAT = "dateFormat";
 
+	/**
+	 * Name of the parameter specifying whether the interpretation of the date
+	 * and time of SimpleDateFormat object is to be lenient or not. With lenient
+	 * interpretation, a date such as "February 942, 1996" will be treated as
+	 * being equivalent to the 941st day after February 1, 1996. With strict
+	 * (non-lenient) interpretation, such dates will cause an exception to be
+	 * thrown. The default is lenient.
+	 */
 	public static final String PARAMETER_LENIENCY = "leniency";
 
 }


### PR DESCRIPTION
This commit adds the option of specifying whether or not date/time parsing is to be lenient when using the function DateExtraction. It also modifies the description of the parameter "Date format" so as to be less prone to mistakes (e.g., quotes should not be used and the format refers to the one in the source data).

ING-3214