### PR TITLE
feat: type selection broken on custom export config

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/InstanceExportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/InstanceExportConfigurationPage.java
@@ -21,6 +21,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
@@ -110,6 +111,13 @@ public class InstanceExportConfigurationPage extends CommonInstanceExportConfigu
 		final Label label = new Label(page, SWT.NONE);
 		label.setText("Choose your Type you want to export:");
 
+		Label separatorLabel = new Label(page, SWT.NONE);
+		separatorLabel.setText("Warning! Feature types with no data are not selectable");
+
+		// Set the text colour of the label to yellow
+		Color greyLabel = PlatformUI.getWorkbench().getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
+		separatorLabel.setForeground(greyLabel);
+
 		page.pack();
 
 		// wait for selected type
@@ -132,9 +140,6 @@ public class InstanceExportConfigurationPage extends CommonInstanceExportConfigu
 				public void selectionChanged(SelectionChangedEvent event) {
 					setPageComplete(!(event.getSelection().isEmpty()));
 					if (typeSelector.getSelectedObject() != null) {
-						// TypeDefinition type =
-						// typeSelector.getSelectedObject();
-						// label.getParent().layout();
 						page.layout();
 						page.pack();
 					}

--- a/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/InstanceExportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/InstanceExportConfigurationPage.java
@@ -15,6 +15,8 @@
 
 package eu.esdihumboldt.hale.io.csv.ui;
 
+import java.util.Set;
+
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -29,7 +31,6 @@ import org.eclipse.ui.PlatformUI;
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.instance.io.InstanceWriter;
 import eu.esdihumboldt.hale.common.instance.model.DataSet;
-import eu.esdihumboldt.hale.common.instance.model.TypeFilter;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
 import eu.esdihumboldt.hale.ui.common.definition.selector.TypeDefinitionSelector;
@@ -50,17 +51,22 @@ public class InstanceExportConfigurationPage extends CommonInstanceExportConfigu
 		public boolean select(Viewer viewer, Object parentElement, Object element) {
 			if (!(element instanceof TypeDefinition))
 				return false;
-			InstanceService ins = PlatformUI.getWorkbench().getService(InstanceService.class);
-			// select all source type which has at least one instance
-			if (!ins.getInstances(DataSet.SOURCE).select(new TypeFilter((TypeDefinition) element))
-					.isEmpty()) {
+
+			InstanceService instanceService = PlatformUI.getWorkbench()
+					.getService(InstanceService.class);
+
+			Set<TypeDefinition> instanceSourceTypes = instanceService
+					.getInstanceTypes(DataSet.SOURCE);
+			if (instanceSourceTypes.contains(element)) {
 				return true;
 			}
-			// select all type which has at least one transformed instance
-			if (!ins.getInstances(DataSet.TRANSFORMED)
-					.select(new TypeFilter((TypeDefinition) element)).isEmpty()) {
+
+			Set<TypeDefinition> instanceTransformedTypes = instanceService
+					.getInstanceTypes(DataSet.TRANSFORMED);
+			if (instanceTransformedTypes.contains(element)) {
 				return true;
 			}
+
 			return false;
 		}
 	};
@@ -115,7 +121,8 @@ public class InstanceExportConfigurationPage extends CommonInstanceExportConfigu
 		separatorLabel.setText("Warning! Feature types with no data are not selectable");
 
 		// Set the text colour of the label to yellow
-		Color greyLabel = PlatformUI.getWorkbench().getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
+		Color greyLabel = PlatformUI.getWorkbench().getDisplay()
+				.getSystemColor(SWT.COLOR_DARK_GRAY);
 		separatorLabel.setForeground(greyLabel);
 
 		page.pack();

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/InstanceTableIOConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/InstanceTableIOConstants.java
@@ -45,9 +45,4 @@ public class InstanceTableIOConstants {
 	 */
 	public static final String EXPORT_TYPE = "selectedExportType";
 
-	/**
-	 * Parameter for exporting empty feature types to XLS Export
-	 */
-	public static final String EXPORT_IGNORE_EMPTY_FEATURETYPES = "ignoreEmptyFeaturetypes";
-
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/XLSInstanceIOTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/XLSInstanceIOTest.java
@@ -60,8 +60,6 @@ public class XLSInstanceIOTest extends TestCase {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(true));
-		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("ItemType"));
 
 		File tempDir = Files.createTempDir();

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/writer/XLSInstanceWriterTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/writer/XLSInstanceWriterTest.java
@@ -96,8 +96,6 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(true));
-		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("city"));
 
 		File tmpFile = tmpFolder.newFile("excelTestWriteSimpleSchema.xls");
@@ -148,8 +146,6 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
-		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("person"));
 
 		File tmpFile = tmpFolder.newFile("excelTestWriteComplexSchema.xls");
@@ -200,8 +196,6 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
-		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("person"));
 
 		File tmpFile = tmpFolder.newFile("excelNotNestedProperties.xls");
@@ -252,8 +246,6 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
-		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("person" + "," + "t1"));
 
 		File tmpFile = tmpFolder.newFile("excelWith2Sheets.xls");

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
@@ -15,10 +15,7 @@
 
 package eu.esdihumboldt.hale.io.xls.ui;
 
-import java.util.NoSuchElementException;
 import java.util.Set;
-
-import javax.xml.namespace.QName;
 
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -43,9 +40,6 @@ import org.eclipse.ui.PlatformUI;
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.instance.io.InstanceWriter;
 import eu.esdihumboldt.hale.common.instance.model.DataSet;
-import eu.esdihumboldt.hale.common.instance.model.Instance;
-import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
-import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
 import eu.esdihumboldt.hale.io.csv.ui.CommonInstanceExportConfigurationPage;
@@ -239,33 +233,6 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 	public void disable() {
 		// TODO Auto-generated method stub
 
-	}
-
-	/**
-	 * @param instances InstanceCollection
-	 * @return boolean true if the instance has at least one properties
-	 */
-	protected boolean extractedSelectableTypeDefinition(InstanceCollection instances) {
-		try (ResourceIterator<Instance> instanceIterator = instances.iterator();) {
-			Instance instance = null;
-			try {
-				instance = instanceIterator.next();
-				Iterable<QName> allProperties = instance.getPropertyNames();
-
-				for (QName qname : allProperties) {
-
-					// get properties of the current instance
-					Object[] properties = instance.getProperty(qname);
-					if (properties != null && properties.length != 0) {
-						return true;
-					}
-				}
-			} catch (NoSuchElementException e) {
-				return false;
-			}
-
-		}
-		return false;
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
@@ -15,8 +15,8 @@
 
 package eu.esdihumboldt.hale.io.xls.ui;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import javax.xml.namespace.QName;
 
@@ -25,23 +25,31 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
+import org.eclipse.jface.viewers.ICheckStateProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.ui.PlatformUI;
 
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.instance.io.InstanceWriter;
+import eu.esdihumboldt.hale.common.instance.model.DataSet;
+import eu.esdihumboldt.hale.common.instance.model.Instance;
+import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
+import eu.esdihumboldt.hale.common.instance.model.ResourceIterator;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
 import eu.esdihumboldt.hale.io.csv.ui.CommonInstanceExportConfigurationPage;
+import eu.esdihumboldt.hale.ui.service.instance.InstanceService;
 
 /**
  * Configuration page for exporting Excel
@@ -52,7 +60,6 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 
 	private CheckboxTableViewer featureTypeTable;
 	private Button selectAll = null;
-	private Button ignoreEmptyFeaturetypes = null;
 	private Group chooseFeatureTypes;
 	private Table table;
 
@@ -91,19 +98,6 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 	protected void onShowPage(boolean firstShow) {
 		if (firstShow) {
 
-			ignoreEmptyFeaturetypes = new Button(chooseFeatureTypes, SWT.CHECK);
-			ignoreEmptyFeaturetypes.setText("Ignore feature types without data");
-			ignoreEmptyFeaturetypes
-					.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
-
-			ignoreEmptyFeaturetypes.addSelectionListener(new SelectionAdapter() {
-
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-				}
-			});
-			ignoreEmptyFeaturetypes.setSelection(false);
-
 			selectAll = new Button(chooseFeatureTypes, SWT.CHECK);
 			selectAll.setText("Select all");
 			selectAll.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
@@ -118,6 +112,14 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 					setPageComplete(validate());
 				}
 			});
+
+			Label separatorLabel = new Label(page, SWT.NONE);
+			separatorLabel.setText("Warning! Feature types with no data are not selectable");
+
+			// Set the text colour of the label to yellow
+			Color greyLabel = PlatformUI.getWorkbench().getDisplay()
+					.getSystemColor(SWT.COLOR_DARK_GRAY);
+			separatorLabel.setForeground(greyLabel);
 
 			table = new Table(chooseFeatureTypes, SWT.CHECK | SWT.MULTI | SWT.SCROLL_PAGE);
 			table.setHeaderVisible(false);
@@ -138,22 +140,60 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 			});
 			featureTypeTable.setContentProvider(ArrayContentProvider.getInstance());
 
-			Collection<? extends TypeDefinition> relevantTypes = getWizard().getProvider()
-					.getTargetSchema().getMappingRelevantTypes();
+			featureTypeTable.setInput(
+					getWizard().getProvider().getTargetSchema().getMappingRelevantTypes());
 
-			ArrayList<QName> tableContent = new ArrayList<>();
-			for (TypeDefinition typeDefinition : relevantTypes) {
-				tableContent.add(typeDefinition.getName());
-			}
-
-			featureTypeTable.setInput(relevantTypes);
 			featureTypeTable.addCheckStateListener(new ICheckStateListener() {
 
 				@Override
 				public void checkStateChanged(CheckStateChangedEvent event) {
+					// Programmatic action to toggle the state
+					selectAll.setSelection(
+							featureTypeTable.getCheckedElements().length == featureTypeTable
+									.getTable().getItemCount());
+
 					page.layout();
 					page.pack();
 					setPageComplete(validate());
+				}
+			});
+
+			featureTypeTable.setCheckStateProvider(new ICheckStateProvider() {
+
+				@Override
+				public boolean isChecked(Object element) {
+					if (!(element instanceof TypeDefinition))
+						return false;
+					return checkboxState(element);
+				}
+
+				@Override
+				public boolean isGrayed(Object element) {
+					if (!(element instanceof TypeDefinition))
+						return false;
+					return checkboxState(element);
+				}
+
+				/**
+				 * @param element
+				 * @return true if the button cannot be selected
+				 */
+				private boolean checkboxState(Object element) {
+					InstanceService instanceService = PlatformUI.getWorkbench()
+							.getService(InstanceService.class);
+
+					Set<TypeDefinition> instanceSourceTypes = instanceService
+							.getInstanceTypes(DataSet.SOURCE);
+					if (instanceSourceTypes.contains(element)) {
+						return false;
+					}
+
+					Set<TypeDefinition> instanceTransformedTypes = instanceService
+							.getInstanceTypes(DataSet.TRANSFORMED);
+					if (instanceTransformedTypes.contains(element)) {
+						return false;
+					}
+					return true;
 				}
 			});
 
@@ -172,9 +212,6 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 	@Override
 	public boolean updateConfiguration(InstanceWriter provider) {
 		super.updateConfiguration(provider);
-
-		provider.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
-				Value.of(ignoreEmptyFeaturetypes.getSelection()));
 
 		Object[] elements = featureTypeTable.getCheckedElements();
 		String param = "";
@@ -202,6 +239,33 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 	public void disable() {
 		// TODO Auto-generated method stub
 
+	}
+
+	/**
+	 * @param instances InstanceCollection
+	 * @return boolean true if the instance has at least one properties
+	 */
+	protected boolean extractedSelectableTypeDefinition(InstanceCollection instances) {
+		try (ResourceIterator<Instance> instanceIterator = instances.iterator();) {
+			Instance instance = null;
+			try {
+				instance = instanceIterator.next();
+				Iterable<QName> allProperties = instance.getPropertyNames();
+
+				for (QName qname : allProperties) {
+
+					// get properties of the current instance
+					Object[] properties = instance.getProperty(qname);
+					if (properties != null && properties.length != 0) {
+						return true;
+					}
+				}
+			} catch (NoSuchElementException e) {
+				return false;
+			}
+
+		}
+		return false;
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSInstanceWriter.java
@@ -74,9 +74,6 @@ public class XLSInstanceWriter extends AbstractTableInstanceWriter {
 		boolean solveNestedProperties = getParameter(
 				InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES).as(Boolean.class, false);
 
-		boolean ignoreEmptyFeaturetypes = getParameter(
-				InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES).as(Boolean.class, false);
-
 		// write xls file
 		if (getContentType().getId().equals("eu.esdihumboldt.hale.io.xls.xls")) {
 			workbook = new HSSFWorkbook();
@@ -114,8 +111,7 @@ public class XLSInstanceWriter extends AbstractTableInstanceWriter {
 			for (QName selectedTypeName : selectedFeatureTypes) {
 				// get all instances of the selected Type
 				InstanceCollection instances = getInstanceCollection(selectedTypeName);
-				addSheetByQName(solveNestedProperties, ignoreEmptyFeaturetypes, selectedTypeName,
-						instances);
+				addSheetByQName(solveNestedProperties, selectedTypeName, instances);
 			}
 		}
 
@@ -124,17 +120,17 @@ public class XLSInstanceWriter extends AbstractTableInstanceWriter {
 		}
 
 		reporter.setSuccess(true);
+
 		return reporter;
 	} // close try-iterator
 
 	/**
 	 * @param solveNestedProperties : Solve nested properties
-	 * @param ignoreEmptyFeaturetypes don't add empty feature types to excel
 	 * @param selectedTypeName selected feature type
 	 * @param instances InstanceCollection available
 	 */
-	private void addSheetByQName(boolean solveNestedProperties, boolean ignoreEmptyFeaturetypes,
-			QName selectedTypeName, InstanceCollection instances) {
+	private void addSheetByQName(boolean solveNestedProperties, QName selectedTypeName,
+			InstanceCollection instances) {
 
 		// use ResourceIterator<Instance> in a try block because is closable
 		// -
@@ -145,11 +141,6 @@ public class XLSInstanceWriter extends AbstractTableInstanceWriter {
 			try {
 				instance = instanceIterator.next();
 			} catch (NoSuchElementException e) {
-				if (!ignoreEmptyFeaturetypes) {
-					Sheet sheet = workbook.createSheet(selectedTypeName.getLocalPart());
-					sheet.createRow(0);
-					resizeSheet(sheet);
-				}
 				return;
 			}
 


### PR DESCRIPTION
CSV: Add a warning label to CSV dialog telling that feature types without data are not selectable.
XSL: remove the button "Ignore feature types without data" and add intro the checkbox table disabled from selection elements that don't have any data for export.

ING-3987