### PR TITLE
fix: export transformed data leads to a shift of the attribute values

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/writer/ShapefileInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.shp/src/eu/esdihumboldt/hale/io/shp/writer/ShapefileInstanceWriter.java
@@ -641,8 +641,7 @@ public class ShapefileInstanceWriter extends AbstractGeoInstanceWriter {
 					if (geoProp.getGeometry() != null) {
 						String geometryType = geoProp.getGeometry().getGeometryType();
 						if (schemaFbMap.get(localPart) != null
-								&& schemaFbMap.get(localPart).get(geometryType) != null
-								&& value != null) {
+								&& schemaFbMap.get(localPart).get(geometryType) != null) {
 							schemaFbMap.get(localPart).get(geometryType).add(value);
 						}
 					}


### PR DESCRIPTION
No shift in the attributes happens when exporting a transformed data to shp-file.

ING-4052