### PR TITLE
Groovy Merge UI: one single variable or a list is proposed

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/JoinTypeStructureTray.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/JoinTypeStructureTray.java
@@ -40,7 +40,6 @@ import eu.esdihumboldt.hale.ui.util.viewer.tree.TreePathProviderAdapter;
  */
 public class JoinTypeStructureTray extends TypeStructureTray {
 
-	private static boolean isMerge = false;
 	private ParameterValue param = null;
 
 	/**
@@ -53,7 +52,7 @@ public class JoinTypeStructureTray extends TypeStructureTray {
 	 */
 	public JoinTypeStructureTray(ParameterValue param, TypeProvider types,
 			SchemaSpaceID schemaSpace) {
-		super(types, schemaSpace, isMerge);
+		super(types, schemaSpace, false);
 		this.param = param;
 
 	}

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/JoinTypeStructureTray.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/JoinTypeStructureTray.java
@@ -40,6 +40,7 @@ import eu.esdihumboldt.hale.ui.util.viewer.tree.TreePathProviderAdapter;
  */
 public class JoinTypeStructureTray extends TypeStructureTray {
 
+	private static boolean isMerge = false;
 	private ParameterValue param = null;
 
 	/**
@@ -50,8 +51,9 @@ public class JoinTypeStructureTray extends TypeStructureTray {
 	 * @param types the type provider
 	 * @param schemaSpace the schema space
 	 */
-	public JoinTypeStructureTray(ParameterValue param, TypeProvider types, SchemaSpaceID schemaSpace) {
-		super(types, schemaSpace);
+	public JoinTypeStructureTray(ParameterValue param, TypeProvider types,
+			SchemaSpaceID schemaSpace) {
+		super(types, schemaSpace, isMerge);
 		this.param = param;
 
 	}
@@ -70,8 +72,8 @@ public class JoinTypeStructureTray extends TypeStructureTray {
 
 		ToolItem item = new ToolItem(bar, SWT.PUSH);
 
-		item.setImage(CommonSharedImages.getImageRegistry().get(
-				CommonSharedImages.IMG_SOURCE_SCHEMA));
+		item.setImage(
+				CommonSharedImages.getImageRegistry().get(CommonSharedImages.IMG_SOURCE_SCHEMA));
 		item.setToolTipText("Show source structure");
 
 		item.addSelectionListener(new SelectionAdapter() {

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
@@ -72,6 +72,7 @@ import eu.esdihumboldt.hale.ui.common.definition.viewer.SchemaPatternFilter;
 import eu.esdihumboldt.hale.ui.common.definition.viewer.StyledDefinitionLabelProvider;
 import eu.esdihumboldt.hale.ui.common.definition.viewer.TypeDefinitionContentProvider;
 import eu.esdihumboldt.hale.ui.common.definition.viewer.TypePropertyContentProvider;
+import eu.esdihumboldt.hale.ui.functions.groovy.GroovyMergePage;
 import eu.esdihumboldt.hale.ui.util.IColorManager;
 import eu.esdihumboldt.hale.ui.util.groovy.GroovyColorManager;
 import eu.esdihumboldt.hale.ui.util.groovy.GroovySourceViewerUtil;
@@ -109,6 +110,8 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 
 	}
 
+	static boolean isMerge = false;
+
 	/**
 	 * Create a tool item for displaying the source or target type structure in
 	 * the dialog tray.
@@ -120,6 +123,10 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 	 */
 	public static void createToolItem(ToolBar bar, final HaleWizardPage<?> page,
 			final SchemaSpaceID schemaSpace, final TypeProvider types) {
+
+		if (page instanceof GroovyMergePage) {
+			isMerge = true;
+		}
 
 		ToolItem item = new ToolItem(bar, SWT.PUSH);
 		switch (schemaSpace) {
@@ -169,6 +176,7 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 
 		this.types = types;
 		this.schemaSpace = schemaSpace;
+
 	}
 
 	@Override
@@ -371,7 +379,6 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 		boolean hasPropDef = false;
 		StringBuilder access = new StringBuilder();
 
-		boolean RetypeOrMerge = false;
 		// determine parent type
 		if (path.getFirstSegment() instanceof TypeDefinition) {
 			// types are the top level elements
@@ -396,7 +403,6 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 			}
 			else {
 				// assuming Retype/Merge
-				RetypeOrMerge = true;
 				access.append(GroovyConstants.BINDING_SOURCE);
 			}
 		}
@@ -479,7 +485,7 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 			StringBuilder example = new StringBuilder();
 
 			boolean canOccurMultipleTimes = false;
-			if (path.getFirstSegment() instanceof TypeDefinition || RetypeOrMerge == true) {
+			if (path.getFirstSegment() instanceof TypeDefinition || isMerge) {
 				canOccurMultipleTimes = true;
 			}
 			/*

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
@@ -124,13 +124,13 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 		ToolItem item = new ToolItem(bar, SWT.PUSH);
 		switch (schemaSpace) {
 		case SOURCE:
-			item.setImage(CommonSharedImages.getImageRegistry().get(
-					CommonSharedImages.IMG_SOURCE_SCHEMA));
+			item.setImage(CommonSharedImages.getImageRegistry()
+					.get(CommonSharedImages.IMG_SOURCE_SCHEMA));
 			item.setToolTipText("Show source structure");
 			break;
 		case TARGET:
-			item.setImage(CommonSharedImages.getImageRegistry().get(
-					CommonSharedImages.IMG_TARGET_SCHEMA));
+			item.setImage(CommonSharedImages.getImageRegistry()
+					.get(CommonSharedImages.IMG_TARGET_SCHEMA));
 			item.setToolTipText("Show target structure");
 			break;
 		}
@@ -195,8 +195,8 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 		// create tree viewer
 		PatternFilter patternFilter = new SchemaPatternFilter();
 		patternFilter.setIncludeLeadingWildcard(true);
-		final FilteredTree filteredTree = new TreePathFilteredTree(page, SWT.MULTI | SWT.H_SCROLL
-				| SWT.V_SCROLL | SWT.BORDER, patternFilter, true);
+		final FilteredTree filteredTree = new TreePathFilteredTree(page,
+				SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER, patternFilter, true);
 
 		TreeViewer tree = filteredTree.getViewer();
 		tree.setUseHashlookup(true);
@@ -235,15 +235,17 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 		}
 
 		// source viewer
-		final SourceViewer viewer = new SourceViewer(page, null, SWT.MULTI | SWT.BORDER
-				| SWT.H_SCROLL | SWT.V_SCROLL | SWT.READ_ONLY);
+		final SourceViewer viewer = new SourceViewer(page, null,
+				SWT.MULTI | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL | SWT.READ_ONLY);
 
 		final IColorManager colorManager = new GroovyColorManager();
 		SourceViewerConfiguration configuration = new SimpleGroovySourceViewerConfiguration(
-				colorManager, ImmutableList.of(BINDING_TARGET, BINDING_BUILDER, BINDING_INDEX,
-						BINDING_SOURCE, BINDING_SOURCE_TYPES, BINDING_TARGET_TYPE, BINDING_CELL,
-						BINDING_LOG, BINDING_CELL_CONTEXT, BINDING_FUNCTION_CONTEXT,
-						BINDING_TRANSFORMATION_CONTEXT), null);
+				colorManager,
+				ImmutableList.of(BINDING_TARGET, BINDING_BUILDER, BINDING_INDEX, BINDING_SOURCE,
+						BINDING_SOURCE_TYPES, BINDING_TARGET_TYPE, BINDING_CELL, BINDING_LOG,
+						BINDING_CELL_CONTEXT, BINDING_FUNCTION_CONTEXT,
+						BINDING_TRANSFORMATION_CONTEXT),
+				null);
 		viewer.configure(configuration);
 
 		GridDataFactory.fillDefaults().grab(true, false).hint(200, 130)
@@ -369,6 +371,7 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 		boolean hasPropDef = false;
 		StringBuilder access = new StringBuilder();
 
+		boolean RetypeOrMerge = false;
 		// determine parent type
 		if (path.getFirstSegment() instanceof TypeDefinition) {
 			// types are the top level elements
@@ -393,14 +396,15 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 			}
 			else {
 				// assuming Retype/Merge
+				RetypeOrMerge = true;
 				access.append(GroovyConstants.BINDING_SOURCE);
 			}
 		}
 
 		// is a property or list of inputs referenced -> use accessor
 		boolean propertyOrList = path.getSegmentCount() > startIndex
-				|| (path.getLastSegment() instanceof ChildDefinition<?> && canOccureMultipleTimes((ChildDefinition<?>) path
-						.getLastSegment()));
+				|| (path.getLastSegment() instanceof ChildDefinition<?>
+						&& canOccureMultipleTimes((ChildDefinition<?>) path.getLastSegment()));
 		if (!propertyOrList) {
 			if (parent instanceof TypeDefinition && canHaveValue((TypeDefinition) parent)) {
 				if (!DefinitionUtil.hasChildren((Definition<?>) path.getLastSegment())) {
@@ -475,7 +479,7 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 			StringBuilder example = new StringBuilder();
 
 			boolean canOccurMultipleTimes = false;
-			if (path.getFirstSegment() instanceof TypeDefinition) {
+			if (path.getFirstSegment() instanceof TypeDefinition || RetypeOrMerge == true) {
 				canOccurMultipleTimes = true;
 			}
 			/*
@@ -484,8 +488,8 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 			 */
 			for (int i = path.getSegmentCount() - 1; i >= 0 && !canOccurMultipleTimes; i--) {
 				if (path.getSegment(i) instanceof ChildDefinition<?>) {
-					canOccurMultipleTimes = canOccureMultipleTimes((ChildDefinition<?>) path
-							.getSegment(i));
+					canOccurMultipleTimes = canOccureMultipleTimes(
+							(ChildDefinition<?>) path.getSegment(i));
 				}
 			}
 

--- a/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.functions.groovy/src/eu/esdihumboldt/hale/ui/functions/groovy/internal/TypeStructureTray.java
@@ -110,8 +110,6 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 
 	}
 
-	static boolean isMerge = false;
-
 	/**
 	 * Create a tool item for displaying the source or target type structure in
 	 * the dialog tray.
@@ -123,10 +121,6 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 	 */
 	public static void createToolItem(ToolBar bar, final HaleWizardPage<?> page,
 			final SchemaSpaceID schemaSpace, final TypeProvider types) {
-
-		if (page instanceof GroovyMergePage) {
-			isMerge = true;
-		}
 
 		ToolItem item = new ToolItem(bar, SWT.PUSH);
 		switch (schemaSpace) {
@@ -153,7 +147,8 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 						dialog.closeTray();
 					}
 
-					dialog.openTray(new TypeStructureTray(types, schemaSpace));
+					dialog.openTray(new TypeStructureTray(types, schemaSpace,
+							page instanceof GroovyMergePage));
 				}
 				else {
 					// TODO show dialog instead?
@@ -164,16 +159,19 @@ public class TypeStructureTray extends DialogTray implements GroovyConstants {
 
 	private final TypeProvider types;
 	private final SchemaSpaceID schemaSpace;
+	private final boolean isMerge;
 
 	/**
 	 * Create a type structure tray.
 	 * 
 	 * @param types the type provider
 	 * @param schemaSpace the schema space
+	 * @param isMerge is a Groovy Retype Merge
 	 */
-	public TypeStructureTray(TypeProvider types, SchemaSpaceID schemaSpace) {
+	public TypeStructureTray(TypeProvider types, SchemaSpaceID schemaSpace, boolean isMerge) {
 		super();
 
+		this.isMerge = isMerge;
 		this.types = types;
 		this.schemaSpace = schemaSpace;
 


### PR DESCRIPTION
When using the help wizard during a Groovy Merge to specify a Groovy script (to build a target instance from a merged source), the access variable from the source structure automatically proposes to access one single value or all values in a list.

ING-3488