### PR TITLE
fix: usage of a broken or risky cryptographic algorithm

### DIFF
--- a/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/groovy/internal/PreferencesGroovyService.java
+++ b/ui/plugins/eu.esdihumboldt.hale.ui/src/eu/esdihumboldt/hale/ui/service/groovy/internal/PreferencesGroovyService.java
@@ -15,8 +15,8 @@
 
 package eu.esdihumboldt.hale.ui.service.groovy.internal;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -317,9 +317,9 @@ public class PreferencesGroovyService extends DefaultGroovyService {
 			// not simply using hashCode, because it would be far to easy to
 			// modify the script in a undetectable way
 			try {
-				MessageDigest md = MessageDigest.getInstance("MD5");
+				MessageDigest md = MessageDigest.getInstance("SHA-256");
 				for (String script : scripts)
-					md.update(script.getBytes("UTF-8"));
+					md.update(script.getBytes(StandardCharsets.UTF_8));
 				byte[] hash = md.digest();
 				StringBuilder sb = new StringBuilder(2 * hash.length);
 				for (byte b : hash) {
@@ -329,9 +329,7 @@ public class PreferencesGroovyService extends DefaultGroovyService {
 				// Both exceptions cannot happen in a valid Java platform.
 				// Anyways, if they happen, execution should stop here!
 			} catch (NoSuchAlgorithmException e) {
-				throw new IllegalStateException("No MD5 MessageDigest!");
-			} catch (UnsupportedEncodingException e) {
-				throw new IllegalStateException("No UTF-8 Charset!");
+				throw new IllegalStateException("No SHA-256 MessageDigest!");
 			}
 		}
 		return scriptHash;


### PR DESCRIPTION
Replace MD5 with SH-256 because MD5 is susceptible to several vulnerabilities, including collision attacks. By switching from MD5 to SHA-256, we enhance the security of your hashing process, making it suitable for modern cryptographic applications.

ING-4368