### PR TITLE
fix: fix check if an object is identifiable

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/Identifiable.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance/src/eu/esdihumboldt/hale/common/instance/model/Identifiable.java
@@ -43,7 +43,7 @@ public interface Identifiable {
 	 *         actually has an ID
 	 */
 	static boolean is(Object o) {
-		return (o instanceof Identifiable && !((Identifiable) o).hasId());
+		return (o instanceof Identifiable && ((Identifiable) o).hasId());
 	}
 
 	/**


### PR DESCRIPTION
Due to the wrong check, the index based Merge and Join handlers were not used at all. Also, no instances were added to the index service.