### PR TITLE
fix: Update decimal places to 20 for Geotools

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/InstanceToJson.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.json/src/eu/esdihumboldt/hale/io/json/internal/InstanceToJson.java
@@ -86,7 +86,7 @@ public class InstanceToJson implements InstanceJsonConstants {
 	 */
 	public InstanceToJson(boolean geoJson) {
 
-		this(geoJson, new IgnoreNamespaces() /* new JsonNamespaces() */, 7);
+		this(geoJson, new IgnoreNamespaces() /* new JsonNamespaces() */, 20);
 	}
 
 	/**


### PR DESCRIPTION
For hale studio it does not make sense to limit
decimal places so that the original data remains
intact. However, we need to provide some value
to Geotools and it does not make sense to configure max integer. 
Therefore, providing higher value of 20 to Geotools even if it 
represents some kind of ridiculous  "accuracy" for WGS 84.