### PR TITLE
ci: skip PR comment for PRs from forks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,7 +58,7 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Note: Write permissions cannot be granted from forks (only works for private repos requiring enabling a related setting)
 
     concurrency:
       group: artifacts-${{ github.ref }}
@@ -111,6 +111,7 @@ jobs:
           retention-days: 14
 
       - name: Find artifact comment if it exists
+        if: "! github.event.pull_request.head.repo.fork " # Only run with write permissions
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         with:
@@ -120,6 +121,7 @@ jobs:
           body-includes: "hale studio builds for this pull request:"
 
       - name: Comment with links to artifacts
+        if: "! github.event.pull_request.head.repo.fork " # Only run with write permissions
         id: comment-plan
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:


### PR DESCRIPTION
...because they don't have the required write permission.