### PR TITLE
build: change priority list of pluginRepositories

### DIFF
--- a/build/templates/pom-parent.xml
+++ b/build/templates/pom-parent.xml
@@ -17,10 +17,7 @@
     </pluginRepository -->
     <!-- see https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin -->
      
-    <pluginRepository>
-	    <id>groovy-plugins-release</id>
-	    <url>https://groovy.jfrog.io/artifactory/plugins-release</url>
-  	</pluginRepository>
+    
   	
     <pluginRepository>
       <id>central</id>
@@ -31,7 +28,15 @@
         <enabled>false</enabled>
       </snapshots>
     </pluginRepository>
+    
+    <pluginRepository>
+	    <id>groovy-plugins-release</id>
+	    <url>https://groovy.jfrog.io/artifactory/plugins-release</url>
+  	</pluginRepository>
+    
   </pluginRepositories>
+  
+  
   
   <!-- repositories>
     <repository>


### PR DESCRIPTION
groovy-jfrog.io artifactory no longer contains jar: org.osgi:org.osgi.service.prefs:jar:1.1.2, so priority list of pluginRepositories is now changed to include maven central on top