### PR TITLE
fix: fix use of EntityMatch and condition for multiple candidates

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge.test/src/eu/esdihumboldt/hale/common/align/merge/test/impl/DefaultMergeCellMigratorTest.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge.test/src/eu/esdihumboldt/hale/common/align/merge/test/impl/DefaultMergeCellMigratorTest.groovy
@@ -460,7 +460,7 @@ class DefaultMergeCellMigratorTest extends AbstractMergeCellMigratorTest {
 	private void filterCheckNull(Cell migrated) {
 		JaxbAlignmentIO.printCell(migrated, System.out)
 
-		// the condition should be present on the source
+		// the condition should be absent on the source
 		def source = CellUtil.getFirstEntity(migrated.source).definition
 		def filter = source.propertyPath.empty ? source.filter : source.propertyPath[0].condition?.filter
 		assertNull(filter)

--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge.test/src/eu/esdihumboldt/hale/common/align/merge/test/impl/JoinRetainConditionsTest.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge.test/src/eu/esdihumboldt/hale/common/align/merge/test/impl/JoinRetainConditionsTest.groovy
@@ -63,12 +63,12 @@ class JoinRetainConditionsTest extends AbstractMergeCellMigratorTest {
 				assertEquals(expectedFilterA, filter.filterTerm)
 			}
 			else if (e.definition.definition.displayName == 'B') {
-				// expect filter part to have been propagated to A
+				// expect filter part to have been propagated to B
 				assertNotNull(filter)
 				assertEquals(expectedFilterB, filter.filterTerm)
 			}
 			else if (e.definition.definition.displayName == 'C') {
-				// expect filter part to have been propagated to A
+				// expect filter part to have been propagated to C
 				assertNotNull(filter)
 				assertEquals(expectedFilterC, filter.filterTerm)
 			}

--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/AbstractMergeCellMigrator.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/AbstractMergeCellMigrator.java
@@ -361,12 +361,12 @@ public abstract class AbstractMergeCellMigrator<C> extends DefaultCellMigrator
 					// try to transfer contexts
 					Entity singleSource = CellUtil.getFirstEntity(newSource);
 					if (singleSource != null) {
-						EntityDefinition transferedSource = AbstractMigration.translateContexts(
+						EntityDefinition transferredSource = AbstractMigration.translateContexts(
 								original, EntityMatch.of(singleSource.getDefinition()), migration,
 								null, log).getMatch();
 						ListMultimap<String, Entity> s = ArrayListMultimap.create();
 						s.put(newSource.keySet().iterator().next(),
-								AlignmentUtil.createEntity(transferedSource));
+								AlignmentUtil.createEntity(transferredSource));
 						newCell.setSource(s);
 					}
 				}
@@ -440,14 +440,14 @@ public abstract class AbstractMergeCellMigrator<C> extends DefaultCellMigrator
 						TypeDefinition inputType = input.getDefinition().getType();
 						if (input.getDefinition().getPropertyPath().isEmpty()
 								&& joinTypes.contains(inputType)) {
-							EntityDefinition transferedSource = AbstractMigration
+							EntityDefinition transferredSource = AbstractMigration
 									.translateContexts(originalSource.getDefinition(),
 											new EntityMatch(input.getDefinition(),
-													joinTypes.size() > 0, true),
+													joinTypes.size() > 1, true),
 											migration, inputType, log)
 									.getMatch();
-							joinTypeFilters.put(inputType, transferedSource.getFilter());
-							return AlignmentUtil.createEntity(transferedSource);
+							joinTypeFilters.put(inputType, transferredSource.getFilter());
+							return AlignmentUtil.createEntity(transferredSource);
 						}
 						else {
 							return input;
@@ -539,7 +539,7 @@ public abstract class AbstractMergeCellMigrator<C> extends DefaultCellMigrator
 		TypeEntityDefinition focus = joinConfig.getTypes().iterator().next();
 		AtomicReference<Filter> focusFilter = new AtomicReference<>();
 
-		boolean multipleSources = newCell.getSource().size() > 0;
+		boolean multipleSources = newCell.getSource().size() > 1;
 
 		// transfer context
 		newCell.setSource(ArrayListMultimap.create(Multimaps.transformValues(newCell.getSource(),
@@ -549,14 +549,14 @@ public abstract class AbstractMergeCellMigrator<C> extends DefaultCellMigrator
 					public Entity apply(Entity input) {
 						if (input.getDefinition().getPropertyPath().isEmpty()
 								&& input.getDefinition().getType().equals(focus.getType())) {
-							EntityDefinition transferedSource = AbstractMigration
+							EntityDefinition transferredSource = AbstractMigration
 									.translateContexts(originalSource.getDefinition(),
 											new EntityMatch(input.getDefinition(), multipleSources,
 													true),
 											migration, focus.getType(), log)
 									.getMatch();
-							focusFilter.set(transferedSource.getFilter());
-							return AlignmentUtil.createEntity(transferedSource);
+							focusFilter.set(transferredSource.getFilter());
+							return AlignmentUtil.createEntity(transferredSource);
 						}
 						else {
 							return input;

--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/AbstractMigration.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/AbstractMigration.groovy
@@ -56,7 +56,7 @@ abstract class AbstractMigration implements AlignmentMigration {
 		if (!matchedEntity.isPresent()) {
 			matchedEntity = findParentMatch(defaultEntity, preferRoot)
 			if (matchedEntity.present) {
-				log.warn "Inaccurate match of $entity to ${matchedEntity.get()} via parent entity"
+				log.warn "Inaccurate match of $entity to ${matchedEntity.get().match} via parent entity"
 			}
 		}
 

--- a/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/DefaultSchemaMigration.groovy
+++ b/common/plugins/eu.esdihumboldt.hale.common.align.merge/src/eu/esdihumboldt/hale/common/align/merge/impl/DefaultSchemaMigration.groovy
@@ -20,6 +20,7 @@ import javax.xml.namespace.QName
 
 import eu.esdihumboldt.hale.common.align.groovy.accessor.EntityAccessor
 import eu.esdihumboldt.hale.common.align.migrate.AlignmentMigration
+import eu.esdihumboldt.hale.common.align.migrate.EntityMatch
 import eu.esdihumboldt.hale.common.align.model.ChildContext
 import eu.esdihumboldt.hale.common.align.model.EntityDefinition
 import eu.esdihumboldt.hale.common.align.model.impl.PropertyEntityDefinition
@@ -44,7 +45,7 @@ class DefaultSchemaMigration implements AlignmentMigration {
 	}
 
 	@Override
-	public Optional<EntityDefinition> entityReplacement(EntityDefinition entity, TypeDefinition preferRoot, SimpleLog log) {
+	public Optional<EntityMatch> entityReplacement(EntityDefinition entity, TypeDefinition preferRoot, SimpleLog log) {
 
 		// default behavior - try to find entity in new schema, based on names w/o namespace
 
@@ -60,7 +61,7 @@ class DefaultSchemaMigration implements AlignmentMigration {
 
 		if (entity.propertyPath.empty) {
 			// type entity definition - yield
-			return Optional.<EntityDefinition>of(typeEntity)
+			return Optional.of(EntityMatch.of(typeEntity))
 		}
 		else {
 			// property entity definition -> follow the path
@@ -95,7 +96,8 @@ class DefaultSchemaMigration implements AlignmentMigration {
 				return Optional.empty()
 			}
 			else {
-				return Optional.ofNullable(applyContexts(candidate, entity))
+				EntityDefinition resolved = applyContexts(candidate, entity)
+				return resolved == null ? Optional.empty() : Optional.of(EntityMatch.of(resolved))
 			}
 		}
 	}

--- a/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/impl/UnmigratedCell.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.align/src/eu/esdihumboldt/hale/common/align/migrate/impl/UnmigratedCell.java
@@ -85,8 +85,8 @@ public class UnmigratedCell extends MutableCellDecorator {
 			@Override
 			public Optional<EntityMatch> entityReplacement(EntityDefinition entity,
 					TypeDefinition preferRoot, SimpleLog log) {
-				return Optional
-						.ofNullable(new EntityMatch(joinedMappings.get(entity), false, false));
+				EntityDefinition mapped = joinedMappings.get(entity);
+				return mapped == null ? Optional.empty() : Optional.of(EntityMatch.of(mapped));
 			}
 
 			@Override

--- a/common/plugins/eu.esdihumboldt.hale.common.filter/src/eu/esdihumboldt/hale/common/filter/AbstractGeotoolsFilter.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.filter/src/eu/esdihumboldt/hale/common/filter/AbstractGeotoolsFilter.java
@@ -242,7 +242,7 @@ public abstract class AbstractGeotoolsFilter
 								messagePrefix, toFilterTerm(part), splitType);
 					} catch (CQLException e) {
 						log.error(
-								"{0}A filter operand part of the filter's {1} condition was removed because no matches for the respective properties were found; error converting filter part to string",
+								"{0}A filter operand part of the filter''s {1} condition was removed because no matches for the respective properties were found; error converting filter part to string",
 								messagePrefix, splitType, e);
 					}
 				}
@@ -262,7 +262,7 @@ public abstract class AbstractGeotoolsFilter
 									splitType);
 						} catch (CQLException e) {
 							log.error(
-									"{0}A filter operand part of the filter's {2} condition contains references related to other types than {1}; error converting filter part to string",
+									"{0}A filter operand part of the filter''s {2} condition contains references related to other types than {1}; error converting filter part to string",
 									messagePrefix, focusType.getDisplayName(), splitType, e);
 						}
 					}

--- a/common/plugins/eu.esdihumboldt.hale.common.filter/src/eu/esdihumboldt/hale/common/filter/internal/EntityReplacementVisitor.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.filter/src/eu/esdihumboldt/hale/common/filter/internal/EntityReplacementVisitor.java
@@ -112,7 +112,7 @@ public class EntityReplacementVisitor extends DuplicatingFilterVisitor {
 	}
 
 	/**
-	 * @return if none the attempted replacements matched.
+	 * @return true if none of the attempted replacements matched.
 	 */
 	public boolean isAllMismatches() {
 		return total > 0 && matched == 0;


### PR DESCRIPTION
- DefaultSchemaMigration.entityReplacement now returns Optional<EntityMatch> (return type was mismatched with interface despite @CompileStatic due to Groovy generic erasure; would ClassCast at runtime on any call site using .map(EntityMatch::getMatch))
- UnmigratedCell returns Optional.empty() when lookup misses, rather than wrapping a null match inside EntityMatch.of()
- AbstractMergeCellMigrator: fix two multipleCandidates flags that used size() > 0 (always true) instead of size() > 1
- minor fixes

ING-5131