### PR TITLE
ci: pass Artifactory user and password to deployArtifacts task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,9 @@ jobs:
         working-directory: ./build    
 
       - name: Deploy Artifacts
+        env:
+          WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+          WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
         run: ./build.sh deployArtifacts
         working-directory: ./build   
 


### PR DESCRIPTION
It looks like the Artifactory secrets are not passed to the `deployArtifacts` task, so adding them to `env` explicitly here. If this solves the problem that the `uploadEclipse` step is currently not executed remains to be seen.