### PR TITLE
build: use separate update site for offline resource bundles

### DIFF
--- a/platform/hale-platform.target
+++ b/platform/hale-platform.target
@@ -48,8 +48,12 @@
 		<unit id="de.fhg.igd.equinox.test.feature.feature.group" version="1.2.0.202203220819"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-		<repository location="https://gitlab.wetransform.to/hale/hale-build-support/raw/6e39a720fdf24268e09fa6b3d74b4fdb8bff6ac8/updatesites/platform"/>
-		<unit id="eu.esdihumboldt.hale.platform.feature.group" version="5.0.0.i20240116"/>
+		<repository location="http://build-artifacts.wetransform.to/p2/offline-resources/current"/>
+		<unit id="to.wetransform.offlineresources.feature.feature.group" version="2024.2.21.bnd-Q1xqaw"/>
+	</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+		<repository location="https://gitlab.wetransform.to/hale/hale-build-support/raw/0342a0f0c4f57a1ec4109f1fbe6e6fecd7dc722b/updatesites/platform"/>
+		<unit id="eu.esdihumboldt.hale.platform.feature.group" version="5.0.0.i20240220"/>
 	</location>
 </locations>
 </target>

--- a/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
+++ b/ui/plugins/eu.esdihumboldt.hale.ui.application/HALE.product
@@ -96,7 +96,6 @@ https://www.wetransform.to/services/support/
       <feature id="eu.esdihumboldt.hale.io.feature.core"/>
       <feature id="eu.esdihumboldt.hale.io.feature.html"/>
       <feature id="eu.esdihumboldt.hale.ui.feature.dropins"/>
-      <feature id="eu.esdihumboldt.hale.platform.resources"/>
       <feature id="eu.esdihumboldt.hale.ui.feature.updates"/>
       <feature id="eu.esdihumboldt.hale.io.feature.msaccess"/>
       <feature id="eu.esdihumboldt.hale.io.feature.mssql"/>

--- a/util/features/eu.esdihumboldt.util.feature.resource/feature.xml
+++ b/util/features/eu.esdihumboldt.util.feature.resource/feature.xml
@@ -8,10 +8,6 @@
       Licenses of the individual features and plug-ins apply.
    </license>
 
-   <includes
-         id="eu.esdihumboldt.hale.platform.resources"
-         version="0.0.0"/>
-
    <plugin
          id="eu.esdihumboldt.util.resource"
          download-size="0"
@@ -34,6 +30,62 @@
 
    <plugin
          id="eu.esdihumboldt.util.resource.schemas.end"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.codelists.inspire"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.codelists.inspire.accept-xml"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.featureconcepts.inspire"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.schemas.inspire"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.schemas.opengis.net"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.schemas.portele.de"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.schemas.repository.gdi-de.org"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="eu.esdihumboldt.util.resource.w3.org"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Replace the offline resource bundles created as part of hale-platform by bundles created using the offline-resource repository. The related build and bundles in hale-platform become obsolete.