### PR TITLE
Enhancements for the GeoPackage writer

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -43,6 +44,7 @@ public class GeopackageWriterSettingsPage extends
 		AbstractConfigurationPage<GeopackageInstanceWriter, IOWizard<GeopackageInstanceWriter>> {
 
 	private ComboViewer spatialIndexType;
+	private Button createEmptyTables;
 
 	/**
 	 * Default constructor
@@ -102,6 +104,8 @@ public class GeopackageWriterSettingsPage extends
 		}
 		provider.setSpatialIndexType(indexType.getParameterValue());
 
+		provider.setCreateEmptyTables(createEmptyTables.getSelection());
+
 		return true;
 	}
 
@@ -112,6 +116,16 @@ public class GeopackageWriterSettingsPage extends
 	protected void createContent(Composite page) {
 		page.setLayout(new GridLayout(1, false));
 		GridDataFactory groupData = GridDataFactory.fillDefaults().grab(true, false);
+
+		Group tableGroup = new Group(page, SWT.NONE);
+		tableGroup.setText("Table generation settings");
+		GridLayoutFactory.swtDefaults().numColumns(2).applyTo(tableGroup);
+		groupData.applyTo(tableGroup);
+		createEmptyTables = new Button(tableGroup, SWT.CHECK);
+
+		Label createEmptyTablesLabel = new Label(tableGroup, SWT.NONE);
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).applyTo(createEmptyTablesLabel);
+		createEmptyTablesLabel.setText("Also create tables for types that have no instances");
 
 		Group spatialIndexGroup = new Group(page, SWT.NONE);
 		spatialIndexGroup.setText("Spatial index");

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
@@ -45,6 +45,7 @@ public class GeopackageWriterSettingsPage extends
 
 	private ComboViewer spatialIndexType;
 	private Button createEmptyTables;
+	private Button overwriteTarget;
 
 	/**
 	 * Default constructor
@@ -105,6 +106,7 @@ public class GeopackageWriterSettingsPage extends
 		provider.setSpatialIndexType(indexType.getParameterValue());
 
 		provider.setCreateEmptyTables(createEmptyTables.getSelection());
+		provider.setOverwriteTargetFile(overwriteTarget.getSelection());
 
 		return true;
 	}
@@ -116,6 +118,16 @@ public class GeopackageWriterSettingsPage extends
 	protected void createContent(Composite page) {
 		page.setLayout(new GridLayout(1, false));
 		GridDataFactory groupData = GridDataFactory.fillDefaults().grab(true, false);
+
+		Group fileGroup = new Group(page, SWT.NONE);
+		fileGroup.setText("File settings");
+		GridLayoutFactory.swtDefaults().numColumns(2).applyTo(fileGroup);
+		groupData.applyTo(fileGroup);
+		overwriteTarget = new Button(fileGroup, SWT.CHECK);
+
+		Label overwriteTargetLabel = new Label(fileGroup, SWT.NONE);
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).applyTo(overwriteTargetLabel);
+		overwriteTargetLabel.setText("Overwrite target file if it exists");
 
 		Group tableGroup = new Group(page, SWT.NONE);
 		tableGroup.setText("Table generation settings");

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -90,6 +90,19 @@
                   class="java.lang.Boolean">
             </parameterBinding>
          </providerParameter>
+         <providerParameter
+               description="Overwrite target GeoPackage file if it exists"
+               label="Overwrite target file"
+               name="overwriteTargetFile"
+               optional="true">
+            <valueDescriptor
+                  default="false"
+                  defaultDescription="By default this option is disabled">
+            </valueDescriptor>
+            <parameterBinding
+                  class="java.lang.Boolean">
+            </parameterBinding>
+         </providerParameter>
       </provider>
    </extension>
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -77,6 +77,19 @@
                   defaultDescription="By default, an RTree Spatial Index is created">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Generate tables for types that have no instances"
+               label="Create empty tables"
+               name="createEmptyTables"
+               optional="true">
+            <valueDescriptor
+                  default="false"
+                  defaultDescription="By default this option is disabled">
+            </valueDescriptor>
+            <parameterBinding
+                  class="java.lang.Boolean">
+            </parameterBinding>
+         </providerParameter>
       </provider>
    </extension>
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
@@ -125,6 +125,12 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 	public static final String PARAM_CREATE_EMPTY_TABLES = "createEmptyTables";
 
 	/**
+	 * The parameter name for the flag specifying if the target file should be
+	 * overwritten if it exists. Defaults to <code>false</code>.
+	 */
+	public static final String PARAM_OVERWRITE_TARGET_FILE = "overwriteTargetFile";
+
+	/**
 	 * Set the type of spatial index to create for new tables
 	 * 
 	 * @param spatialIndexType Spatial index type to use
@@ -141,6 +147,15 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 	 */
 	public void setCreateEmptyTables(boolean createEmptyTables) {
 		setParameter(PARAM_CREATE_EMPTY_TABLES, Value.of(createEmptyTables));
+	}
+
+	/**
+	 * Set if the target GeoPackage file should be overwritten if it exists.
+	 * 
+	 * @param overwriteTargetFile True to overwrite the target file if it exists
+	 */
+	public void setOverwriteTargetFile(boolean overwriteTargetFile) {
+		setParameter(PARAM_OVERWRITE_TARGET_FILE, Value.of(overwriteTargetFile));
 	}
 
 	@Override
@@ -180,8 +195,10 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 				throw new IllegalArgumentException("Only files are supported as data source", e);
 			}
 
-			if (file.exists() && file.length() == 0L) {
-				// convenience for overwriting empty existing file
+			boolean overwriteTargetFile = getParameter(PARAM_OVERWRITE_TARGET_FILE)
+					.as(Boolean.class, false);
+			if (file.exists() && (file.length() == 0L || overwriteTargetFile)) {
+				// overwrite empty existing file or if requested via setting
 				file.delete();
 			}
 			if (!file.exists()) {

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
@@ -118,12 +118,29 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 	public static final String DEFAULT_SPATIAL_INDEX_TYPE = "rtree";
 
 	/**
+	 * The parameter name for the flag specifying if tables should be created
+	 * for all mapping-relevant types, even if they're empty. Defaults to
+	 * <code>false</code>.
+	 */
+	public static final String PARAM_CREATE_EMPTY_TABLES = "createEmptyTables";
+
+	/**
 	 * Set the type of spatial index to create for new tables
 	 * 
 	 * @param spatialIndexType Spatial index type to use
 	 */
 	public void setSpatialIndexType(String spatialIndexType) {
 		setParameter(PARAM_SPATIAL_INDEX_TYPE, Value.of(spatialIndexType));
+	}
+
+	/**
+	 * Set if tables should be created for all mapping-relevant types, even if
+	 * they're empty.
+	 * 
+	 * @param createEmptyTables True to create empty tables
+	 */
+	public void setCreateEmptyTables(boolean createEmptyTables) {
+		setParameter(PARAM_CREATE_EMPTY_TABLES, Value.of(createEmptyTables));
 	}
 
 	@Override
@@ -197,6 +214,16 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 				 * writeInstances(geoPackage, instances.select(new
 				 * TypeFilter(td)), progress, reporter); }
 				 */
+			}
+
+			// Create tables for empty types last to make sure that for all
+			// non-empty types SRS information from the instances is available
+			// during table creation
+			if (getParameter(PARAM_CREATE_EMPTY_TABLES).as(Boolean.class, false)) {
+				for (TypeDefinition td : getTargetSchema().getMappingRelevantTypes()) {
+					String tableName = td.getName().getLocalPart();
+					createTableIfNecessary(geoPackage, tableName, td, null, reporter);
+				}
 			}
 
 //			connection.commit();
@@ -516,7 +543,7 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 			srs = findOrCreateSrs(geoPackage, crs, log);
 		}
 
-		if (srs == null) {
+		if (srs == null && instance != null) {
 			// try to determine from example instance
 			Object geom = new InstanceAccessor(instance)
 					.findChildren(geomProp.getName().getLocalPart()).value();


### PR DESCRIPTION
Adds two parameters to the GeoPackage writer that
- allows creating tables for all mapping-relevant target types, even if they have no instances
- allow to overwrite the target file if it exists

WGS-2281
#988 