### PR TITLE
feat: support loading schema from Json data

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/SimpleLog.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.core/src/eu/esdihumboldt/hale/common/core/report/SimpleLog.java
@@ -133,7 +133,12 @@ public interface SimpleLog {
 	 * @param args the pattern arguments
 	 */
 	default void warn(String pattern, Object... args) {
-		warn(MessageFormat.format(pattern, args));
+		String message = MessageFormat.format(pattern, args);
+		Throwable error = null;
+		if (args != null && args[args.length - 1] instanceof Throwable) {
+			error = (Throwable) args[args.length - 1];
+		}
+		warn(message, error);
 	}
 
 	void error(String message, Throwable e);
@@ -149,7 +154,12 @@ public interface SimpleLog {
 	 * @param args the pattern arguments
 	 */
 	default void error(String pattern, Object... args) {
-		error(MessageFormat.format(pattern, args));
+		String message = MessageFormat.format(pattern, args);
+		Throwable error = null;
+		if (args != null && args[args.length - 1] instanceof Throwable) {
+			error = (Throwable) args[args.length - 1];
+		}
+		error(message, error);
 	}
 
 	void info(String message, Throwable e);
@@ -166,7 +176,12 @@ public interface SimpleLog {
 	 * @param args the pattern arguments
 	 */
 	default void info(String pattern, Object... args) {
-		info(MessageFormat.format(pattern, args));
+		String message = MessageFormat.format(pattern, args);
+		Throwable error = null;
+		if (args != null && args[args.length - 1] instanceof Throwable) {
+			error = (Throwable) args[args.length - 1];
+		}
+		info(message, error);
 	}
 
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.json.test/src/eu/esdihumboldt/hale/io/json/test/JsonSchemaReaderTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.json.test/src/eu/esdihumboldt/hale/io/json/test/JsonSchemaReaderTest.groovy
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.test
+
+import static org.assertj.core.api.Assertions.*
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.function.Consumer
+
+import javax.xml.namespace.QName
+
+import org.junit.Test
+import org.locationtech.jts.geom.LineString
+import org.locationtech.jts.geom.Point
+
+import eu.esdihumboldt.hale.common.core.io.impl.LogProgressIndicator
+import eu.esdihumboldt.hale.common.core.io.supplier.LocatableInputSupplier
+import eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty
+import eu.esdihumboldt.hale.common.schema.model.DefinitionUtil
+import eu.esdihumboldt.hale.common.schema.model.Schema
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.Cardinality
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.Binding
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.GeometryType
+import eu.esdihumboldt.hale.io.json.JsonSchemaReader
+import eu.esdihumboldt.hale.io.json.internal.schema.JsonType
+import eu.esdihumboldt.util.io.StringInputSupplier
+
+/**
+ * Tests for reading a schema from Json data.
+ * 
+ * @author Simon Templer
+ */
+@SuppressWarnings("restriction")
+//@CompileStatic - disabled because it causes problems in Maven Tycho build
+class JsonSchemaReaderTest {
+
+	// default charset used in tests
+	Charset charset = StandardCharsets.UTF_8
+
+	@Test
+	void testStringProperty() {
+		def json = '''
+[
+  {
+    "name": "Henry"
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def property = type.getChild(new QName('name')).asProperty()
+		assertThat(property)
+				.isNotNull()
+		assertThat(property.getConstraint(Cardinality.class))
+				.satisfies({
+					assertThat(it.minOccurs).isEqualTo(0)
+					assertThat(it.maxOccurs).isEqualTo(1)
+				} as Consumer<Cardinality>)
+		assertThat(property.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+	}
+
+	@Test
+	void testNumberProperty() {
+		def json = '''
+[
+  {
+    "age": 12
+  },
+  {
+    "age": 1.2
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def property = type.getChild(new QName('age')).asProperty()
+		assertThat(property)
+				.isNotNull()
+		assertThat(property.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(BigDecimal.class)
+	}
+
+	@Test
+	void testBooleanProperty() {
+		def json = '''
+[
+  {
+    "yes": true
+  },
+  {
+    "yes": false
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def property = type.getChild(new QName('yes')).asProperty()
+		assertThat(property)
+				.isNotNull()
+		assertThat(property.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(Boolean.class)
+	}
+
+	@Test
+	void testMixedProperty() {
+		def json = '''
+[
+  {
+    "age": 12
+  },
+  {
+    "age": "12"
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def property = type.getChild(new QName('age')).asProperty()
+		assertThat(property)
+				.isNotNull()
+		assertThat(property.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+	}
+
+	@Test
+	void testMultipleProperties() {
+		def json = '''
+[
+  {
+    "age": 12
+  },
+  {
+    "name": "Henry"
+  },
+  {
+    "name": "Peter",
+    "address": "Peter's home"
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(3)
+
+		def ageProperty = type.getChild(new QName('age')).asProperty()
+		assertThat(ageProperty)
+				.isNotNull()
+		assertThat(ageProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(BigDecimal.class)
+
+		def nameProperty = type.getChild(new QName('name')).asProperty()
+		assertThat(nameProperty)
+				.isNotNull()
+		assertThat(nameProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+
+		def addressProperty = type.getChild(new QName('address')).asProperty()
+		assertThat(addressProperty)
+				.isNotNull()
+	}
+
+	@Test
+	void testNested() {
+		def json = '''
+[
+  {
+    "person": {
+      "name": "Henry"
+    }
+  },
+  {
+    "person": {
+      "age": 12
+    }
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def personProperty = type.getChild(new QName('person')).asProperty()
+		assertThat(personProperty)
+				.isNotNull()
+
+		def children = DefinitionUtil.getAllProperties(personProperty.propertyType)
+		assertThat(children).hasSize(2)
+
+		def nameProperty = personProperty.propertyType.getChild(new QName('name')).asProperty()
+		assertThat(nameProperty)
+				.isNotNull()
+		assertThat(nameProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+
+		def ageProperty = personProperty.propertyType.getChild(new QName('age')).asProperty()
+		assertThat(ageProperty)
+				.isNotNull()
+		assertThat(ageProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(BigDecimal.class)
+	}
+
+	@Test
+	void testArray() {
+		def json = '''
+[
+  {
+    "people": [
+      {
+        "name": "Henry"
+      },
+      {
+        "name": "Peter"
+      }
+    ]
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def peopleProperty = type.getChild(new QName('people')).asProperty()
+		assertThat(peopleProperty)
+				.isNotNull()
+		assertThat(peopleProperty.getConstraint(Cardinality.class))
+				.satisfies({
+					assertThat(it.minOccurs).isEqualTo(0)
+					assertThat(it.maxOccurs).isEqualTo(Cardinality.UNBOUNDED)
+				} as Consumer<Cardinality>)
+
+		def children = DefinitionUtil.getAllProperties(peopleProperty.propertyType)
+		assertThat(children).hasSize(1)
+
+		def nameProperty = peopleProperty.propertyType.getChild(new QName('name')).asProperty()
+		assertThat(nameProperty)
+				.isNotNull()
+		assertThat(nameProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+	}
+
+	@Test
+	void testPointGeometry() {
+		def json = '''
+[
+  {
+    "geom": {
+      "type": "Point",
+      "coordinates": [30, 10]
+    } 
+  }
+]
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(1)
+
+		def property = type.getChild(new QName('geom')).asProperty()
+		assertThat(property)
+				.isNotNull()
+		assertThat(property.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(GeometryProperty.class)
+		assertThat(property.propertyType.getConstraint(GeometryType.class))
+				.satisfies({
+					assertThat(it.geometry).isTrue()
+					assertThat(it.binding).isEqualTo(Point.class)
+				} as Consumer<GeometryType>)
+	}
+
+	@Test
+	void testGeoJson() {
+		def json = '''
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+        ]
+      },
+      "properties": {
+        "name": "Somewhere"
+      }
+    }
+  ]
+}
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(1)
+
+		def type = firstType(schema)
+
+		def properties = DefinitionUtil.getAllProperties(type)
+		assertThat(properties).hasSize(2)
+
+		def geomProperty = type.getChild(JsonType.GEOJSON_GEOMETRY_NAME).asProperty()
+		assertThat(geomProperty)
+				.isNotNull()
+		assertThat(geomProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(GeometryProperty.class)
+		assertThat(geomProperty.propertyType.getConstraint(GeometryType.class))
+				.satisfies({
+					assertThat(it.geometry).isTrue()
+					assertThat(it.binding).isEqualTo(LineString.class)
+				} as Consumer<GeometryType>)
+
+		def nameProperty = type.getChild(new QName('name')).asProperty()
+		assertThat(nameProperty)
+				.isNotNull()
+		assertThat(nameProperty.propertyType.getConstraint(Binding.class).binding)
+				.isEqualTo(String.class)
+	}
+
+	@Test
+	void testMultiType() {
+		def json = '''
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "@type": "Place",
+      "properties": {
+        "name": "Somewhere"
+      }
+    },
+    {
+      "@type": "Person",
+      "properties": {
+        "name": "Henry"
+      }
+    }
+  ]
+}
+'''
+
+		def reader = jsonStringReader(json)
+		def schema = execute(reader)
+
+		assertThat(schema.getMappingRelevantTypes())
+				.hasSize(2)
+
+		assertThat(schema.getMappingRelevantTypes()
+				.collect { TypeDefinition t -> t.name.localPart })
+				.containsExactlyInAnyOrder("Person", "Place")
+
+		schema.getMappingRelevantTypes().each { TypeDefinition type ->
+			def properties = DefinitionUtil.getAllProperties(type)
+			assertThat(properties).hasSize(1)
+
+			def nameProperty = type.getChild(new QName('name')).asProperty()
+			assertThat(nameProperty)
+					.isNotNull()
+			assertThat(nameProperty.propertyType.getConstraint(Binding.class).binding)
+					.isEqualTo(String.class)
+		}
+	}
+
+	// helpers
+
+	TypeDefinition firstType(Schema schema) {
+		assertThat(schema.getMappingRelevantTypes())
+				.isNotEmpty()
+
+		schema.mappingRelevantTypes.iterator().next()
+	}
+
+	Schema execute(JsonSchemaReader reader) {
+		def report = reader.execute(new LogProgressIndicator())
+		assertThat(report.isSuccess()).isTrue()
+		reader.getSchema()
+	}
+
+	JsonSchemaReader jsonStringReader(String testData) {
+		JsonSchemaReader reader = new JsonSchemaReader()
+
+		reader.setCharset(charset)
+		def stringSource =  new StringInputSupplier(testData, charset)
+		reader.setSource(new LocatableInputSupplier() {
+
+					@Override
+					public Object getInput() throws IOException {
+						stringSource.getInput()
+					}
+
+					@Override
+					public URI getLocation() {
+						return null;
+					}
+
+					@Override
+					public URI getUsedLocation() {
+						return null;
+					}
+				})
+		reader
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: HALE Json IO
 Bundle-SymbolicName: eu.esdihumboldt.hale.io.json;singleton:=true
 Bundle-Version: 5.1.0.qualifier
-Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: com.google.common.base;version="1.6.0",
  com.google.common.collect;version="9.0.0",
@@ -32,6 +31,7 @@ Import-Package: com.google.common.base;version="1.6.0",
  eu.esdihumboldt.hale.common.schema.geometry,
  eu.esdihumboldt.hale.common.schema.groovy,
  eu.esdihumboldt.hale.common.schema.io,
+ eu.esdihumboldt.hale.common.schema.io.impl,
  eu.esdihumboldt.hale.common.schema.model,
  eu.esdihumboldt.hale.common.schema.model.constraint,
  eu.esdihumboldt.hale.common.schema.model.constraint.property,
@@ -63,7 +63,8 @@ Import-Package: com.google.common.base;version="1.6.0",
  org.osgi.framework;version="1.3.0",
  org.slf4j;version="1.5.11"
 Export-Package: eu.esdihumboldt.hale.io.json,
- eu.esdihumboldt.hale.io.json.internal
+ eu.esdihumboldt.hale.io.json.internal;x-internal:=true,
+ eu.esdihumboldt.hale.io.json.internal.schema;x-internal:=true
 Require-Bundle: org.eclipse.core.contenttype;bundle-version="3.4.100",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  de.fhg.igd.eclipse.util,

--- a/io/plugins/eu.esdihumboldt.hale.io.json/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/plugin.xml
@@ -103,6 +103,42 @@
             </parameterBinding>
          </providerParameter>
       </provider>
+      <provider
+            allowDuplicate="false"
+            class="eu.esdihumboldt.hale.io.json.JsonSchemaReader"
+            description="Reads Json data and derives a schema from it"
+            id="eu.esdihumboldt.hale.io.json.reader.dataschema"
+            name="Schema from JSON">
+         <contentType
+               ref="eu.esdihumboldt.hale.io.json">
+         </contentType>
+         <contentType
+               ref="eu.esdihumboldt.hale.io.json.gzip">
+         </contentType>
+         <providerParameter
+               description="Mode for reading Json structure"
+               label="Read mode"
+               name="mode"
+               optional="true">
+            <parameterEnumeration>
+               <enumerationValue
+                     value="auto">
+               </enumerationValue>
+               <enumerationValue
+                     value="singleObject">
+               </enumerationValue>
+               <enumerationValue
+                     value="firstArray">
+               </enumerationValue>
+            </parameterEnumeration>
+            <valueDescriptor
+                  default="auto"
+                  defaultDescription="Load objects from a Json array or a GeoJson FeatureCollection"
+                  sample="singleObject"
+                  sampleDescription="When the source file is only a single object at its root, use this mode">
+            </valueDescriptor>
+         </providerParameter>
+      </provider>
    </extension>
 
 </plugin>

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/JsonSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/JsonSchemaReader.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
+import eu.esdihumboldt.hale.common.core.io.IOProviderConfigurationException;
+import eu.esdihumboldt.hale.common.core.io.ProgressIndicator;
+import eu.esdihumboldt.hale.common.core.io.Value;
+import eu.esdihumboldt.hale.common.core.io.report.IOReport;
+import eu.esdihumboldt.hale.common.core.io.report.IOReporter;
+import eu.esdihumboldt.hale.common.core.report.SimpleLog;
+import eu.esdihumboldt.hale.common.schema.io.impl.AbstractSchemaReader;
+import eu.esdihumboldt.hale.common.schema.model.Schema;
+import eu.esdihumboldt.hale.io.json.internal.IgnoreNamespaces;
+import eu.esdihumboldt.hale.io.json.internal.JsonInstanceProcessor;
+import eu.esdihumboldt.hale.io.json.internal.JsonReadMode;
+import eu.esdihumboldt.hale.io.json.internal.NamespaceManager;
+import eu.esdihumboldt.hale.io.json.internal.schema.JsonToSchema;
+
+/**
+ * Reader for a schema from a Json/GeoJson data file.
+ * 
+ * @author Simon Templer
+ */
+public class JsonSchemaReader extends AbstractSchemaReader {
+
+	private static final ALogger log = ALoggerFactory.getLogger(JsonSchemaReader.class);
+
+	/**
+	 * Name of the parameter that specifies the read mode.
+	 */
+	public static final String PARAM_READ_MODE = "mode";
+
+	private Schema schema;
+
+	/**
+	 * Default constructor
+	 */
+	public JsonSchemaReader() {
+		super();
+
+		addSupportedParameter(PARAM_READ_MODE);
+	}
+
+	@Override
+	public boolean isCancelable() {
+		// actual
+		return false;
+	}
+
+	@Override
+	protected IOReport execute(ProgressIndicator progress, IOReporter reporter)
+			throws IOProviderConfigurationException, IOException {
+		progress.begin("Attempting to read " + getDefaultTypeName(), ProgressIndicator.UNKNOWN);
+
+		try {
+			boolean expectGeoJson = true; // currently defaults to true, no
+											// major difference in functionality
+
+			// local name for type (unless there are @type notations in the
+			// data)
+			// TODO allow custom value through configuration
+			String typeNameHint = "Json";
+
+			// try to determine from file name
+			URI loc = getSource().getLocation();
+			if (loc != null) {
+				String candidate = loc.getPath();
+				if (candidate != null && !candidate.isEmpty()) {
+					int lastSlash = candidate.lastIndexOf('/');
+					if (lastSlash >= 0 && lastSlash + 1 < candidate.length()) {
+						candidate = candidate.substring(lastSlash + 1);
+					}
+					if (candidate.toLowerCase().endsWith(".json")) {
+						candidate = candidate.substring(0, candidate.length() - 5);
+					}
+					typeNameHint = candidate.replaceAll("[^\\w-_]", "_");
+				}
+			}
+
+			// currently no specific namespace support
+			NamespaceManager namespaces = new IgnoreNamespaces();
+
+			JsonToSchema translator = new JsonToSchema(getReadMode(), expectGeoJson, typeNameHint,
+					namespaces, SimpleLog.fromLogger(log), getSharedTypes());
+			try (BufferedReader reader = new BufferedReader(
+					new InputStreamReader(getSource().getInput(), getCharset()))) {
+				JsonInstanceProcessor.process(reader, translator, null,
+						// TODO configurable limit
+						50);
+			}
+			this.schema = translator.getSchema();
+
+			reporter.setSuccess(true);
+		} catch (Exception e) {
+			reporter.error("Error preparing reading {0}", getDefaultTypeName(), e);
+			reporter.setSuccess(false);
+		} finally {
+			progress.end();
+		}
+		return reporter;
+	}
+
+	/**
+	 * Set the read mode to use.
+	 * 
+	 * @param mode the mode for reading Json
+	 */
+	public void setReadMode(JsonReadMode mode) {
+		if (mode == null) {
+			setParameter(PARAM_READ_MODE, Value.NULL);
+		}
+		else {
+			setParameter(PARAM_READ_MODE, Value.of(mode.toString()));
+		}
+	}
+
+	/**
+	 * @return the mode to use for reading Json
+	 */
+	public JsonReadMode getReadMode() {
+		JsonReadMode value = getParameter(PARAM_READ_MODE).as(JsonReadMode.class);
+		if (value == null)
+			return JsonReadMode.auto;
+		else
+			return value;
+	}
+
+	@Override
+	protected String getDefaultTypeName() {
+		return "Schema from JSON";
+	}
+
+	@Override
+	public Schema getSchema() {
+		return schema;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/JsonToInstance.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/JsonToInstance.java
@@ -227,6 +227,18 @@ public class JsonToInstance extends AbstractJsonInstanceProcessor<Instance>
 	 * @return the qualified name
 	 */
 	private QName extractName(String text) {
+		return JsonToInstance.extractName(text, namespaces);
+	}
+
+	/**
+	 * Extract a qualified name from a text representation with an optional
+	 * namespace prefix.
+	 * 
+	 * @param text the text representation of the name
+	 * @param namespaces the namespace manager
+	 * @return the qualified name
+	 */
+	public static QName extractName(String text, NamespaceManager namespaces) {
 		if (text == null) {
 			return null;
 

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonProperty.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonProperty.groovy
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema
+
+import javax.xml.namespace.QName
+
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.GeometryCollection
+import org.locationtech.jts.geom.LineString
+import org.locationtech.jts.geom.MultiLineString
+import org.locationtech.jts.geom.MultiPoint
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.Polygon
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.google.common.collect.HashMultiset
+import com.google.common.collect.Multiset
+
+import eu.esdihumboldt.hale.common.core.report.SimpleLog
+import eu.esdihumboldt.hale.common.schema.model.DefinitionGroup
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.Cardinality
+import eu.esdihumboldt.hale.common.schema.model.constraint.property.NillableFlag
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultPropertyDefinition
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+/**
+ * Information collected on a Json property across different instances.
+ * 
+ * @author Simon Templer
+ */
+@CompileStatic
+@Canonical
+class JsonProperty {
+	/**
+	 * Element type in case of an array (otherwise null)
+	 */
+	JsonProperty elements
+	/**
+	 * Children in case of an object (otherwise empty)
+	 */
+	final Map<String, JsonProperty> children = new LinkedHashMap<>()
+	/**
+	 * Primitive value types encountered 
+	 */
+	final Multiset<JsonValueType> types = HashMultiset.create();
+	/**
+	 * Geometry value types encountered
+	 */
+	final Multiset<Class<? extends Geometry>> geometryTypes = HashMultiset.create();
+
+	private int valueCount = 0;
+
+	/**
+	 * @param value
+	 */
+	public void add(JsonNode value, boolean requireGeometry, SimpleLog log) {
+		if (value == null || value.isMissingNode()) {
+			return;
+		}
+
+		if (value.isObject()) {
+			ObjectNode object = (ObjectNode) value
+
+			// determine if this is a geometry
+			JsonNode typeNode = object.get("type")
+			Class<Geometry> geometryType = null
+			if (typeNode != null && typeNode.isTextual()) {
+				String type = typeNode.asText()
+
+				JsonNode coordinatesNode = object.get("coordinates")
+				boolean hasCoordinates = coordinatesNode != null && coordinatesNode.isArray()
+
+				switch (type) {
+					case "Point":
+						if (hasCoordinates) {
+							geometryType = Point.class
+						}
+						break;
+					case "MultiPoint":
+						if (hasCoordinates) {
+							geometryType = MultiPoint.class
+						}
+						break;
+					case "LineString":
+						if (hasCoordinates) {
+							geometryType = LineString.class
+						}
+						break;
+					case "MultiLineString":
+						if (hasCoordinates) {
+							geometryType = MultiLineString.class
+						}
+						break;
+					case "Polygon":
+						if (hasCoordinates) {
+							geometryType = Polygon.class
+						}
+						break;
+					case "MultiPolygon":
+						if (hasCoordinates) {
+							geometryType = MultiPolygon.class
+						}
+						break;
+					case "GeometryCollection":
+						JsonNode geometriesNode = object.get("geometries")
+						boolean hasGeometries = geometriesNode != null && geometriesNode.isArray()
+						if (hasGeometries) {
+							geometryType = GeometryCollection.class
+						}
+						break;
+				}
+			}
+
+			if (geometryType != null) {
+				geometryTypes.add(geometryType)
+				valueCount++
+			}
+			else if (requireGeometry) {
+				log.warn("Expected GeoJson geometry but object is not a valid geometry")
+			}
+			else {
+				// handle generic object
+
+				object.fields().forEachRemaining {
+					// add child for each field
+					children.computeIfAbsent(it.key) { new JsonProperty() }.add(it.value, false, log)
+				}
+
+				valueCount++
+			}
+		}
+		else {
+			if (requireGeometry) {
+				log.warn("Unexpected node type {0}, expected GeoJson geometry", value.getClass().getSimpleName())
+				return;
+			}
+
+			if (value.isArray()) {
+				// handle array
+				ArrayNode array = (ArrayNode) value
+
+				array.elements().forEachRemaining {
+					if (elements == null) {
+						elements = new JsonProperty()
+					}
+
+					elements.add(it, false, log)
+				}
+
+				valueCount++
+			}
+			else if (value.isValueNode()) {
+				JsonValueType valueType = JsonValueType.STRING
+				if (value.isNumber()) {
+					valueType = JsonValueType.NUMBER
+				}
+				else if (value.isBoolean()) {
+					valueType = JsonValueType.BOOLEAN
+				}
+				//TODO more types / more fine-grained support?
+
+				types.add(valueType);
+
+				valueCount++
+			}
+		}
+	}
+	/**
+	 * Build a property definition.
+	 */
+	public DefaultPropertyDefinition buildProperty(QName propertyName, DefinitionGroup parent, SchemaBuilderContext context) {
+		// check if array
+		if (elements != null) {
+			// Note: directly nested arrays are currently not supported
+
+			DefaultPropertyDefinition property = elements.buildProperty(propertyName, parent, context);
+
+			// for arrays allow any number of elements by default
+			property.setConstraint(Cardinality.CC_ANY_NUMBER);
+
+			return property;
+		}
+
+		boolean primitive = false
+
+		// determine property type
+		TypeDefinition propertyType
+
+		// 1. check if geometry
+		if (!geometryTypes.isEmpty()) {
+			propertyType = context.getGeometryType(mergeGeometryTypes(geometryTypes));
+		}
+		// 2. check if object
+		else if (!children.isEmpty()) {
+			QName nestedTypeName = new QName(parent.getIdentifier() + "/" + propertyName.getLocalPart(), "AnonymousType")
+			propertyType = new DefaultTypeDefinition(nestedTypeName)
+
+			children.forEach { name, property ->
+				// build property and add to type
+				property.buildProperty(new QName(name), propertyType, context);
+			}
+		}
+		// 3. primitive type
+		else {
+			propertyType = context.getType(mergeValueTypes(types))
+			primitive = true
+		}
+
+		// create and add property
+		DefaultPropertyDefinition property = new DefaultPropertyDefinition(propertyName, parent, propertyType)
+
+		// set constraints
+		property.setConstraint(Cardinality.CC_OPTIONAL);
+		if (primitive) {
+			property.setConstraint(NillableFlag.ENABLED);
+		}
+
+		return property;
+	}
+
+	private Class<? extends Geometry> mergeGeometryTypes(Multiset<Class<? extends Geometry>> types) {
+		if (types == null || types.empty) {
+			// default to generic geometry
+			Geometry.class
+		}
+		else if (types.elementSet().size() == 1) {
+			// only one type
+			types.iterator().next()
+		}
+		else {
+			// mixed types
+			boolean isMulti = types.contains(GeometryCollection.class) || types.contains(MultiPoint.class) ||
+					types.contains(MultiLineString.class) || types.contains(MultiPolygon.class)
+			if (isMulti) {
+				GeometryCollection.class
+			}
+			else {
+				Geometry.class
+			}
+		}
+	}
+
+	private JsonValueType mergeValueTypes(Multiset<JsonValueType> types) {
+		if (types == null || types.empty) {
+			// default to string
+			JsonValueType.STRING
+		}
+		else if (types.elementSet().size() == 1) {
+			// only one type
+			types.iterator().next()
+		}
+		else {
+			// mixed types
+			//TODO use neutral binding?
+			//XXX for now use string for mixed
+			JsonValueType.STRING
+		}
+	}
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonToSchema.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonToSchema.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema;
+
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import eu.esdihumboldt.hale.common.core.report.SimpleLog;
+import eu.esdihumboldt.hale.common.schema.model.Schema;
+import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultSchema;
+import eu.esdihumboldt.hale.io.json.internal.AbstractJsonInstanceProcessor;
+import eu.esdihumboldt.hale.io.json.internal.JsonReadMode;
+import eu.esdihumboldt.hale.io.json.internal.JsonToInstance;
+import eu.esdihumboldt.hale.io.json.internal.NamespaceManager;
+
+/**
+ * Creates a schema definition from Json objects.
+ * 
+ * @author Simon Templer
+ */
+public class JsonToSchema extends AbstractJsonInstanceProcessor<Void> {
+
+	/**
+	 * Default namespace for schemas and types.
+	 */
+	public static final String DEFAULT_NAMESPACE = "http://www.esdi-humboldt.eu/hale/json";
+
+	private DefaultSchema schema;
+
+	private final String typeNameHint;
+
+	private final NamespaceManager namespaces;
+
+	private final JsonTypes types;
+
+	private final TypeIndex sharedTypes;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param mode the read mode for instances
+	 * @param expectGeoJson if GeoJson is expected
+	 * @param typeNameHint the name for the created type used if no other
+	 *            information on the type can be found
+	 * @param namespaces the namespace manager
+	 * @param log the log
+	 * @param sharedTypes the shared types
+	 */
+	public JsonToSchema(JsonReadMode mode, boolean expectGeoJson, String typeNameHint,
+			NamespaceManager namespaces, SimpleLog log, TypeIndex sharedTypes) {
+		super(mode, expectGeoJson);
+
+		this.typeNameHint = typeNameHint;
+		this.namespaces = namespaces;
+		this.types = new JsonTypes(log);
+		this.sharedTypes = sharedTypes;
+	}
+
+	@Override
+	protected Void processInstance(Map<String, JsonNode> fields, ObjectNode geom,
+			Map<String, JsonNode> properties) {
+		// determine type name
+		QName typeName;
+
+		// extract @type information if present
+		JsonNode typeField = fields.get("@type");
+		if (typeField != null && typeField.isTextual()) {
+			typeName = JsonToInstance.extractName(typeField.textValue(), namespaces);
+		}
+		else {
+			typeName = new QName(DEFAULT_NAMESPACE, typeNameHint);
+		}
+
+		JsonType type = types.getType(typeName);
+
+		if (geom != null) {
+			type.addGeoJsonGeometry(geom);
+		}
+
+		properties.forEach((name, value) -> {
+			type.addProperty(name, value);
+		});
+
+		return null;
+	}
+
+	/**
+	 * @return the loaded schema
+	 */
+	public Schema getSchema() {
+		if (schema == null) {
+			schema = buildSchema();
+		}
+		return schema;
+	}
+
+	/**
+	 * @return a schema built from the collected information
+	 */
+	private DefaultSchema buildSchema() {
+		DefaultSchema schema = new DefaultSchema(DEFAULT_NAMESPACE, null);
+
+		SchemaBuilderContext context = new SchemaBuilderContext(DEFAULT_NAMESPACE, sharedTypes);
+
+		// build types
+		types.buildTypes(context).forEach(t -> schema.addType(t));
+
+		// add common types from context
+		context.getCommonTypes().forEach(t -> schema.addType(t));
+
+		return schema;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonType.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonType.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import eu.esdihumboldt.hale.common.core.report.SimpleLog;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.MappableFlag;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.MappingRelevantFlag;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition;
+import eu.esdihumboldt.hale.io.json.internal.InstanceJsonConstants;
+
+/**
+ * Represents a specific type of Json object.
+ * 
+ * @author Simon Templer
+ */
+public class JsonType {
+
+	/**
+	 * Name of the GeoJson geometry property in a type.
+	 */
+	public static final QName GEOJSON_GEOMETRY_NAME = new QName(
+			InstanceJsonConstants.NAMESPACE_GEOJSON, "geometry");
+
+	private final QName name;
+
+	private final SimpleLog log;
+
+	/**
+	 * @param name the name of the type
+	 * @param log the log
+	 */
+	public JsonType(QName name, SimpleLog log) {
+		this.name = name;
+		this.log = log;
+	}
+
+	private final Map<String, JsonProperty> properties = new LinkedHashMap<>();
+
+	private final JsonProperty geoJsonGeometry = new JsonProperty();
+
+	/**
+	 * Build the type definition from the collected information.
+	 * 
+	 * @param context the schema building context
+	 * 
+	 * @return the type definition
+	 */
+	public TypeDefinition buildType(SchemaBuilderContext context) {
+		DefaultTypeDefinition type = new DefaultTypeDefinition(name);
+
+		if (!geoJsonGeometry.getGeometryTypes().isEmpty()) {
+			geoJsonGeometry.buildProperty(GEOJSON_GEOMETRY_NAME, type, context);
+		}
+
+		properties.forEach((name, property) -> {
+			// build property and add to type
+			property.buildProperty(new QName(name), type, context);
+		});
+
+		type.setConstraint(MappableFlag.ENABLED);
+		type.setConstraint(MappingRelevantFlag.ENABLED);
+
+		return type;
+	}
+
+	/**
+	 * Add a GeoJson geometry node.
+	 * 
+	 * @param geom the geometry node
+	 */
+	public void addGeoJsonGeometry(ObjectNode geom) {
+		geoJsonGeometry.add(geom, true, log);
+	}
+
+	/**
+	 * Add a property based on a Json node.
+	 * 
+	 * @param name the property name
+	 * @param value the Json value
+	 */
+	public void addProperty(String name, JsonNode value) {
+		properties.computeIfAbsent(name, n -> new JsonProperty()).add(value, false, log);
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonTypes.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonTypes.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
+import eu.esdihumboldt.hale.common.core.report.SimpleLog;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+
+/**
+ * Create type definitions from information collected on different object types
+ * encountered in Json.
+ * 
+ * @author Simon Templer
+ */
+public class JsonTypes {
+
+	private final Map<QName, JsonType> types = new HashMap<>();
+
+	private final SimpleLog log;
+
+	/**
+	 * @param log the log to use
+	 */
+	public JsonTypes(SimpleLog log) {
+		super();
+		this.log = log;
+	}
+
+	/**
+	 * Get or create the type of the given name.
+	 * 
+	 * @param name the type name
+	 * @return the representation of the Json type
+	 */
+	public JsonType getType(QName name) {
+		return types.computeIfAbsent(name, n -> new JsonType(n, log));
+	}
+
+	/**
+	 * Build the type definitions from the collected information.
+	 * 
+	 * @param context the schema building context
+	 * 
+	 * @return the type definitions
+	 */
+	public Iterable<TypeDefinition> buildTypes(SchemaBuilderContext context) {
+		return types.values().stream().map(t -> t.buildType(context)).collect(Collectors.toList());
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonValueType.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/JsonValueType.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema;
+
+import java.math.BigDecimal;
+
+/**
+ * Types of primitive values encountered in Json.
+ * 
+ * @author Simon Templer
+ */
+public enum JsonValueType {
+
+	/**
+	 * String value type
+	 */
+	STRING("StringValueType", String.class),
+
+	/**
+	 * Number value type
+	 */
+	NUMBER("NumberValueType", BigDecimal.class),
+
+	/**
+	 * Boolean value type
+	 */
+	BOOLEAN("BooleanValueType", Boolean.class);
+
+	final String typeName;
+
+	final Class<?> binding;
+
+	/**
+	 * @param typeName the local name of the respective type
+	 * @param binding the binding to use
+	 */
+	private JsonValueType(String typeName, Class<?> binding) {
+		this.typeName = typeName;
+		this.binding = binding;
+	}
+
+}

--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/SchemaBuilderContext.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/schema/SchemaBuilderContext.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023 wetransform GmbH
+ * 
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution. If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Contributors:
+ *     wetransform GmbH <http://www.wetransform.to>
+ */
+
+package eu.esdihumboldt.hale.io.json.internal.schema;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.locationtech.jts.geom.Geometry;
+
+import eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty;
+import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
+import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.Binding;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.GeometryType;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.HasValueFlag;
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.MappableFlag;
+import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition;
+
+/**
+ * Context for building a schema for Json data. Responsible for managing shared
+ * types, e.g. for primitive values.
+ * 
+ * @author Simon Templer
+ */
+public class SchemaBuilderContext {
+
+	private final String defaultNamespace;
+	private final TypeIndex sharedTypes;
+
+	private final Map<QName, TypeDefinition> commonTypes = new HashMap<>();
+
+	/**
+	 * 
+	 * @param defaultNamespace the namespace to use for common types
+	 * @param sharedTypes the shared types (e.g. from other loaded schemas) for
+	 *            type reuse
+	 */
+	public SchemaBuilderContext(String defaultNamespace, TypeIndex sharedTypes) {
+		super();
+		this.defaultNamespace = defaultNamespace;
+		this.sharedTypes = sharedTypes;
+	}
+
+	/**
+	 * Get a type representing a Json primitive type.
+	 * 
+	 * @param valueType the desired Json type
+	 * @return the type definition for the Json type
+	 */
+	public TypeDefinition getType(JsonValueType valueType) {
+		QName name = new QName(defaultNamespace, valueType.typeName);
+
+		TypeDefinition result = sharedTypes != null ? sharedTypes.getType(name) : null;
+
+		if (result == null) {
+			result = commonTypes.computeIfAbsent(name, n -> {
+				DefaultTypeDefinition type = new DefaultTypeDefinition(n);
+
+				type.setConstraint(MappableFlag.DISABLED);
+
+				type.setConstraint(HasValueFlag.ENABLED);
+				type.setConstraint(Binding.get(valueType.binding));
+
+				return type;
+			});
+		}
+
+		return result;
+	}
+
+	/**
+	 * Get a type representing a GeoJson geometry type.
+	 * 
+	 * @param geomType the desired geometry type
+	 * @return the type definition for the geometry type
+	 */
+	public TypeDefinition getGeometryType(Class<? extends Geometry> geomType) {
+		QName name = new QName(defaultNamespace, geomType.getSimpleName() + "GeometryType");
+
+		TypeDefinition result = sharedTypes != null ? sharedTypes.getType(name) : null;
+
+		if (result == null) {
+			result = commonTypes.computeIfAbsent(name, n -> {
+				DefaultTypeDefinition type = new DefaultTypeDefinition(n);
+
+				type.setConstraint(MappableFlag.DISABLED);
+
+				type.setConstraint(HasValueFlag.ENABLED);
+				type.setConstraint(GeometryType.get(geomType));
+				type.setConstraint(Binding.get(GeometryProperty.class));
+
+				return type;
+			});
+		}
+
+		return result;
+	}
+
+	/**
+	 * 
+	 * @return the common types that were created during schema building
+	 */
+	public Iterable<TypeDefinition> getCommonTypes() {
+		return commonTypes.values();
+	}
+
+}


### PR DESCRIPTION
First version that comes with some known restrictions:

- Parameters for the reader are not configurable in the UI, so e.g. the read mode can't be selected and only Json arrays and GeoJson FeatureCollections are supported in the UI at the moment.
- The schema reader only considers the first 50 objects encountered in the Json data. This is currently not configurable.
- Nested arrays (array of arrays) are not supported

ING-4046