### PR TITLE
refactor: merge schemas for HSD export

### DIFF
--- a/build/buildSrc/build.gradle
+++ b/build/buildSrc/build.gradle
@@ -19,7 +19,7 @@
 // along with hale-build.  If not, see <http://www.gnu.org/licenses/>.
 
 repositories {
-	jcenter()
+	mavenCentral()
 	maven { // Sonatype snapshots (for custom unpuzzle)
 		url 'http://oss.sonatype.org/content/repositories/snapshots/'
 	}

--- a/build/gradle/deployArtifacts.gradle
+++ b/build/gradle/deployArtifacts.gradle
@@ -227,7 +227,7 @@ repositories {
 	maven { // wetransform artifactory (snapshots)
 		url 'https://artifactory.wetransform.to/artifactory/libs-snapshot/'
 	}
-	jcenter()
+	mavenCentral()
 	maven {
 		url 'https://repo.osgeo.org/repository/release/'
 	}

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaWriter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/HaleSchemaWriter.java
@@ -32,6 +32,7 @@ import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
 import eu.esdihumboldt.hale.common.schema.io.impl.AbstractSchemaWriter;
+import eu.esdihumboldt.hale.common.schema.model.Schema;
 import eu.esdihumboldt.util.groovy.xml.NSDOMBuilder;
 
 /**
@@ -53,7 +54,12 @@ public class HaleSchemaWriter extends AbstractSchemaWriter {
 		try (OutputStream out = getTarget().getOutput()) {
 			// create DOM
 			NSDOMBuilder builder = SchemaToXml.createBuilder();
-			Element root = new SchemaToXml().schemasToXml(builder, getSchemas().getSchemas());
+
+			// by default merge all schemas TODO make configurable?
+			Iterable<? extends Schema> schemas = MergeSchemas.merge(getSchemas().getSchemas(),
+					true);
+
+			Element root = new SchemaToXml().schemasToXml(builder, schemas);
 
 			// configure transformer for serialization
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/MergeSchemas.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/MergeSchemas.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.common.schema.persist.hsd;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Streams;
+
+import eu.esdihumboldt.hale.common.schema.model.Schema;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultSchemaSpace;
+
+/**
+ * Helper class for merging multiple schemas for export.
+ * 
+ * @author Simon Templer
+ */
+public class MergeSchemas {
+
+	private static class MergedSchema extends DefaultSchemaSpace implements Schema {
+
+		private final String namespace;
+
+		public MergedSchema(String namespace, Iterable<? extends Schema> schemas) {
+			this.namespace = namespace;
+			for (Schema schema : schemas) {
+				addSchema(schema);
+			}
+		}
+
+		@Override
+		public URI getLocation() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String getNamespace() {
+			return this.namespace;
+		}
+
+	}
+
+	/**
+	 * Namespace to use for combined schemas if no common namespace is
+	 * available.
+	 */
+	public static final String DEFAULT_COMBINED_NAMESPACE = HaleSchemaConstants.NS + "/combine";
+
+	/**
+	 * Merge the given schemas to a single schema.
+	 * 
+	 * @param schemas the schemas to merge
+	 * @param mergeAll <code>true</code> if all schemas should be merged
+	 *            independent of the namespace, <code>false</code> if only those
+	 *            with the same namespace should be merged
+	 * @return the merged schemas
+	 */
+	public static Iterable<? extends Schema> merge(Iterable<? extends Schema> schemas,
+			boolean mergeAll) {
+		// count namespaces
+		Map<String, Long> counts = Streams.stream(schemas).map(schema -> schema.getNamespace())
+				.collect(Collectors.groupingBy(e -> e, Collectors.counting()));
+
+		if (mergeAll) {
+			// we merge to one namespace
+			String namespace;
+			if (counts.size() == 1) {
+				// if there is only one namespace, use it
+				namespace = counts.keySet().iterator().next();
+			}
+			else {
+				namespace = DEFAULT_COMBINED_NAMESPACE;
+			}
+
+			Schema schema = new MergedSchema(namespace, schemas);
+
+			return Collections.singletonList(schema);
+		}
+		else {
+			// TODO support merging by namespace
+			throw new UnsupportedOperationException();
+		}
+	}
+
+}

--- a/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaWriterJson.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.schema.persist/src/eu/esdihumboldt/hale/common/schema/persist/hsd/json/HaleSchemaWriterJson.java
@@ -27,6 +27,8 @@ import eu.esdihumboldt.hale.common.core.io.report.IOReport;
 import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
 import eu.esdihumboldt.hale.common.core.io.report.impl.IOMessageImpl;
 import eu.esdihumboldt.hale.common.schema.io.impl.AbstractSchemaWriter;
+import eu.esdihumboldt.hale.common.schema.model.Schema;
+import eu.esdihumboldt.hale.common.schema.persist.hsd.MergeSchemas;
 import eu.esdihumboldt.util.groovy.json.JsonStreamBuilder;
 
 /**
@@ -49,7 +51,12 @@ public class HaleSchemaWriterJson extends AbstractSchemaWriter {
 				Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
 			// create DOM
 			JsonStreamBuilder builder = new JsonStreamBuilder(writer, true);
-			new SchemaToJson().schemasToJson(builder, getSchemas().getSchemas(), null);
+
+			// by default merge all schemas TODO make configurable?
+			Iterable<? extends Schema> schemas = MergeSchemas.merge(getSchemas().getSchemas(),
+					true);
+
+			new SchemaToJson().schemasToJson(builder, schemas, null);
 
 			reporter.setSuccess(true);
 		} catch (Exception e) {


### PR DESCRIPTION
When exporting multiple schemas to HSD as XML or Json, merge any schemas
to one schema.
This works around the restriction, that only a single schema can be
imported from an HSD file.