### PR TITLE
hale: Enable exporting feature types with no data

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/InstanceTableIOConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/InstanceTableIOConstants.java
@@ -60,4 +60,9 @@ public class InstanceTableIOConstants {
 	 */
 	public static final String URL_STRING = "url";
 
+	/**
+	 * Parameter for exporting empty feature types to XLS Export
+	 */
+	public static final String EXPORT_IGNORE_EMPTY_FEATURETYPES = "ignoreEmptyFeaturetypes";
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/AbstractTableInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/AbstractTableInstanceWriter.java
@@ -147,6 +147,34 @@ public abstract class AbstractTableInstanceWriter extends AbstractInstanceWriter
 	} // close method
 
 	/**
+	 * Iterates over properties of the type definition and creates a map of the
+	 * given properties
+	 * 
+	 * @param definition given type to check
+	 * @param headerRow the current header row of the table
+	 * @return a map of properties with string of localpart of the QName of the
+	 *         property as key
+	 */
+	protected Map<String, Object> getPropertyMap(TypeDefinition definition,
+			List<String> headerRow) {
+		Iterable<QName> allProperties = DefinitionUtil.getAllProperties(definition).stream()
+				.map(def -> def.getName()).collect(Collectors.toList());
+		Map<String, Object> row = new HashMap<String, Object>();
+		for (QName qname : allProperties) {
+
+			String cellValue = "";
+			Object property = null;
+			if (shouldBeDisplayed(property)) {
+				cellValue = qname.getLocalPart();
+			}
+			addProperty(headerRow, row, property, cellValue);
+
+		}
+
+		return row;
+	}
+
+	/**
 	 * 
 	 * @param instance the actual instance
 	 * @param qNameOfTheInstance the qname of the instance

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/XLSInstanceIOTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/XLSInstanceIOTest.java
@@ -59,6 +59,8 @@ public class XLSInstanceIOTest extends TestCase {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(true));
+		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
+				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("ItemType"));
 
 		File tempDir = Files.createTempDir();

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/writer/XLSInstanceWriterTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/writer/XLSInstanceWriterTest.java
@@ -98,6 +98,8 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(true));
+		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
+				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("city"));
 
 		File tmpFile = tmpFolder.newFile("excelTestWriteSimpleSchema.xls");
@@ -148,6 +150,8 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
+		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
+				Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("person"));
 
 		File tmpFile = tmpFolder.newFile("excelTestWriteComplexSchema.xls");
@@ -197,6 +201,8 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
+		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
+				Value.of(true));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE, Value.of("person"));
 
 		File tmpFile = tmpFolder.newFile("excelNotNestedProperties.xls");
@@ -248,6 +254,8 @@ public class XLSInstanceWriterTest {
 				.getContentType("eu.esdihumboldt.hale.io.xls.xls");
 		writer.setParameter(InstanceTableIOConstants.SOLVE_NESTED_PROPERTIES, Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.USE_SCHEMA, Value.of(false));
+		writer.setParameter(InstanceTableIOConstants.EXPORT_IGNORE_EMPTY_FEATURETYPES,
+				Value.of(false));
 		writer.setParameter(InstanceTableIOConstants.EXPORT_TYPE,
 				Value.of("{http://www.example.org/t2/}PersonType,{http://www.example.org/t2/}T2"));
 

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/plugin.xml
@@ -173,8 +173,8 @@
             </parameterBinding>
          </providerParameter>
          <providerParameter
-               description="Ignore feature types without data to be added to the exported Excel"
-               label="Ignore feature types without data"
+               description="Exclude feature types without data to be added to the exported Excel"
+               label="Exclude feature types without data"
                name="ignoreEmptyFeaturetypes"
                optional="true">
             <parameterBinding


### PR DESCRIPTION
Users can select feature types without data for both: 

> Custom export configuration for hale-connect using Excel as output type 
> Export of transformed data as Excel from hale-studio

For the feature types without data there is the indication in the label that _[no data]_  is present. Has been reintroduced the button "**Exclude feature types without data**"

ING-4107