### PR TITLE
fix/feat:  add GUI parameter to select date formatter for the Excel/CSV

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.csv.test/src/data/test3.csv
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv.test/src/data/test3.csv
@@ -1,0 +1,3 @@
+Name	Xcoord	Ycoord	date
+test	12	16	1.02.2023
+test3	45	2	22.03.2023

--- a/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/TypeSelectionPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv.ui/src/eu/esdihumboldt/hale/io/csv/ui/TypeSelectionPage.java
@@ -44,7 +44,6 @@ import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 import eu.esdihumboldt.hale.io.csv.reader.CommonSchemaConstants;
 import eu.esdihumboldt.hale.io.csv.reader.internal.CSVConfiguration;
-import eu.esdihumboldt.hale.io.xls.reader.ReaderSettings;
 import eu.esdihumboldt.hale.ui.common.definition.selector.TypeDefinitionSelector;
 import eu.esdihumboldt.hale.ui.io.instance.InstanceReaderConfigurationPage;
 import eu.esdihumboldt.hale.ui.service.schema.SchemaService;
@@ -59,7 +58,11 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 	/**
 	 * Parameter for the the custom date label
 	 */
-	private static final String CUSTOM_FORMAT_LABEL = "Custom format";
+	public static final String CUSTOM_FORMAT_LABEL = "Custom format";
+	/**
+	 * Parameter for combo box for an empty selection
+	 */
+	public static final String EMPTY_SELECTION = "";
 
 	private TypeDefinitionSelector sel;
 	private Spinner skipNlinesSpinner;
@@ -67,7 +70,10 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 	private Label skipNlinesLabels;
 	private ComboViewer dateFormatterCombo;
 	private Text customFormat;
-	private Label labelCustomFormat;
+	public Label labelCustomFormat;
+	private Label howToRepresentCustomFormatLabel;
+	private Label howToUseCustomFormatLabel;
+	protected Label dateFormatterLabel;
 
 	/**
 	 * default constructor
@@ -140,8 +146,9 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 		skipNlinesSpinner.setPageIncrement(10);
 
 //		create date formatter combo
-		Label dateFormatterLabel = new Label(page, SWT.NONE);
-		dateFormatterLabel.setText("Format for imported date values");
+		dateFormatterLabel = new Label(page, SWT.NONE);
+		dateFormatterLabel.setText("Reformatting of dates\r\n"
+				+ "(date values are tried to be detected automatically)");
 		dateFormatterCombo = new ComboViewer(page, SWT.READ_ONLY);
 		dateFormatterCombo.setContentProvider(ArrayContentProvider.getInstance());
 		List<String> list = createDatePatternsList();
@@ -153,26 +160,25 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 				IStructuredSelection selection = (IStructuredSelection) event.getSelection();
 				if (selection.size() > 0 && labelCustomFormat != null && customFormat != null) {
 					String currentSelection = (String) selection.getFirstElement();
+					boolean isVisible = false;
 					if (currentSelection.equals(CUSTOM_FORMAT_LABEL)) {
 						// show the custom formatting label/text widget
-						labelCustomFormat.setVisible(true);
-						customFormat.setVisible(true);
+						isVisible = true;
 					}
-					else {
-						// hide the custom formatting label/text widget
-						labelCustomFormat.setVisible(false);
-						customFormat.setVisible(false);
-					}
+					labelCustomFormat.setVisible(isVisible);
+					customFormat.setVisible(isVisible);
+					howToRepresentCustomFormatLabel.setVisible(isVisible);
+					howToUseCustomFormatLabel.setVisible(isVisible);
 				}
 			}
 		});
-		dateFormatterCombo.setSelection(new StructuredSelection(list.get(0)));
+		dateFormatterCombo.setSelection(new StructuredSelection(createDatePatternsList().get(0)));
 
 		// add label and text area for a custom formatting
 		labelCustomFormat = new Label(page, SWT.NONE);
-		labelCustomFormat.setText("Custom date format:");
+		labelCustomFormat.setText("");
 		labelCustomFormat
-				.setLayoutData(GridDataFactory.swtDefaults().align(SWT.END, SWT.CENTER).create());
+				.setLayoutData(GridDataFactory.swtDefaults().align(SWT.LEFT, SWT.CENTER).create());
 
 		customFormat = new Text(page, SWT.BORDER | SWT.SINGLE);
 		customFormat.setLayoutData(GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER)
@@ -181,13 +187,30 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 		labelCustomFormat.setVisible(false);
 		customFormat.setVisible(false);
 
+		howToRepresentCustomFormatLabel = new Label(page, SWT.NONE);
+		howToRepresentCustomFormatLabel.setText("How to represent");
+		howToRepresentCustomFormatLabel
+				.setLayoutData(GridDataFactory.swtDefaults().align(SWT.LEFT, SWT.CENTER).create());
+
+		howToUseCustomFormatLabel = new Label(page, SWT.NONE);
+		howToUseCustomFormatLabel.setText("dd: Day of the month\r\n" + "MM: Numerical month\r\n"
+				+ "yyyy: Year in four digits\r\n" + "hh: Hour in 24-hour format\r\n"
+				+ "mm: Minutes\r\n" + "ss: Seconds.");
+		howToUseCustomFormatLabel
+				.setLayoutData(GridDataFactory.swtDefaults().align(SWT.LEFT, SWT.CENTER).create());
+		howToRepresentCustomFormatLabel.setVisible(false);
+		howToUseCustomFormatLabel.setVisible(false);
+
 		page.pack();
 
 		setPageComplete(false);
 	}
 
-	private List<String> createDatePatternsList() {
-		return Arrays.asList(
+	/**
+	 * @return list of formatting for date drop down
+	 */
+	protected List<String> createDatePatternsList() {
+		return Arrays.asList(EMPTY_SELECTION,
 				// Standard date formats
 				"yyyy-MM-dd", "yy-MM-dd", "dd-MM-yyyy", "MM-dd-yyyy", "yyyy/MM/dd", "dd/MM/yyyy",
 				"dd/MMM/yyyy", "MM/dd/yyyy", "yyyy.MM.dd", "dd.MM.yyyy", "MM.dd.yyyy", "yyyyMMdd",
@@ -202,12 +225,27 @@ public class TypeSelectionPage extends InstanceReaderConfigurationPage implement
 				Value.of(skipNlinesSpinner.getSelection()));
 
 		if (customFormat.isVisible()) {
-			provider.setParameter(ReaderSettings.PARAMETER_DATE_FORMAT,
+
+			if (customFormat.getText().isBlank()) {
+				return false;
+			}
+
+			provider.setParameter(CSVConstants.PARAMETER_DATE_FORMAT,
 					Value.of(customFormat.getText()));
 		}
 		else {
-			provider.setParameter(ReaderSettings.PARAMETER_DATE_FORMAT,
-					Value.of(dateFormatterCombo.getSelection()));
+			// Get the selection from the combo viewer
+			String selectedValue = (String) ((IStructuredSelection) dateFormatterCombo
+					.getSelection()).getFirstElement();
+
+			if (selectedValue.equals("")) {
+				// The empty string is selected
+				provider.setParameter(CSVConstants.PARAMETER_DATE_FORMAT, null);
+			}
+			else {
+				provider.setParameter(CSVConstants.PARAMETER_DATE_FORMAT,
+						Value.of(dateFormatterCombo.getSelection()));
+			}
 		}
 
 		if (sel.getSelectedObject() != null) {

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/plugin.xml
@@ -69,6 +69,19 @@
             </valueDescriptor>
          </providerParameter>
          <providerParameter
+               description="Specify the format for importing String values that represent a Date"
+               label="Date Time Formatter"
+               name="dateTimeFormatterDefault"
+               optional="true">
+            <parameterBinding
+                  class="java.lang.String">
+            </parameterBinding>
+            <valueDescriptor
+                  default="dd.mm.yyyy"
+                  defaultDescription="Default to dd.mm.yyyy">
+            </valueDescriptor>
+         </providerParameter>
+         <providerParameter
                label="Type name"
                name="typename"
                optional="false"

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/CSVConstants.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/CSVConstants.java
@@ -64,4 +64,10 @@ public interface CSVConstants {
 	 */
 	public static final char DEFAULT_DECIMAL = '.';
 
+	/**
+	 * Parameter for the reader specifying how values imported from Date cells
+	 * should be formatted.
+	 */
+	public static final String PARAMETER_DATE_FORMAT = "dateTimeFormatterDefault";
+
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/internal/CSVInstanceCollection.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/internal/CSVInstanceCollection.java
@@ -16,8 +16,16 @@
 package eu.esdihumboldt.hale.io.csv.reader.internal;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.MessageFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -174,10 +182,65 @@ public class CSVInstanceCollection implements InstanceCollection, InstanceCollec
 			return instance;
 		}
 
+		/**
+		 * @param dateString String date
+		 * @param dateTime date time parameter
+		 * @return Date
+		 */
+		public String parseDate(String dateString, String dateTime) {
+			DateFormat[] dateFormats = { DateFormat.getDateInstance(),
+					DateFormat.getDateTimeInstance(), new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"),
+					new SimpleDateFormat("MM/dd/yy HH:mm:ss"),
+					new SimpleDateFormat("MM/dd/yyyy HH:mm:ss"),
+					new SimpleDateFormat("MM-dd-yyyy HH:mm:ss"),
+					new SimpleDateFormat("MM-dd-yy HH:mm:ss"), new SimpleDateFormat("yyyy-MM-dd"),
+					new SimpleDateFormat("dd/MM/yyyy"), new SimpleDateFormat("dd/MMM/yyyy"),
+					new SimpleDateFormat("MM/dd/yy"), new SimpleDateFormat("MM/dd/yyyy"),
+					new SimpleDateFormat("yyyy/MM/dd"), new SimpleDateFormat("MM-dd-yyyy"),
+					new SimpleDateFormat("MM-dd-yy"), new SimpleDateFormat("yy-MM-dd"),
+					new SimpleDateFormat("dd-MM-yyyy"), new SimpleDateFormat("yyyy.MM.dd"),
+					new SimpleDateFormat("dd.MM.yyyy"), new SimpleDateFormat("MM.dd.yyyy"),
+					new SimpleDateFormat("yyyyMMdd"), new SimpleDateFormat("MMMM d, yyyy"),
+					new SimpleDateFormat("yy-MM"), new SimpleDateFormat("yyyy-MM"),
+					new SimpleDateFormat("MM-yy"), new SimpleDateFormat("MM-yyyy"),
+					// Add more date formats as needed
+			};
+
+			for (DateFormat dateFormat : dateFormats) {
+				try {
+					dateFormat.setLenient(false); // Disable lenient parsing
+					Date dateCellValue = dateFormat.parse(dateString);
+
+					// Convert java.util.Date to java.time.LocalDateTime
+					LocalDateTime localDateTime = dateCellValue.toInstant()
+							.atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+					DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTime);
+
+					// Define a DateTimeFormatter with a specific pattern
+					if (dateTimeFormatter == null) {
+						dateTimeFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT);
+					}
+
+					// If parsing succeeds, break out of the loop
+					// Format LocalDateTime using DateTimeFormatter
+					return localDateTime.format(dateTimeFormatter);
+				} catch (ParseException e) {
+					// Parsing failed with this format, try the next one
+				}
+			}
+			return null;
+		}
+
 		private Object convertValue(String part, PropertyDefinition property) {
 			if (part == null || part.isEmpty()) {
 				// FIXME make this configurable?
 				return null;
+			}
+
+			String dateTime = reader.getParameter(CSVUtil.PARAMETER_DATE_FORMAT).as(String.class);
+			if (dateTime != null && !part.isEmpty()) {
+				part = parseDate(part, dateTime);
 			}
 
 			Binding binding = property.getPropertyType().getConstraint(Binding.class);

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/internal/CSVInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/reader/internal/CSVInstanceReader.java
@@ -28,6 +28,7 @@ import eu.esdihumboldt.hale.common.instance.io.InstanceReader;
 import eu.esdihumboldt.hale.common.instance.io.impl.AbstractInstanceReader;
 import eu.esdihumboldt.hale.common.instance.model.InstanceCollection;
 import eu.esdihumboldt.hale.io.csv.CSVFileIO;
+import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 
 /**
  * Reads instances from a CSVfile
@@ -37,6 +38,15 @@ import eu.esdihumboldt.hale.io.csv.CSVFileIO;
 public class CSVInstanceReader extends AbstractInstanceReader {
 
 	private InstanceCollection instances;
+
+	/**
+	 * Default constructor.
+	 */
+	public CSVInstanceReader() {
+		super();
+
+		addSupportedParameter(CSVConstants.PARAMETER_DATE_FORMAT);
+	}
 
 	/**
 	 * @see IOProvider#isCancelable()

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/reader/XLSReaderTest.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.test/src/eu/esdihumboldt/hale/io/xls/test/reader/XLSReaderTest.java
@@ -48,6 +48,7 @@ import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.Binding;
 import eu.esdihumboldt.hale.common.test.TestUtil;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
+import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 import eu.esdihumboldt.hale.io.csv.reader.CommonSchemaConstants;
 import eu.esdihumboldt.hale.io.csv.reader.internal.AbstractTableSchemaReader;
 import eu.esdihumboldt.hale.io.xls.reader.ReaderSettings;
@@ -674,7 +675,7 @@ public class XLSReaderTest {
 		schemaReader.setParameter(CommonSchemaConstants.PARAM_TYPENAME, Value.of(typeName));
 		schemaReader.setParameter(AbstractTableSchemaReader.PARAM_PROPERTYTYPE,
 				Value.of(paramPropertyType));
-		schemaReader.setParameter(ReaderSettings.PARAMETER_DATE_FORMAT, Value.of(dateFormatter));
+		schemaReader.setParameter(CSVConstants.PARAMETER_DATE_FORMAT, Value.of(dateFormatter));
 
 		IOReport report = schemaReader.execute(null);
 		assertTrue("Schema import was not successfull.", report.isSuccess());

--- a/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceImportConfigurationPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls.ui/src/eu/esdihumboldt/hale/io/xls/ui/XLSInstanceImportConfigurationPage.java
@@ -16,6 +16,8 @@
 package eu.esdihumboldt.hale.io.xls.ui;
 
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.poi.ss.usermodel.Workbook;
 import org.eclipse.jface.layout.GridDataFactory;
@@ -30,11 +32,9 @@ import de.fhg.igd.slf4jplus.ALoggerFactory;
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.instance.io.InstanceReader;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
+import eu.esdihumboldt.hale.io.csv.ui.TypeSelectionPage;
 import eu.esdihumboldt.hale.io.xls.AbstractAnalyseTable;
 import eu.esdihumboldt.hale.io.xls.reader.ReaderSettings;
-import eu.esdihumboldt.hale.ui.io.config.AbstractConfigurationPage;
-import eu.esdihumboldt.hale.ui.io.instance.InstanceImportWizard;
-import eu.esdihumboldt.hale.io.csv.ui.TypeSelectionPage;
 
 /**
  * Configuration page for the instance export provider of Excel files
@@ -75,12 +75,21 @@ public class XLSInstanceImportConfigurationPage extends TypeSelectionPage {
 		super.createContent(page);
 	}
 
+	@Override
+	protected List<String> createDatePatternsList() {
+		return Arrays.asList(
+				// Standard date formats
+				"yyyy-MM-dd", "yy-MM-dd", "dd-MM-yyyy", "MM-dd-yyyy", "yyyy/MM/dd", "dd/MM/yyyy",
+				"dd/MMM/yyyy", "MM/dd/yyyy", "yyyy.MM.dd", "dd.MM.yyyy", "MM.dd.yyyy", "yyyyMMdd",
+				// Custom date format
+				"MMMM d, yyyy", TypeSelectionPage.CUSTOM_FORMAT_LABEL);
+	}
+
 	/**
 	 * @see eu.esdihumboldt.hale.ui.HaleWizardPage#onShowPage(boolean)
 	 */
 	@Override
 	protected void onShowPage(boolean firstShow) {
-
 		if (!firstShow) {
 			setErrorMessage(null);
 		}
@@ -102,7 +111,11 @@ public class XLSInstanceImportConfigurationPage extends TypeSelectionPage {
 			return;
 		}
 		super.onShowPage(firstShow);
+
+		dateFormatterLabel
+				.setText("Format for imported date values\r\n(values are represented as strings)");
 		sheetSelection.select(0);
+
 		setPageComplete(false);
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/AbstractAnalyseTable.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/AbstractAnalyseTable.java
@@ -119,7 +119,7 @@ public abstract class AbstractAnalyseTable {
 	 * Analyzes the table header.
 	 * 
 	 * @param sheet the table sheet
-	 * @param dateTimeFormatter
+	 * @param dateTimeFormatter date formatter
 	 */
 	protected void analyseHeader(Sheet sheet, DateTimeFormatter dateTimeFormatter) {
 		Row header = sheet.getRow(0);
@@ -151,8 +151,8 @@ public abstract class AbstractAnalyseTable {
 	 * the skip line
 	 * 
 	 * @param sheet the table sheet
-	 * @param skipNlines
-	 * @param dateTimeFormatter
+	 * @param skipNlines skip N lines
+	 * @param dateTimeFormatter date formatter
 	 */
 	private void analyseContent(Sheet sheet, int skipNlines, DateTimeFormatter dateTimeFormatter) {
 		for (int i = skipNlines; i <= sheet.getLastRowNum(); i++) {
@@ -168,7 +168,7 @@ public abstract class AbstractAnalyseTable {
 	 *            separately)
 	 * @param row the table row
 	 * @param sheet the sheet
-	 * @param dateTimeFormatter
+	 * @param dateTimeFormatter date formatter
 	 */
 	protected abstract void analyseRow(int num, Row row, Sheet sheet,
 			DateTimeFormatter dateTimeFormatter);

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/ReaderSettings.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/ReaderSettings.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.content.IContentType;
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.core.io.ValueList;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
+import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 import eu.esdihumboldt.hale.io.csv.reader.CommonSchemaConstants;
 import eu.esdihumboldt.hale.io.xls.AbstractAnalyseTable;
 
@@ -52,12 +53,6 @@ public class ReaderSettings {
 	 * Parameter with detailed settings per sheet.
 	 */
 	public static final String PARAMETER_SHEET_SETTINGS = "sheetSettings";
-
-	/**
-	 * Parameter for the reader specifying how values imported from Date cells
-	 * should be formatted.
-	 */
-	public static final String PARAMETER_DATE_FORMAT = "dateTimeFormatterDefault";
 
 	/**
 	 * Collect information and settings on a single sheet.
@@ -201,7 +196,8 @@ public class ReaderSettings {
 		}
 
 		// read dateFormat
-		String dateFormatString = reader.getParameter(PARAMETER_DATE_FORMAT).as(String.class);
+		String dateFormatString = reader.getParameter(CSVConstants.PARAMETER_DATE_FORMAT)
+				.as(String.class);
 
 		// apply to all sheets as default
 		for (SheetInfo sheet : sheets) {

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/XLSInstanceReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/XLSInstanceReader.java
@@ -42,6 +42,7 @@ import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition;
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition;
 import eu.esdihumboldt.hale.common.schema.model.TypeIndex;
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.Binding;
+import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 import eu.esdihumboldt.hale.io.csv.reader.internal.CSVInstanceReader;
 import eu.esdihumboldt.hale.io.xls.AnalyseXLSSchemaTable;
 import eu.esdihumboldt.hale.io.xls.reader.ReaderSettings.SheetInfo;
@@ -62,7 +63,7 @@ public class XLSInstanceReader extends AbstractInstanceReader {
 	public XLSInstanceReader() {
 		super();
 
-		addSupportedParameter(ReaderSettings.PARAMETER_DATE_FORMAT);
+		addSupportedParameter(CSVConstants.PARAMETER_DATE_FORMAT);
 	}
 
 	/**

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/XLSSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/reader/XLSSchemaReader.java
@@ -39,6 +39,7 @@ import eu.esdihumboldt.hale.common.schema.model.impl.DefaultTypeDefinition;
 import eu.esdihumboldt.hale.io.csv.InstanceTableIOConstants;
 import eu.esdihumboldt.hale.io.csv.PropertyType;
 import eu.esdihumboldt.hale.io.csv.PropertyTypeExtension;
+import eu.esdihumboldt.hale.io.csv.reader.CSVConstants;
 import eu.esdihumboldt.hale.io.csv.reader.CommonSchemaConstants;
 import eu.esdihumboldt.hale.io.csv.reader.internal.AbstractTableSchemaReader;
 import eu.esdihumboldt.hale.io.csv.reader.internal.CSVConfiguration;
@@ -72,7 +73,7 @@ public class XLSSchemaReader extends AbstractTableSchemaReader {
 			throws IOProviderConfigurationException, IOException {
 
 		sheetNum = getParameter(InstanceTableIOConstants.SHEET_INDEX).as(int.class, 0);
-		String dateTime = getParameter(ReaderSettings.PARAMETER_DATE_FORMAT).as(String.class);
+		String dateTime = getParameter(CSVConstants.PARAMETER_DATE_FORMAT).as(String.class);
 
 		progress.begin("Load XLS/XLSX schema", ProgressIndicator.UNKNOWN);
 


### PR DESCRIPTION
The issue has been extended to CSV as well, as the code is/might be common in some points. 

Add a combo box with different patterns for the date formatter + a custom text. This pattern is then used when importing cells/rows of type Date.

ING-4165