### PR TITLE
fix: use correct representation of date and time when exporting XML/GML

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.gml/src/eu/esdihumboldt/hale/io/gml/internal/simpletype/SimpleTypeUtil.java
@@ -108,6 +108,7 @@ public class SimpleTypeUtil {
 					GDate gdate = builder.toGDate();
 
 					xmlDate.setGDateValue(gdate);
+					return xmlDate.getStringValue();
 				}
 				else if (simpleTypeValue instanceof XmlDateTime) {
 					XmlDateTime xmlDateTime = (XmlDateTime) simpleTypeValue;
@@ -124,6 +125,7 @@ public class SimpleTypeUtil {
 					GDate gdate = builder.toGDate();
 
 					xmlDateTime.setGDateValue(gdate);
+					return xmlDateTime.getStringValue();
 				}
 				else if (simpleTypeValue != null && simpleTypeValue instanceof XmlAnySimpleType) {
 					// Numbers should be handled here


### PR DESCRIPTION
Resolves issue introduced in 5.2.0 release.
Conversion to XmlDate and XmlDateTime was done but the result not used.