### PR TITLE
fix:  functions not working for elements with value and attribute

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/transformation/function/PropertyValue.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/transformation/function/PropertyValue.java
@@ -35,10 +35,12 @@ public interface PropertyValue {
 	public abstract Object getValue();
 
 	/**
-	 * Get the property value converted to the given type.
+	 * 
+	 * Get the property value converted to the given type or if the property
+	 * value is an instance, the instance value converted to the given type
 	 * 
 	 * @param type the type the value should be converted to
-	 * @return the converted property value
+	 * @return the converted property value or the converted instance value
 	 * @throws ConversionException if the conversion service is not available or
 	 *             the conversion fails or is not supported
 	 */

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/transformation/function/impl/PropertyValueImpl.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/transformation/function/impl/PropertyValueImpl.java
@@ -23,6 +23,7 @@ import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition;
 import eu.esdihumboldt.hale.common.align.transformation.function.PropertyValue;
 import eu.esdihumboldt.hale.common.convert.ConversionServiceNotAvailableException;
 import eu.esdihumboldt.hale.common.core.HalePlatform;
+import eu.esdihumboldt.hale.common.instance.model.Instance;
 
 /**
  * Default {@link PropertyValue} implementation.
@@ -67,6 +68,10 @@ public class PropertyValueImpl implements PropertyValue {
 
 		if (type.isAssignableFrom(value.getClass())) {
 			return (T) value;
+		}
+
+		if (value instanceof Instance) {
+			return (T) ((Instance) value).getValue();
 		}
 
 		ConversionService cs = HalePlatform.getService(ConversionService.class);

--- a/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/internal/OSerializationHelper.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/internal/OSerializationHelper.java
@@ -33,16 +33,16 @@ import java.util.Set;
 
 import javax.xml.namespace.QName;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBWriter;
 import org.springframework.core.convert.ConversionService;
 
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.ORecordAbstract;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.ORecordBytes;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKBWriter;
 
 import de.fhg.igd.osgi.util.OsgiUtils;
 import eu.esdihumboldt.hale.common.core.HalePlatform;

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/internal/ConceptualSchemaTransformerTest.java
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/internal/ConceptualSchemaTransformerTest.java
@@ -350,6 +350,17 @@ public class ConceptualSchemaTransformerTest extends DefaultTransformationTest {
 	 * @throws Exception if an error occurs executing the test
 	 */
 	@Test
+	public void testFormattingStringInstance() throws Exception {
+		testTransform(TransformationExamples
+				.getExample(TransformationExamples.FORMATTING_STRING_INSTANCE));
+	}
+
+	/**
+	 * Test a Join that has the innerJoin flag enabled.
+	 * 
+	 * @throws Exception if an error occurs executing the test
+	 */
+	@Test
 	public void testInnerJoin() throws Exception {
 		testTransform(TransformationExamples.getExample(TransformationExamples.INNER_JOIN));
 	}

--- a/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/test/TransformationExamples.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/src/eu/esdihumboldt/cst/test/TransformationExamples.groovy
@@ -112,6 +112,7 @@ abstract class TransformationExamples {
 
 	public static final String XSL_XPATH_1 = 'xpath1'
 
+	public static final String FORMATTING_STRING_INSTANCE = 'formatting_string_instance'
 	public static final String INNER_JOIN = 'inner_join'
 	public static final String INNER_JOIN_FIRST_LEVEL = 'inner_join_first_level'
 	public static final String INNER_JOIN_CONDITIONS = 'inner_join_conditions'
@@ -233,6 +234,7 @@ abstract class TransformationExamples {
 		(XSL_XPATH_1): defaultExample(XSL_XPATH_1),
 
 		// builder based examples
+		(FORMATTING_STRING_INSTANCE): builderExample(FORMATTING_STRING_INSTANCE),
 		(INNER_JOIN): builderExample(INNER_JOIN),
 		(INNER_JOIN_FIRST_LEVEL): builderExample(INNER_JOIN_FIRST_LEVEL),
 		(INNER_JOIN_CONDITIONS): builderExample(INNER_JOIN_CONDITIONS),

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hale-project version="5.2.0.qualifier">
+    <name>mapping</name>
+    <author>EmanuelaEpure</author>
+    <created>2024-02-29T15:13:01.528+01:00</created>
+    <modified>2024-02-29T15:18:03.421+01:00</modified>
+    <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
+        <setting name="charset">UTF-8</setting>
+        <setting name="projectFiles.separate">false</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
+        <setting name="target">file:/C:/Users/EmanuelaEpure/Documents/GitHub/hale-studio-5_0/hale/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex</setting>
+    </save-config>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.schemabuilder">
+        <setting name="charset">UTF-8</setting>
+        <setting name="resourceId">87062879-c0a0-43d2-9af3-1444a2c321db</setting>
+        <setting name="source">file:/C:/Users/EmanuelaEpure/Documents/GitHub/hale-studio-5_0/hale/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-schema.groovy</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.schemabuilder</setting>
+    </resource>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.schemabuilder">
+        <setting name="charset">UTF-8</setting>
+        <setting name="resourceId">fef220d5-4f13-4c63-abbd-6dbeb57dc079</setting>
+        <setting name="source">file:/C:/Users/EmanuelaEpure/Documents/GitHub/hale-studio-5_0/hale/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/target-schema.groovy</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.schemabuilder</setting>
+    </resource>
+    <resource action-id="eu.esdihumboldt.hale.io.instance.read.source" provider-id="eu.esdihumboldt.hale.io.instancebuilder">
+        <setting name="charset">UTF-8</setting>
+        <setting name="resourceId">42a12734-31f8-4e40-b75a-b46652ba8b17</setting>
+        <setting name="source">file:/C:/Users/EmanuelaEpure/Documents/GitHub/hale-studio-5_0/hale/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-instances.groovy</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.instancebuilder</setting>
+    </resource>
+    <file name="alignment.xml" location="mapping.halex.alignment.xml"/>
+    <file name="styles.sld" location="mapping.halex.styles.sld"/>
+</hale-project>

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex.alignment.xml
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex.alignment.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alignment xmlns="http://www.esdi-humboldt.eu/hale/alignment">
+    <cell relation="eu.esdihumboldt.hale.align.retype" id="C65e3f9d0-a6e3-4361-9271-7809dc90184b" priority="normal">
+        <source>
+            <class>
+                <type name="A" ns="source"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="T" ns="target"/>
+            </class>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.formattedstring" id="Ccae1fa23-5d3e-41a4-b707-db5593e95cc0" priority="normal">
+        <source name="var">
+            <property>
+                <type name="A" ns="source"/>
+                <child name="a" ns="source"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="T" ns="target"/>
+                <child name="a" ns="target"/>
+            </property>
+        </target>
+        <parameter value="pref_{a}" name="pattern"/>
+    </cell>
+</alignment>

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex.styles.sld
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/mapping.halex.styles.sld
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:UserStyle xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc">
+  <sld:Name>Default Styler</sld:Name>
+</sld:UserStyle>

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-instances.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-instances.groovy
@@ -1,0 +1,13 @@
+createCollection {
+	
+	/*
+	 * Sets of instances that are joined 
+	 */
+	
+	A {
+		a('a1') {
+			a1('a_a1')
+			a2('a_a2')
+		}
+	}
+}

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-schema.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/source-schema.groovy
@@ -1,0 +1,8 @@
+schema('source') {
+	A {
+		a(String) {
+			a1(cardinality: '?')
+			a2(cardinality: '?')
+		}
+	}
+}

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/target-instances.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/target-instances.groovy
@@ -1,0 +1,5 @@
+createCollection {	
+	T {
+		a('pref_a1')
+	}
+}

--- a/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/target-schema.groovy
+++ b/cst/plugins/eu.esdihumboldt.cst.test/testdata/formatting_string_instance/target-schema.groovy
@@ -1,0 +1,5 @@
+schema('target') {
+	T {
+		a()
+	}
+}


### PR DESCRIPTION
For a formatting string or a regex the string that appears into the occurring values as "eu.esdihumboldt.hale.common.instance.orient.storage.DatabaseHandle$InstanceHandle@1008ac5f" it's now represented with the value of the source.

ING-4156