### PR TITLE
feat: add Throwable class to whitelist

### DIFF
--- a/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/internal/RestrictiveGroovyInterceptor.java
+++ b/util/plugins/eu.esdihumboldt.util.groovy.sandbox/src/eu/esdihumboldt/util/groovy/sandbox/internal/RestrictiveGroovyInterceptor.java
@@ -171,6 +171,9 @@ public class RestrictiveGroovyInterceptor extends GroovyInterceptor {
 		allowedClasses.add(NumberFormat.class);
 		allowedClasses.add(DecimalFormat.class);
 		allowedClasses.add(DecimalFormatSymbols.class);
+		
+		// Exception classes
+		allowedClasses.add(Throwable.class);
 
 		// Google collect
 		allowedPackages.add(new AllowedPrefix("com.google.common.collect", true));


### PR DESCRIPTION
Currently, it is not possible to add the message of an exception to the transformation's logs as the class is not whitelisted

SVC-1190