### PR TITLE
fix: Fix TopoJSON encoding issue

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.topojson.test/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.topojson.test/META-INF/MANIFEST.MF
@@ -17,6 +17,8 @@ Require-Bundle: eu.esdihumboldt.hale.io.topojson;bundle-version="4.2.0",
  eu.esdihumboldt.hale.common.schema.groovy;bundle-version="4.2.0",
  eu.esdihumboldt.hale.common.instance.groovy;bundle-version="4.2.0",
  org.opengis;bundle-version="21.0.0",
- org.eclipse.core.runtime;bundle-version="3.17.100"
+ org.eclipse.core.runtime;bundle-version="3.17.100",
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.13.4",
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="2.13.4"
 Import-Package: de.fhg.igd.slf4jplus,
  org.slf4j;version="1.7.2"

--- a/io/plugins/eu.esdihumboldt.hale.io.topojson.test/src/eu/esdihumboldt/hale/io/topojson/test/TopoJsonInstanceWriterTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.topojson.test/src/eu/esdihumboldt/hale/io/topojson/test/TopoJsonInstanceWriterTest.groovy
@@ -16,10 +16,14 @@
 package eu.esdihumboldt.hale.io.topojson.test
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.function.Consumer
 
 import org.junit.Test
@@ -56,6 +60,8 @@ class TopoJsonInstanceWriterTest {
 		SimpleType {
 			id(String)
 			name(String)
+			label(String)
+			date(LocalDate)
 			geometry(GeometryProperty)
 		}
 	}
@@ -103,16 +109,33 @@ class TopoJsonInstanceWriterTest {
 
 	@Test
 	public void testWriteTopoJson() {
+		def aDate = LocalDate.of(2017, 10, 3)
+		def aTimestamp = Instant.parse('2023-04-02T00:00:00Z')
+		// Create a DateTimeFormatter with the desired pattern
+		def formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
 		InstanceCollection instances = new InstanceBuilder(types: schema).createCollection {
 			SimpleType {
 				id '1'
 				name 'Area 1'
+				label 'Label 1'
+				date(aDate)
 				geometry(createGeometry('POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10))', 4326))
 			}
 
 			SimpleType {
 				id '2'
-				name 'Area 2'
+				name '\u0000\u0000\u0000'
+				label null
+				date null
+				geometry(createGeometry('POLYGON ((20 10, 40 10, 40 20, 20 20, 20 10))', 4326))
+			}
+
+			SimpleType {
+				id '3'
+				name 'Area 3\u0000\u0000\u0000'
+				label '\u0000\u0000\u0000'
+				date null
 				geometry(createGeometry('POLYGON ((20 10, 40 10, 40 20, 20 20, 20 10))', 4326))
 			}
 		}
@@ -127,25 +150,31 @@ class TopoJsonInstanceWriterTest {
 			assertEquals(1, json.objects.size())
 			assertEquals(4, json.arcs.size())
 
-			assertEquals(2, json.objects.Topology.geometries.size())
+			assertEquals(3, json.objects.Topology.geometries.size())
 
 			assertEquals(0, json.objects.Topology.geometries[0].id)
 			assertEquals('Polygon', json.objects.Topology.geometries[0].type)
 			assertEquals('Area 1', json.objects.Topology.geometries[0].'properties'.name)
 			assertEquals('1', json.objects.Topology.geometries[0].'properties'.id)
+			assertEquals('Label 1', json.objects.Topology.geometries[0].'properties'.label)
+			assertEquals(aDate.toString(), json.objects.Topology.geometries[0].'properties'.date)
 			assertEquals(1, json.objects.Topology.geometries[0].arcs.size())
 			assertEquals(2, json.objects.Topology.geometries[0].arcs[0].size())
 			assertEquals([0, 1], json.objects.Topology.geometries[0].arcs[0])
 
 			assertEquals(1, json.objects.Topology.geometries[1].id)
 			assertEquals('Polygon', json.objects.Topology.geometries[1].type)
-			assertEquals('Area 2', json.objects.Topology.geometries[1].'properties'.name)
+			assertNull(json.objects.Topology.geometries[1].'properties'.name)
 			assertEquals('2', json.objects.Topology.geometries[1].'properties'.id)
+			assertNull(json.objects.Topology.geometries[1].'properties'.label)
+			assertNull(json.objects.Topology.geometries[1].'properties'.date)
 			assertEquals(1, json.objects.Topology.geometries[1].arcs.size())
 			assertEquals(3, json.objects.Topology.geometries[1].arcs[0].size())
 			assertEquals([-1, 2, 3], json.objects.Topology.geometries[1].arcs[0])
+
+			assertEquals('Area 3', json.objects.Topology.geometries[2].'properties'.name)
+			assertNull(json.objects.Topology.geometries[2].'properties'.label)
+			assertNull(json.objects.Topology.geometries[2].'properties'.date)
 		}
-
 	}
-
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.topojson/META-INF/MANIFEST.MF
+++ b/io/plugins/eu.esdihumboldt.hale.io.topojson/META-INF/MANIFEST.MF
@@ -14,5 +14,10 @@ Require-Bundle: eu.esdihumboldt.hale.io.shp;bundle-version="4.2.0",
  org.eclipse.core.runtime;bundle-version="3.17.100",
  org.opengis;bundle-version="21.0.0",
  eu.esdihumboldt.util;bundle-version="4.2.0",
- eu.esdihumboldt.hale.io.json;bundle-version="4.2.0"
+ eu.esdihumboldt.hale.io.json;bundle-version="4.2.0",
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.13.4",
+ com.fasterxml.jackson.core.jackson-databind;bundle-version="2.13.4"
 Export-Package: eu.esdihumboldt.hale.io.topojson
+Import-Package: de.fhg.igd.slf4jplus,
+ com.fasterxml.jackson.databind;version="2.13.4",
+ org.slf4j;version="1.5.11"


### PR DESCRIPTION
Use Jackson's ObjectMapper to parse the JSON string into a JsonNode, then recursively traverses the JsonNode to replace "null" values with null. Finally, it converts the modified JsonNode back to a JSON string.

ING-3979