### PR TITLE
fix(geopackage): allow loading Geopackage files w/ non standard file extension

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -31,6 +31,15 @@
          <contentType
                ref="eu.esdihumboldt.hale.io.geopackage">
          </contentType>
+         <providerParameter
+               description="Allows to provide a WHERE clause filter for tables in the GeoPackage. One WHERE clause per table can be defined. The syntax is &quot;&amp;lt;table name 1&amp;gt;|&amp;lt;WHERE clause 1&amp;gt;||&amp;lt;table name 2&amp;gt;|&amp;lt;WHERE clause 2&amp;gt;||...&quot;"
+               label="Filters for querying the GeoPackage database"
+               name="queryFilter"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.String">
+            </parameterBinding>
+         </providerParameter>
       </provider>
       <provider
             allowDuplicate="false"
@@ -41,15 +50,6 @@
          <contentType
                ref="eu.esdihumboldt.hale.io.geopackage">
          </contentType>
-         <providerParameter
-               description="Allows to provide a WHERE clause filter for tables in the GeoPackage. One WHERE clause per table can be defined. The syntax is &quot;&amp;lt;table name 1&amp;gt;|&amp;lt;WHERE clause 1&amp;gt;||&amp;lt;table name 2&amp;gt;|&amp;lt;WHERE clause 2&amp;gt;||...&quot;"
-               label="Filters for querying the GeoPackage database"
-               name="queryFilter"
-               optional="true">
-            <parameterBinding
-                  class="java.lang.String">
-            </parameterBinding>
-         </providerParameter>
          <providerParameter
                description="Target coordinate reference system the data should be transformed to (only applies if the schema does not specify the CRS already)."
                label="Target CRS"

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceReader.java
@@ -105,7 +105,7 @@ public class GeopackageInstanceReader extends AbstractInstanceReader {
 				throw new IllegalArgumentException("Only files are supported as data source", e);
 			}
 
-			GeoPackage gpkg = GeoPackageManager.open(file, true);
+			GeoPackage gpkg = GeoPackageManager.open(file, false);
 
 			Map<TypeDefinition, InstanceCollection> collections = new HashMap<>();
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageSchemaReader.java
@@ -47,7 +47,7 @@ public class GeopackageSchemaReader extends AbstractCachedSchemaReader {
 				throw new IllegalArgumentException("Only files are supported as data source", e);
 			}
 
-			GeoPackage gpkg = GeoPackageManager.open(file, true);
+			GeoPackage gpkg = GeoPackageManager.open(file, false);
 
 			Schema schema = new GeopackageSchemaBuilder().buildSchema(gpkg, loc);
 


### PR DESCRIPTION
Previously, loading a Geopackage would only work if the file has a
`.gpkg` or `.gpkx` extension.

ING-2671

Also: fix(geopackage): queryFilter is a parameter for the reader