### PR TITLE
fixup: align XSL with CSV by getting the selected elements without grey elements

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceExportConfigurationPage.java
@@ -15,6 +15,9 @@
 
 package eu.esdihumboldt.hale.io.xls.ui;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jface.layout.GridDataFactory;
@@ -207,9 +210,12 @@ public class XLSInstanceExportConfigurationPage extends CommonInstanceExportConf
 	public boolean updateConfiguration(InstanceWriter provider) {
 		super.updateConfiguration(provider);
 
-		Object[] elements = featureTypeTable.getCheckedElements();
+		List<Object> sourceList = new ArrayList<>(
+				Arrays.asList(featureTypeTable.getCheckedElements()));
+		sourceList.removeAll(Arrays.asList(featureTypeTable.getGrayedElements()));
+
 		String param = "";
-		for (Object el : elements) {
+		for (Object el : sourceList) {
 			param = param + ((TypeDefinition) el).getName().toString() + ",";
 		}
 		provider.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of(param));


### PR DESCRIPTION
Align the XSL and CSV by getting the selected elements of the CheckboxTableViewer and removing the greyed out elements that cannot be selected. The grey elements are not used later because they don't have any properties, but better to send the complete and right list of selected elements.

related ING-3941