### PR TITLE
ci: disable publishing Maven artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           EOF
 
       - name: Test
-        run: ./build.sh integrationStage
+        run: ./build.sh commitStage # integrationStage no longer working due to outdated Docker client, tests are performed in hale-core
         working-directory: ./build
 
       - name: Product

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,13 +100,13 @@ jobs:
         run: ./upload-site.sh
         working-directory: ./build    
 
-      - name: Deploy Artifacts
-        env:
-          WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
-          WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
-          JAVA_TOOL_OPTIONS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=120'
-        run: ./build.sh deployArtifacts
-        working-directory: ./build   
+      # - name: Deploy Artifacts
+      #   env:
+      #     WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      #     WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      #     JAVA_TOOL_OPTIONS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=120'
+      #   run: ./build.sh deployArtifacts
+      #   working-directory: ./build   
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Test
         if: ${{ inputs.includeTests }}
-        run: ./build.sh integrationStage
+        run: ./build.sh commitStage # integrationStage no longer working due to outdated Docker client, tests are performed in hale-core
         working-directory: ./build
 
       - name: Publish Test Report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,38 +171,38 @@ jobs:
   
   # Note: one reason deploy artifacts is handled as separate job is that it currently usually fails (connection reset issue)
   # and should not impact the main release job
-  deploy-artifacts:
-    name: Deploy Maven artifacts
-    runs-on: ubuntu-latest
-    needs: [release]
-    if: ${{ !inputs.dryRun && needs.release.outputs.release-published != 'false' }}
-    steps:
-      - name: Setup Maven
-        uses: s4u/setup-maven-action@2f53a7669c7543a045d0bb6c92436df0c5a726f8 # v1.14.0
-        with:
-          java-version: 17
-          java-distribution: temurin
-          maven-version: 3.9.6
-          checkout-ref: refs/tags/v${{needs.release.outputs.release-version}} # check out release tag
+  # deploy-artifacts:
+  #   name: Deploy Maven artifacts
+  #   runs-on: ubuntu-latest
+  #   needs: [release]
+  #   if: ${{ !inputs.dryRun && needs.release.outputs.release-published != 'false' }}
+  #   steps:
+  #     - name: Setup Maven
+  #       uses: s4u/setup-maven-action@2f53a7669c7543a045d0bb6c92436df0c5a726f8 # v1.14.0
+  #       with:
+  #         java-version: 17
+  #         java-distribution: temurin
+  #         maven-version: 3.9.6
+  #         checkout-ref: refs/tags/v${{needs.release.outputs.release-version}} # check out release tag
 
-      - name: Deploy Artifacts
-        env:
-          WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
-          WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
-          JAVA_TOOL_OPTIONS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=120'
-        run: ./build.sh deployArtifacts
-        working-directory: ./build
+  #     - name: Deploy Artifacts
+  #       env:
+  #         WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+  #         WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+  #         JAVA_TOOL_OPTIONS: '-Dmaven.wagon.httpconnectionManager.ttlSeconds=120'
+  #       run: ./build.sh deployArtifacts
+  #       working-directory: ./build
 
-        # https://github.com/marketplace/actions/slack-notify-build
-      - name: Notify failure to Slack
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
-        with:
-          channel: build-failures
-          status: FAILED
-          color: danger
+  #       # https://github.com/marketplace/actions/slack-notify-build
+  #     - name: Notify failure to Slack
+  #       if: failure()
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+  #       uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+  #       with:
+  #         channel: build-failures
+  #         status: FAILED
+  #         color: danger
 
   publish-products:
     name: Publish products and update site


### PR DESCRIPTION
...to avoid conflicts with new hale-core repository.

Also remove execution of Docker integration tests that don't work due to the outdated Docker client.

ING-4375
ING-4362

Related to https://github.com/halestudio/hale-core/pull/11