### PR TITLE
fix: adapt name of system property for join handler

### DIFF
--- a/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Join.java
+++ b/cst/plugins/eu.esdihumboldt.cst.functions.core/src/eu/esdihumboldt/cst/functions/core/Join.java
@@ -54,7 +54,7 @@ public class Join extends Retype implements JoinFunction, InstanceIndexContribut
 	public InstanceHandler<? super TransformationEngine> getInstanceHandler() {
 		boolean useIndexJoinHandler = false;
 
-		String setting = System.getProperty("hale.functions.join.use_index_join_handler");
+		String setting = System.getProperty("hale.functions.use_index_join_handler");
 
 		if (setting == null) {
 			setting = System.getenv("HALE_FUNCTIONS_USE_INDEX_JOIN_HANDLER");


### PR DESCRIPTION
...to match similar name of similar properties and environment variables.
New name also matches the documentation.

Backported from https://github.com/halestudio/hale-core/pull/117