### PR TITLE
Replace default map by OpenStreetMap

### DIFF
--- a/ext/styledmap/de.fhg.igd.mapviewer.server.tiles/src/de/fhg/igd/mapviewer/server/tiles/CustomTileMapServerFactory.java
+++ b/ext/styledmap/de.fhg.igd.mapviewer.server.tiles/src/de/fhg/igd/mapviewer/server/tiles/CustomTileMapServerFactory.java
@@ -181,13 +181,21 @@ public class CustomTileMapServerFactory implements MapServerFactoryCollection {
 		// check if any Map Server is configured?
 		if (CustomTileMapServer.getConfigurationNames().length > 0) {
 			for (String name : CustomTileMapServer.getConfigurationNames()) {
-				results.add(new CustomTileFactory(name));
+				if (name.equals("Stamen Terrain")) {
+					// Stamen Tiles were discontinued on 2023-10-31
+					CustomTileMapServer.removeConfiguration(name);
+				}
+				else {
+					results.add(new CustomTileFactory(name));
+				}
 			}
 		}
-		else {
+
+		if (results.isEmpty()) {
 			// no, then add default one.
 			results.add(addDefault());
 		}
+
 		return results;
 	}
 
@@ -208,11 +216,10 @@ public class CustomTileMapServerFactory implements MapServerFactoryCollection {
 	private MapServer addDefaultServer() {
 		CustomTileMapServer server = new CustomTileMapServer();
 
-		server.setName("Stamen Terrain");
-		server.setUrlPattern("http://tile.stamen.com/terrain/{z}/{x}/{y}.jpg");
-		server.setZoomLevel(16);
-		server.setAttributionText(
-				"Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.");
+		server.setName("OpenStreetMap");
+		server.setUrlPattern("https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+		server.setZoomLevel(20);
+		server.setAttributionText("Map tiles by OpenStreetMap, under CC BY-SA 2.0");
 
 		server.save();
 		return server;

--- a/ext/styledmap/org.jdesktop.swingx.mapviewer/META-INF/MANIFEST.MF
+++ b/ext/styledmap/org.jdesktop.swingx.mapviewer/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Require-Bundle: org.jdesktop.swingx;bundle-version="1.0.0"
 Import-Package: com.google.common.cache;version="27.0.0",
  com.google.common.collect;version="9.0.0",
  edu.umd.cs.findbugs.annotations,
+ eu.esdihumboldt.hale.common.core,
  eu.esdihumboldt.util.http,
  eu.esdihumboldt.util.http.client,
  org.apache.commons.logging;version="1.1.1",
@@ -33,6 +34,7 @@ Import-Package: com.google.common.cache;version="27.0.0",
  org.opengis.referencing.crs,
  org.opengis.referencing.cs,
  org.opengis.referencing.operation,
- org.opengis.util
+ org.opengis.util,
+ org.osgi.framework;version="1.9.0"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.jdesktop.swingx.mapviewer

--- a/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/AbstractTileCache.java
+++ b/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/AbstractTileCache.java
@@ -17,6 +17,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.jdesktop.swingx.mapviewer.DefaultTileFactory.TileRunner;
 
+import eu.esdihumboldt.hale.common.core.HalePlatform;
 import eu.esdihumboldt.util.http.ProxyUtil;
 import eu.esdihumboldt.util.http.client.ClientProxyUtil;
 import eu.esdihumboldt.util.http.client.ClientUtil;
@@ -94,6 +95,10 @@ public abstract class AbstractTileCache implements TileCache {
 		if (client == null) {
 			HttpClientBuilder builder = ClientUtil.threadSafeHttpClientBuilder(null);
 			builder = ClientProxyUtil.applyProxy(builder, proxy);
+			// Set user agent according to RFC 9110
+			// tile.openstreetmap.org will return HTTP 403 if no user agent is
+			// sent in the requests
+			builder.setUserAgent("hale-studio/" + HalePlatform.getCoreVersion().toString());
 
 			client = builder.build();
 

--- a/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/AbstractTileCache.java
+++ b/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/AbstractTileCache.java
@@ -60,7 +60,7 @@ public abstract class AbstractTileCache implements TileCache {
 	 */
 	@SuppressWarnings("javadoc")
 	protected InputStream openInputStream(URI uri) throws IllegalStateException, IOException {
-		if (!uri.getScheme().equals("http")) {
+		if (!uri.getScheme().startsWith("http")) {
 			// open non-http uris (e.g. filesystem, jar entry)
 			return uri.toURL().openStream();
 		}

--- a/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/DefaultTileFactory.java
+++ b/ext/styledmap/org.jdesktop.swingx.mapviewer/src/org/jdesktop/swingx/mapviewer/DefaultTileFactory.java
@@ -30,7 +30,7 @@ public class DefaultTileFactory implements TileFactory {
 
 	private static final Log log = LogFactory.getLog(DefaultTileFactory.class);
 
-	private int threadPoolSize = 4;
+	private int threadPoolSize = 2;
 	private ExecutorService service;
 
 	private final TileProvider provider;

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/BBOXPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/BBOXPage.java
@@ -141,11 +141,10 @@ public class BBOXPage extends ConfigurationWizardPage<WFSGetFeatureConfig> {
 	private void updateMap(WFSCapabilities caps) {
 		CustomTileMapServer tileServer = new CustomTileMapServer();
 
-		// use Stamen Terrain as default map here
-		tileServer.setUrlPattern("http://tile.stamen.com/terrain/{z}/{x}/{y}.jpg");
-		tileServer.setAttributionText(
-				"Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under CC BY SA.");
-		tileServer.setZoomLevel(16);
+		// use OpenStreetMap as default map here
+		tileServer.setUrlPattern("https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+		tileServer.setAttributionText("Map tiles by OpenStreetMap, under CC BY-SA 2.0");
+		tileServer.setZoomLevel(20);
 
 		MapServer server = tileServer;
 


### PR DESCRIPTION
Replaces the Stamen Terrain default map by OpenStreetMap.

To comply with the [usage policy of the OpenStreetMap tile server](https://operations.osmfoundation.org/policies/tiles/), the number of parallel connections is reduced to two and a HTTP User-Agent header is added to the requests.

The old default map configuration, if present, is automatically removed and the new default configuration is added.

ING-4081