### PR TITLE
fix(geopackage): read boolean fields as Boolean instead of Integer (#1223)

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.test/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriterTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.test/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriterTest.groovy
@@ -597,6 +597,65 @@ class GeopackageInstanceWriterTest {
 		}
 	}
 
+	/**
+	 * Test that boolean field values are read back as Boolean, not as Integer.
+	 * Regression test for https://github.com/halestudio/hale/issues/1223
+	 */
+	@Test
+	void testWriteReadBoolean() {
+		Schema schema = new SchemaBuilder().schema {
+			entity {
+				name(String)
+				active(Boolean)
+			}
+		}
+
+		InstanceCollection instances = new InstanceBuilder(types: schema).createCollection {
+			entity {
+				name 'Alice'
+				active(Boolean.TRUE)
+			}
+			entity {
+				name 'Bob'
+				active(Boolean.FALSE)
+			}
+		}
+
+		withNewGeopackage(schema, instances) { File file ->
+			// verify schema: boolean column must have Boolean binding
+			def loadedSchema = GeopackageSchemaReaderTest.loadSchema(file)
+			def type = loadedSchema.getType(new QName(GeopackageSchemaBuilder.DEFAULT_NAMESPACE, 'entity'))
+			def activeProp = type.getChild(new QName('active')).asProperty()
+			assert activeProp != null
+			assert activeProp.getPropertyType().getConstraint(Binding.class).getBinding() == Boolean.class
+
+			// load instances and verify values are Boolean, not Integer
+			def loaded = GeopackageInstanceReaderTest.loadInstances(loadedSchema, file)
+			assertEquals(2, loaded.size())
+
+			loaded.iterator().withCloseable {
+				while (it.hasNext()) {
+					Instance inst = it.next()
+					def name = inst.p.name.value()
+					def active = inst.p.active.value()
+
+					assert active instanceof Boolean : "Expected Boolean but got ${active?.class?.name}: $active"
+
+					switch (name) {
+						case 'Alice':
+							assert active == Boolean.TRUE
+							break
+						case 'Bob':
+							assert active == Boolean.FALSE
+							break
+						default:
+							throw new IllegalStateException("Unexpected name: $name")
+					}
+				}
+			}
+		}
+	}
+
 	@Test
 	void testNoSpatialIndexCreation() {
 		Schema schema = new SchemaBuilder().schema {

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/internal/TableInstanceBuilder.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/internal/TableInstanceBuilder.groovy
@@ -35,6 +35,7 @@ import eu.esdihumboldt.hale.common.schema.model.PropertyDefinition
 import eu.esdihumboldt.hale.common.schema.model.TypeDefinition
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.Cardinality
 import eu.esdihumboldt.hale.common.schema.model.constraint.property.NillableFlag
+import eu.esdihumboldt.hale.common.schema.model.constraint.type.Binding
 import eu.esdihumboldt.hale.common.schema.model.constraint.type.GeometryMetadata
 import eu.esdihumboldt.hale.io.geopackage.GeopackageSchemaBuilder
 import groovy.transform.CompileStatic
@@ -159,6 +160,13 @@ class TableInstanceBuilder {
 					}
 
 					Object value = row.getResultSet().getObject(columnName)
+
+					// SQLite stores BOOLEAN columns as INTEGER (0/1); convert if the schema expects Boolean
+					if (value instanceof Number && !isGeometry) {
+						if (property.propertyType.getConstraint(Binding).binding == Boolean) {
+							value = ((Number) value).intValue() != 0
+						}
+					}
 
 					// geometry conversion
 					if (value != null) {


### PR DESCRIPTION
## Summary

Fixes #1223

GeoPackage stores `BOOLEAN` columns as `INTEGER` (0/1) in SQLite. When reading
data back, JDBC `ResultSet.getObject()` returns a `java.lang.Integer`, while the
schema (built by `GeopackageSchemaBuilder`) correctly declares `Boolean.class` as
the binding for such columns. As a result, boolean values were surfaced as `1`/`0`
instead of `true`/`false`.

**Fix:** In `TableInstanceBuilder.groovy`, after reading the raw JDBC value, convert
`Number -> Boolean` when the target property binding is `Boolean.class`.

**Affected file:** `eu.esdihumboldt.hale.io.geopackage/internal/TableInstanceBuilder.groovy`

## Test

Added `testWriteReadBoolean()` to `GeopackageInstanceWriterTest.groovy`:
- Writes two records with `Boolean.TRUE` and `Boolean.FALSE` values
- Verifies the schema binding is `Boolean.class` (not `Integer`)
- Verifies the read-back values are `Boolean` instances with correct `true`/`false` values

---

Author: The Wroclaw Institute of Spatial Information and Artificial Intelligence
(WIZIPISI - Wrocławski Instytut Zastosowań Informacji Przestrzennej i Sztucznej Inteligencji)