### PR TITLE
build: ensure that MSI installer file name starts with hale-studio

### DIFF
--- a/build/ant/build-msi.xml
+++ b/build/ant/build-msi.xml
@@ -412,7 +412,12 @@
 			<arg value="${build}/${wxs.file.ui}.wixobj" />
 		</exec>
 		
-		<copy tofile="${dist}/${buildId}-${version}-${tag.hyphen}${language}-${wix.arch}.msi"
+		<!-- If the buildId is HALE, use the prefix hale-studio -->
+		<condition property="msiPrefix" value="hale-studio" else="${buildId}">
+			<equals arg1="${buildId}" arg2="HALE" />
+		</condition>
+
+		<copy tofile="${dist}/${msiPrefix}-${version}-${tag.hyphen}${language}-${wix.arch}.msi"
 			file="${build}/${buildId}.msi" overwrite="yes" />
 	</target>
 	


### PR DESCRIPTION
Until now, file names of the MSI installer hale»studio followed the pattern

    HALE-<version>-<language>-<arch>.msi

Change this to

    hale-studio-<version>-<language>-<arch>.msi

but do not change the file names of MSI installers for other products.