### PR TITLE
Update feat_maint_4.x: extend shapefile writer to create .cpg file

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.shp.test/src/eu/esdihumboldt/hale/io/shp/ShapefileInstanceWriterTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp.test/src/eu/esdihumboldt/hale/io/shp/ShapefileInstanceWriterTest.groovy
@@ -26,6 +26,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.function.Consumer
 
+import org.geotools.data.shapefile.ShapefileDataStore
 import org.junit.Test
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry


### PR DESCRIPTION
The new PR contains the update with the missing import that makes the following PR failing:
Reference old failed PR: https://github.com/halestudio/hale/pull/1036