### PR TITLE
ci: include tar archive in published macOS build artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,9 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: hale studio (macos)
-          path: build/target/hale-studio-*macosx*.dmg
+          path: |
+            build/target/hale-studio-*macosx*.dmg
+            build/target/hale-studio-*macosx*.tar.gz
           retention-days: 90
 
       - name: Install AWS CLI


### PR DESCRIPTION
On the command line, a tar archive is easier to handle than the `.dmg` file.