### PR TITLE
fixup! fix: For Shapefile writer recognize geometries for feature types

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.shp.test/src/eu/esdihumboldt/hale/io/shp/ShapefileInstanceWriterTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp.test/src/eu/esdihumboldt/hale/io/shp/ShapefileInstanceWriterTest.groovy
@@ -1025,8 +1025,6 @@ class ShapefileInstanceWriterTest {
 				a('More text')
 				b(1.52)
 				c(23)
-				location(createGeometry('POINT(48.137222 11.575556)', 4326))
-				locat(polyGeom)
 			}
 
 			xyz {
@@ -1082,9 +1080,9 @@ class ShapefileInstanceWriterTest {
 					}
 				}
 			}
-			assertEquals(8, num)
+			assertEquals(6, num)
 			assertEquals(4, xyzCount)
-			assertEquals(4, abcCount)
+			assertEquals(2, abcCount)
 			//			assertEquals(2, attrCount)
 		}
 	}

--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/writer/ShapefileInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/writer/ShapefileInstanceWriter.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -128,7 +129,9 @@ public class ShapefileInstanceWriter extends AbstractGeoInstanceWriter {
 				String cpgFileName = filePath + "/" + f + ShapefileConstants.CPG_EXTENSION;
 				writeCodePageFile(cpgFileName);
 			}
-
+			if (filesWritten.isEmpty()) {
+				reporter.warn("No file has been exported because there was no geometry found.");
+			}
 			reporter.setSuccess(true);
 		} catch (Exception e) {
 			reporter.error(new IOMessageImpl(e.getMessage(), e));
@@ -206,7 +209,7 @@ public class ShapefileInstanceWriter extends AbstractGeoInstanceWriter {
 
 		Map<String, Map<String, SimpleFeatureTypeBuilder>> schemaBuilderMap = new HashMap<String, Map<String, SimpleFeatureTypeBuilder>>();
 
-		List<String> missingGeomsForSchemas = new ArrayList<String>();
+		LinkedHashSet<String> missingGeomsForSchemas = new LinkedHashSet<String>();
 		try (ResourceIterator<Instance> it = instances.iterator()) {
 			while (it.hasNext() && !progress.isCanceled()) {
 				Instance instance = it.next();
@@ -234,7 +237,6 @@ public class ShapefileInstanceWriter extends AbstractGeoInstanceWriter {
 
 			if (missingGeomsForSchemas.contains(schemaEntry.getKey())) {
 				reporter.warn("No geometry found for " + schemaEntry.getKey());
-				continue;
 			}
 
 			for (Entry<String, SimpleFeatureTypeBuilder> geometryEntry : schemaEntry.getValue()
@@ -264,7 +266,7 @@ public class ShapefileInstanceWriter extends AbstractGeoInstanceWriter {
 	 */
 	private void writeGeometrySchema(Instance instance, String localPart,
 			Map<String, SimpleFeatureTypeBuilder> geometryBuilderMap,
-			List<String> missingGeomsForSchemas) {
+			LinkedHashSet<String> missingGeomsForSchemas) {
 		Geometry geom = null;
 
 		List<GeometryProperty<?>> geoms = traverseInstanceForGeometries(instance);

--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/config/SimpleTargetCRSConfigurationPage.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/io/config/SimpleTargetCRSConfigurationPage.java
@@ -165,9 +165,9 @@ public class SimpleTargetCRSConfigurationPage<P extends GeoInstanceWriter, W ext
 			separatorLabel.setText("Warning! Feature types with no geometry will not be exported");
 
 			// Set the text colour of the label to yellow
-			Color yellow = PlatformUI.getWorkbench().getDisplay()
+			Color greyLabel = PlatformUI.getWorkbench().getDisplay()
 					.getSystemColor(SWT.COLOR_DARK_GRAY);
-			separatorLabel.setForeground(yellow);
+			separatorLabel.setForeground(greyLabel);
 		}
 
 		// only update on first show


### PR DESCRIPTION
Shapefile files are correctly generated by the sending the CRS to the Geometry Finder.

ING-3974