### PR TITLE
fix: fix provider definition for geometry.unifyWindingOrder parameters

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/plugin.xml
@@ -444,17 +444,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -722,17 +722,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -930,17 +930,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -1241,17 +1241,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -1423,17 +1423,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter

--- a/io/plugins/eu.esdihumboldt.hale.io.wfs/plugin.xml
+++ b/io/plugins/eu.esdihumboldt.hale.io.wfs/plugin.xml
@@ -65,17 +65,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for WFS-T instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -145,17 +145,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -384,17 +384,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for GML instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
          <providerParameter
@@ -563,17 +563,17 @@
                      value="clockwise">
                </enumerationValue>
                <enumerationValue
-                     value="counterClokwise">
+                     value="counterClockwise">
                </enumerationValue>
                <enumerationValue
-                     value="noChange">
+                     value="noChanges">
                </enumerationValue>
             </parameterEnumeration>
             <valueDescriptor
                   default="counterClockwise"
                   defaultDescription="By default, counterClockwise is set for WFS-T instance"
-                  sample="clockwise, noChange"
-                  sampleDescription="Unifying order can be set as Clockwise or no change in order (clockwise or noChange respectively).">
+                  sample="clockwise, noChanges"
+                  sampleDescription="Unifying order can be set as Clockwise or no changes in order (clockwise or noChanges respectively).">
             </valueDescriptor>
          </providerParameter>
                 <providerParameter


### PR DESCRIPTION
Up to now the `providerParameter` definitions for the parameter `geometry.unifyWindingOrder` contained values that were inconsistent with the corresponding enumeration `EnumWindingOrderTypes`.

Using the inconsistent values in CLI transformations could lead to unexpected results when using the value of the parameters given in the documentation that is derived from the `providerParameter` definitions.