### PR TITLE
chore: remove outdated GeoServer software site from defaults

### DIFF
--- a/build/gradle/commitAndProductionStage.gradle
+++ b/build/gradle/commitAndProductionStage.gradle
@@ -997,8 +997,6 @@ task createProductFeature(dependsOn: [ generatePomFiles, makeProductFile, makePr
 	
 		new File("$productFeaturePath/HALE.p2.inf").text = '''
 	instructions.configure=\
-	  addRepository(location:http${#58}//hale-geoserver.geo-solutions.it/,type:0,name:GeoServer App-Schema Plug-in for hale studio,enabled:true);\
-	  addRepository(location:http${#58}//hale-geoserver.geo-solutions.it/,type:1,name:GeoServer App-Schema Plug-in for hale studio,enabled:true);\
 	  addRepository(location:https${#58}//interactive-instruments.github.io/xtraserver-plugin-for-hale/,type:0,name:XtraServer Plug-in for hale studio,enabled:true);\
 	  addRepository(location:https${#58}//interactive-instruments.github.io/xtraserver-plugin-for-hale/,type:1,name:XtraServer Plug-in for hale studio,enabled:true);
 	'''


### PR DESCRIPTION
As the GeoServer App-Schema plugin is no longer maintained and does not work with recent versions of hale»studio, remove the software site from the list of defaults.

See also #1359 