### PR TITLE
fix: Xplan validation erroneously throws warning on missing objects

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/XPlanGmlInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/writer/XPlanGmlInstanceWriter.java
@@ -155,7 +155,7 @@ public class XPlanGmlInstanceWriter extends StreamGmlWriter {
 		for (String planId : planIdToInstancesMapping.keySet()) {
 			MultiInstanceCollection mic = new MultiInstanceCollection(
 					Arrays.asList(planIdToInstancesMapping.get(planId), nonPlanInstances));
-			ReferenceGraph<String> rg = new ReferenceGraph<String>(new XMLInspector(), mic);
+			ReferenceGraph<String> rg = new ReferenceGraph<String>(new XMLInspector(), mic, planId);
 
 			Iterator<InstanceCollection> p = rg.partition(1, reporter);
 			while (p.hasNext()) {


### PR DESCRIPTION
Closes #4318