### PR TITLE
chore(deps): update offline resources

### DIFF
--- a/platform/hale-platform.target
+++ b/platform/hale-platform.target
@@ -45,7 +45,7 @@
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 		<repository location="http://build-artifacts.wetransform.to/p2/offline-resources/current"/>
-		<unit id="to.wetransform.offlineresources.feature.feature.group" version="2024.3.8.bnd-W1hqew"/>
+		<unit id="to.wetransform.offlineresources.feature.feature.group" version="2024.3.15.bnd-bQhqgw"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 		<repository location="https://gitlab.wetransform.to/hale/hale-build-support/raw/0342a0f0c4f57a1ec4109f1fbe6e6fecd7dc722b/updatesites/platform"/>


### PR DESCRIPTION
Includes changes to INSPIRE schemas done after the hale 5.1 release,
that were not added yet, because the download mechanism was not working
as expected.