### PR TITLE
fixup! feat: download wfs files to tmp folder for bucket service

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/reader/internal/wfs/WfsBackedGmlInstanceCollection.java
@@ -458,7 +458,11 @@ public class WfsBackedGmlInstanceCollection implements InstanceCollection {
 				try {
 					URL url = nextUri.toURL();
 					StringBuilder fileName = new StringBuilder(tmpdir);
-					fileName.append("/").append(url.getPath().replaceAll("/", "."))
+					String urlPath = url.getPath();
+					if (urlPath.startsWith("/")) {
+						urlPath = urlPath.replaceFirst("/", "");
+					}
+					fileName.append("/").append(urlPath.replaceAll("/", "_")).append("_")
 							.append(totalFeaturesProcessed).append(".gml");
 
 					// TODO: may be download files in a thread


### PR DESCRIPTION
Refactor to rename downloaded file to not start with a "." and to have name format as
<datasetId>_<numberOfTotalFeatureProcessed>

ING-3609