### PR TITLE
ci: use AWS CLI v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1.0.7
         with:
-          version: 1
+          version: 2
 
       - name: Update site
         env:


### PR DESCRIPTION
Use AWS CLI v2 as v1 does not seem to be supported anymore on Ubuntu 24.04 (see also [this issue comment](https://github.com/unfor19/install-aws-cli-action/issues/31#issuecomment-2408688017).

@stempler Do you remember why v1 is used here explicitly? And is there a good way of testing a change like this without merging it to `master` first?