### PR TITLE
Build: windows installer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See the [change log guidelines](http://keepachangelog.com/) for information on h
 ### Added
 - Add an option to overwrite content in Geopackage Writer instead of appending content
 - Add a parameter to the GeoPackage writer that allows creating tables for all mapping-relevant target types
-- Add the creation of a .cpg file when a .shp file is beeing exported
+- Create a code page (.cpg) file when exporting a Shapefile
  
 ### Fixed
 - Fix the Commons Text security vulnerability

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,8 @@ On master branch:
 
 After the release
 =================
-1. Create Windows installer
+1. Create Windows installer.
+Prerequisites: install Wix Toolset v.3.11 [available here](https://github.com/wixtoolset/wix3/releases/tag/wix3112rtm)
+Then run `build.bat product -o windows -a x86_64 HALE` from the root directory.
 2. Draft a new release for the latest release at https://github.com/halestudio/hale/releases and publish it.
 3. Update [download page](https://github.com/wetransform/www.wetransform.to/blob/deploy/app/downloads/index.html) so that the latest builds are available for download from https://www.wetransform.to/downloads/

--- a/build/ant/build-msi.xml
+++ b/build/ant/build-msi.xml
@@ -371,7 +371,7 @@
 			</and>
         </condition>
 		<property name="deploymentSpecificWxsInclude" value="" />
-		<replace file="${build}/${wxs.file.config}.wxs" token="@{DEPLOYMENTSPECIFICWXS}" value="${deploymentSpecificWxsInclude}" />
+		<replace file="${build}/${wxs.file.config}.wxs" token="@{DEPLOYMENTSPECIFICWXS}" value="${deploymentSpecificWxsInclude}" encoding="UTF-8"/>
 		
 		<!-- compile MSI file -->
 		<!-- Example call: "C:\Program Files (x86)\WiX Toolset v3.9\bin\candle.exe" -nologo -arch x64 -out .\ WixProduct.wxs WixUI_Product.wxs -->
@@ -419,18 +419,18 @@
 	<target name="wxs.replace">
 		<echo message="Replacing placeholders in WXS file: ${filename}" />
 		
-		<replace file="${filename}" token="@{SHORTVERSION}" value="${shortversion}" />
-		<replace file="${filename}" token="@{SHORTNAME}" value="${shortName}" />
-		<replace file="${filename}" token="@{LANGID}" value="${langid}" />
-		<replace file="${filename}" token="@{PROGRAMFILESFOLDER}" value="${ProgramFilesFolder}" />
-		<replace file="${filename}" token="@{DIRECTORIES}" value="${directories}" />
-		<replace file="${filename}" token="@{COMPONENTS}" value="${components}" />
-		<replace file="${filename}" token="@{ROOTCOMPONENTS}" value="${rootcomponents}" />
-		<replace file="${filename}" token="@{COMPONENTREFS}" value="${componentrefs}" />
-		<replace file="${filename}" token="@{SRC}" value="${relsrc}" />
-		<replace file="${filename}" token="@{BUILDID}" value="${buildId}" />
-		<replace file="${filename}" token="@{TITLE}" value="${title}" />
-		<replace file="${filename}" token="@{GUID.UPGRADECODE}" value="${GUID.UpgradeCode}" />
-		<replace file="${filename}" token="@{GUID.APPLICATIONSHORTCUT}" value="${GUID.ApplicationShortcut}" />
+		<replace file="${filename}" token="@{SHORTVERSION}" value="${shortversion}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{SHORTNAME}" value="${shortName}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{LANGID}" value="${langid}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{PROGRAMFILESFOLDER}" value="${ProgramFilesFolder}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{DIRECTORIES}" value="${directories}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{COMPONENTS}" value="${components}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{ROOTCOMPONENTS}" value="${rootcomponents}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{COMPONENTREFS}" value="${componentrefs}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{SRC}" value="${relsrc}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{BUILDID}" value="${buildId}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{TITLE}" value="${title}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{GUID.UPGRADECODE}" value="${GUID.UpgradeCode}" encoding="UTF-8"/>
+		<replace file="${filename}" token="@{GUID.APPLICATIONSHORTCUT}" value="${GUID.ApplicationShortcut}" encoding="UTF-8"/>
 	</target>
 </project>

--- a/build/config.groovy
+++ b/build/config.groovy
@@ -18,7 +18,7 @@ project = {
 	    win32InstallerUpgradeGUID = '6b6151c0-e3f9-11de-8a39-0800200c9a66'
 
 	    // The GUID for the shortcuts the installer will create
-	    win32InstallerShortcutGUID = '76ed8ea0-e3f9-11de-8a39-0800200c9a66'
+	    win32InstallerShortcutGUID = '751b51b5-cad0-4385-ac36-c20ffe114a75'
 
 	    // Name of the Windows service
 	    serviceName = 'HALE Server'

--- a/build/gradle/commitAndProductionStage.gradle
+++ b/build/gradle/commitAndProductionStage.gradle
@@ -286,7 +286,7 @@ def filterPlatformSpecificFragments(productFile) {
 	}
 
     // overwrite product file
-    productFile.write(productFileContents)
+    productFile.write(productFileContents, 'UTF-8')
 }
 
 /**
@@ -358,7 +358,7 @@ def replaceIconPaths(productFile) {
     }
 
     // overwrite product file
-    productFile.write(productFileContents)
+    productFile.write(productFileContents, 'UTF-8')
 }
 
 /*


### PR DESCRIPTION
The following changes have been done to solve the windows installer build error:
- add encoding UTF-8 to all the replace into file
- add more details in how to create the windows installer
- update GUID used for shortcuts.

ING-3831