### PR TITLE
feat: add paramter "resolvedepth" in UI when downloading data via WFS

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/GetFeatureParamsPage.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/GetFeatureParamsPage.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Spinner;
 
 import eu.esdihumboldt.hale.ui.util.wizard.ConfigurationWizard;
@@ -35,8 +36,14 @@ import eu.esdihumboldt.hale.ui.util.wizard.ConfigurationWizardPage;
  */
 public class GetFeatureParamsPage extends ConfigurationWizardPage<WFSGetFeatureConfig> {
 
+	private final String RESOLVE_DEPTH_ALL = "*";
+
 	private Button maxFeaturesEnabled;
 	private Spinner maxFeatures;
+	private Button resolveLinks;
+	private Button resolveLinksRadioValue;
+	private Spinner resolveLinksValueSpinner;
+	private Button resolveLinksRadioAllValues;
 
 	/**
 	 * Create a new wizard page.
@@ -59,6 +66,21 @@ public class GetFeatureParamsPage extends ConfigurationWizardPage<WFSGetFeatureC
 		}
 		else {
 			configuration.setMaxFeatures(null);
+		}
+
+		if (resolveLinks.getSelection()) {
+			if (resolveLinksRadioValue.getSelection()) {
+				// Set resolve depth based on the value from the spinner
+				int selectedDepth = resolveLinksValueSpinner.getSelection();
+				configuration.setResolveDepth(String.valueOf(selectedDepth));
+			}
+			else if (resolveLinksRadioAllValues.getSelection()) {
+				// Set resolve depth to a predefined value for all values
+				configuration.setResolveDepth(RESOLVE_DEPTH_ALL);
+			}
+		}
+		else {
+			configuration.setResolveDepth(null);
 		}
 		return true;
 	}
@@ -90,6 +112,60 @@ public class GetFeatureParamsPage extends ConfigurationWizardPage<WFSGetFeatureC
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				maxFeatures.setEnabled(maxFeaturesEnabled.getSelection());
+			}
+		});
+
+		Group resolveLinksGroup = new Group(page, SWT.NONE);
+		resolveLinksGroup.setText("Resolve nested references (resolve depth)");
+		GridLayoutFactory.swtDefaults().numColumns(2).equalWidth(false).applyTo(resolveLinksGroup);
+		GridDataFactory.fillDefaults().grab(true, false).applyTo(resolveLinksGroup);
+
+		resolveLinks = new Button(resolveLinksGroup, SWT.CHECK);
+		resolveLinks.setText("Resolve nested references");
+		resolveLinks.setSelection(false);
+
+		// Add an empty string in the second column
+		Label emptyLabel = new Label(resolveLinksGroup, SWT.NONE);
+		emptyLabel.setText(""); // Set an empty string
+
+		resolveLinksRadioValue = new Button(resolveLinksGroup, SWT.RADIO);
+		resolveLinksRadioValue.setText("Resolve nested references to a depth of");
+		resolveLinksRadioValue.setSelection(true);
+		resolveLinksRadioValue.setEnabled(false);
+
+		resolveLinksValueSpinner = new Spinner(resolveLinksGroup, SWT.BORDER);
+		resolveLinksValueSpinner.setMinimum(1);
+		resolveLinksValueSpinner.setMaximum(10);
+		resolveLinksValueSpinner.setIncrement(1);
+		resolveLinksValueSpinner.setPageIncrement(1);
+		resolveLinksValueSpinner.setSelection(1);
+		resolveLinksValueSpinner.setEnabled(false);
+
+		resolveLinksRadioAllValues = new Button(resolveLinksGroup, SWT.RADIO);
+		resolveLinksRadioAllValues.setText("Resolve all immediate and nested references ('*')");
+		resolveLinksRadioAllValues.setEnabled(false);
+
+		// Add an empty string in the second column
+		Label emptyLabelAll = new Label(resolveLinksGroup, SWT.NONE);
+		emptyLabelAll.setText(""); // Set an empty string
+
+		resolveLinks.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				resolveLinksRadioValue.setEnabled(resolveLinks.getSelection());
+				if (resolveLinks.getSelection() && resolveLinksRadioValue.getSelection()) {
+					resolveLinksValueSpinner.setEnabled(resolveLinks.getSelection());
+				}
+				resolveLinksRadioAllValues.setEnabled(resolveLinks.getSelection());
+			}
+		});
+
+		resolveLinksRadioValue.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				resolveLinksValueSpinner.setEnabled(resolveLinksRadioValue.getSelection());
 			}
 		});
 

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/WFSGetFeatureConfig.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/WFSGetFeatureConfig.groovy
@@ -34,4 +34,5 @@ class WFSGetFeatureConfig {
 	BBox bbox
 	String bboxCrsUri
 	Integer maxFeatures
+	String resolveDepth
 }

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/WFSGetFeatureSource.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs.ui/src/eu/esdihumboldt/hale/io/wfs/ui/getfeature/WFSGetFeatureSource.java
@@ -105,6 +105,10 @@ public class WFSGetFeatureSource extends AbstractWFSSource<ImportProvider> {
 				}
 			}
 
+			if (result.getResolveDepth() != null && !result.getResolveDepth().isEmpty()) {
+				builder.addParameter("resolveDepth", result.getResolveDepth());
+			}
+
 			try {
 				sourceURL.setStringValue(builder.build().toString());
 				getPage().setErrorMessage(null);


### PR DESCRIPTION
Add in the dialog for the WFS GetCapability the possibility to choose if you want to add a resolveDepth for a request and how much would that be. Has been added a spinner to choose a number above 0 or the '*' for all the possible depths to be resolved.

ING-4129
Closes [#1085](https://github.com/halestudio/hale/issues/1085)