### PR TITLE
Backport GeoPackage empty table creation to 4.x

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.ui/src/eu/esdihumboldt/hale/io/geopackage/ui/GeopackageWriterSettingsPage.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -43,6 +44,7 @@ public class GeopackageWriterSettingsPage extends
 		AbstractConfigurationPage<GeopackageInstanceWriter, IOWizard<GeopackageInstanceWriter>> {
 
 	private ComboViewer spatialIndexType;
+	private Button createEmptyTables;
 
 	/**
 	 * Default constructor
@@ -102,6 +104,8 @@ public class GeopackageWriterSettingsPage extends
 		}
 		provider.setSpatialIndexType(indexType.getParameterValue());
 
+		provider.setCreateEmptyTables(createEmptyTables.getSelection());
+
 		return true;
 	}
 
@@ -112,6 +116,16 @@ public class GeopackageWriterSettingsPage extends
 	protected void createContent(Composite page) {
 		page.setLayout(new GridLayout(1, false));
 		GridDataFactory groupData = GridDataFactory.fillDefaults().grab(true, false);
+
+		Group tableGroup = new Group(page, SWT.NONE);
+		tableGroup.setText("Table generation settings");
+		GridLayoutFactory.swtDefaults().numColumns(2).applyTo(tableGroup);
+		groupData.applyTo(tableGroup);
+		createEmptyTables = new Button(tableGroup, SWT.CHECK);
+
+		Label createEmptyTablesLabel = new Label(tableGroup, SWT.NONE);
+		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).applyTo(createEmptyTablesLabel);
+		createEmptyTablesLabel.setText("Also create tables for types that have no instances");
 
 		Group spatialIndexGroup = new Group(page, SWT.NONE);
 		spatialIndexGroup.setText("Spatial index");

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/plugin.xml
@@ -77,6 +77,19 @@
                   defaultDescription="By default, an RTree Spatial Index is created">
             </valueDescriptor>
          </providerParameter>
+         <providerParameter
+               description="Generate tables for types that have no instances"
+               label="Create empty tables"
+               name="createEmptyTables"
+               optional="true">
+            <valueDescriptor
+                  default="false"
+                  defaultDescription="By default this option is disabled">
+            </valueDescriptor>
+            <parameterBinding
+                  class="java.lang.Boolean">
+            </parameterBinding>
+         </providerParameter>
       </provider>
    </extension>
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
@@ -118,12 +118,29 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 	public static final String DEFAULT_SPATIAL_INDEX_TYPE = "rtree";
 
 	/**
+	 * The parameter name for the flag specifying if tables should be created
+	 * for all mapping-relevant types, even if they're empty. Defaults to
+	 * <code>false</code>.
+	 */
+	public static final String PARAM_CREATE_EMPTY_TABLES = "createEmptyTables";
+
+	/**
 	 * Set the type of spatial index to create for new tables
 	 * 
 	 * @param spatialIndexType Spatial index type to use
 	 */
 	public void setSpatialIndexType(String spatialIndexType) {
 		setParameter(PARAM_SPATIAL_INDEX_TYPE, Value.of(spatialIndexType));
+	}
+
+	/**
+	 * Set if tables should be created for all mapping-relevant types, even if
+	 * they're empty.
+	 * 
+	 * @param createEmptyTables True to create empty tables
+	 */
+	public void setCreateEmptyTables(boolean createEmptyTables) {
+		setParameter(PARAM_CREATE_EMPTY_TABLES, Value.of(createEmptyTables));
 	}
 
 	@Override
@@ -197,6 +214,16 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 				 * writeInstances(geoPackage, instances.select(new
 				 * TypeFilter(td)), progress, reporter); }
 				 */
+			}
+
+			// Create tables for empty types last to make sure that for all
+			// non-empty types SRS information from the instances is available
+			// during table creation
+			if (getParameter(PARAM_CREATE_EMPTY_TABLES).as(Boolean.class, false)) {
+				for (TypeDefinition td : getTargetSchema().getMappingRelevantTypes()) {
+					String tableName = td.getName().getLocalPart();
+					createTableIfNecessary(geoPackage, tableName, td, null, reporter);
+				}
 			}
 
 //			connection.commit();
@@ -516,7 +543,7 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 			srs = findOrCreateSrs(geoPackage, crs, log);
 		}
 
-		if (srs == null) {
+		if (srs == null && instance != null) {
 			// try to determine from example instance
 			Object geom = new InstanceAccessor(instance)
 					.findChildren(geomProp.getName().getLocalPart()).value();


### PR DESCRIPTION
Backport the change to allow creation of empty tables in GeoPackages from [this PR](https://github.com/halestudio/hale/pull/1027) to the 4.x branch so that it becomes available for hale»connect transformations.