### PR TITLE
fix: implicit narrowing conversion in compound assignment

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/storage/BrowseOrientInstanceCollection.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.instance.orient/src/eu/esdihumboldt/hale/common/instance/orient/storage/BrowseOrientInstanceCollection.java
@@ -228,7 +228,7 @@ public class BrowseOrientInstanceCollection implements InstanceCollection {
 	 */
 	@Override
 	public int size() {
-		int size = 0;
+		long size = 0;
 		DatabaseReference<ODatabaseDocumentTx> ref = database.openRead();
 		ODatabaseDocumentTx db = ref.getDatabase();
 		try {
@@ -244,7 +244,11 @@ public class BrowseOrientInstanceCollection implements InstanceCollection {
 			ref.dispose();
 		}
 
-		return size;
+		if (size > Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("The size exceeds the range of int.");
+		}
+
+		return (int) size;
 	}
 
 	/**

--- a/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/CalculateArea.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/CalculateArea.java
@@ -19,8 +19,9 @@ package eu.esdihumboldt.cst.functions.geometric;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ListMultimap;
 import org.locationtech.jts.geom.Geometry;
+
+import com.google.common.collect.ListMultimap;
 
 import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition;
 import eu.esdihumboldt.hale.common.align.transformation.engine.TransformationEngine;
@@ -74,7 +75,7 @@ public class CalculateArea extends AbstractSingleTargetPropertyTransformation<Tr
 
 		if (geoms.size() > 1) {
 
-			int area = 0;
+			double area = 0;
 
 			for (GeometryProperty<?> geoProp : geoms) {
 				area += geoProp.getGeometry().getArea();
@@ -93,7 +94,8 @@ public class CalculateArea extends AbstractSingleTargetPropertyTransformation<Tr
 			return geom.getArea();
 		}
 		else {
-			throw new TransformationException("Geometry for calculate area could not be retrieved.");
+			throw new TransformationException(
+					"Geometry for calculate area could not be retrieved.");
 		}
 
 	}

--- a/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/CalculateLength.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.geometric/src/eu/esdihumboldt/cst/functions/geometric/CalculateLength.java
@@ -19,8 +19,9 @@ package eu.esdihumboldt.cst.functions.geometric;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ListMultimap;
 import org.locationtech.jts.geom.Geometry;
+
+import com.google.common.collect.ListMultimap;
 
 import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition;
 import eu.esdihumboldt.hale.common.align.transformation.engine.TransformationEngine;
@@ -39,9 +40,9 @@ import eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty;
  * 
  * @author Kevin Mais
  */
-public class CalculateLength extends
-		AbstractSingleTargetPropertyTransformation<TransformationEngine> implements
-		CalculateLengthFunction {
+public class CalculateLength
+		extends AbstractSingleTargetPropertyTransformation<TransformationEngine>
+		implements CalculateLengthFunction {
 
 	/**
 	 * @see eu.esdihumboldt.hale.common.align.transformation.function.impl.AbstractSingleTargetPropertyTransformation#evaluate(java.lang.String,
@@ -75,7 +76,7 @@ public class CalculateLength extends
 
 		if (geoms.size() > 1) {
 
-			int length = 0;
+			double length = 0;
 
 			for (GeometryProperty<?> geoProp : geoms) {
 				length += geoProp.getGeometry().getLength();


### PR DESCRIPTION
Solve the vulnerability raised by CodeQL scanning for the implicit narrowing conversion in compound assignment.

ING-4370