### PR TITLE
build: Use --add-exports= to prevent malformed HALE.ini

### DIFF
--- a/build/templates/products/client.yaml
+++ b/build/templates/products/client.yaml
@@ -17,8 +17,8 @@ HALE:
   - -Xms256M
   - -XX:MinHeapFreeRatio=40
   - -XX:MaxHeapFreeRatio=55
-  - -add-exports java.base/sun.nio.ch=ALL-UNNAMED 
-  - -add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+  - --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+  - --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
   WinIco: /eu.esdihumboldt.hale.ui.application/images/hale.ico
   Plugins:
   - EDU.oswego.cs.dl.util.concurrent

--- a/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
@@ -41,8 +41,8 @@ https://www.wetransform.to/services/support/
 -Dcache.level1.size=0
 -Dcache.level2.enabled=false
 -Dcache.level2.size=0
---add-exports java.base/sun.nio.ch=ALL-UNNAMED 
---add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
          <argsX86>-Xmx1000m</argsX86>
          <argsX86_64>-Xmx2g</argsX86_64>
       </vmArgs>


### PR DESCRIPTION
With the previous `--add-exports`, the build process would generate the following segment in HALE.ini:

```
--add-exports
java.base/sun.nio.ch=ALL-UNNAMED
java.base/jdk.internal.ref=ALL-UNNAMED
```

This leads to hale»studio being unstartable at least on Linux where it gives the following exception:

```
$ ./HALE
Error: Could not find or load main class java.base.jdk.internal.ref=ALL-UNNAMED
Caused by: java.lang.ClassNotFoundException: java.base.jdk.internal.ref=ALL-UNNAMED
```

With the `--add-exports=` notation, the following segment in HALE.ini is generated instead which allows hale»studio to start correctly:

```
--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
```

ING-3267