### PR TITLE
Fix GeoPackage writer silently appending data when target file is in use

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage.test/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriterTest.groovy
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage.test/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriterTest.groovy
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2020 wetransform GmbH
  * 
  * All rights reserved. This program and the accompanying materials are made
@@ -16,6 +16,7 @@
 package eu.esdihumboldt.hale.io.geopackage
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
 import java.nio.file.Files
@@ -26,6 +27,7 @@ import java.util.function.Consumer
 
 import javax.xml.namespace.QName
 
+import org.junit.Assume
 import org.junit.Test
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
@@ -653,6 +655,55 @@ class GeopackageInstanceWriterTest {
 					}
 				}
 			}
+		}
+	}
+
+	/**
+	 * Regression test for https://github.com/halestudio/hale/issues/1201
+	 * When the target GeoPackage file is locked (e.g. open in QGIS), the writer
+	 * must fail with an error instead of silently appending data to the existing file.
+	 */
+	@Test
+	void testOverwriteFailsWhenFileInUse() {
+		// On Linux, open file handles do not prevent deletion (File.delete() returns true
+		// regardless). The bug and the locking mechanism are Windows-specific.
+		Assume.assumeTrue("Test only valid on Windows", System.getProperty("os.name")?.toLowerCase()?.contains("windows"))
+
+		Schema schema = new SchemaBuilder().schema {
+			items {
+				name(String)
+			}
+		}
+
+		InstanceCollection instances = new InstanceBuilder(types: schema).createCollection {
+			items {
+				name 'test'
+			}
+		}
+
+		Path tmpFile = Files.createTempFile('overwrite_inuse_test', '.gpkg')
+		try {
+			// First write succeeds
+			writeInstances(tmpFile.toFile(), schema, instances)
+
+			// Simulate file in use by holding an open read-write handle (as QGIS would on Windows)
+			new RandomAccessFile(tmpFile.toFile(), 'rw').withCloseable {
+				// Attempt to overwrite while file is locked — writer must report failure
+				GeopackageInstanceWriter writer = new GeopackageInstanceWriter()
+				writer.setTarget(new FileIOSupplier(tmpFile.toFile()))
+				def ss = new DefaultSchemaSpace()
+				ss.addSchema(schema)
+				writer.setTargetSchema(ss)
+				writer.setInstances(instances)
+				writer.setOverwriteTargetFile(true)
+
+				IOReport report = writer.execute(new LogProgressIndicator())
+
+				assertFalse('Writer should fail when target file is in use', report.isSuccess())
+				assertFalse('Report should contain an error', report.getErrors().isEmpty())
+			}
+		} finally {
+			Files.deleteIfExists(tmpFile)
 		}
 	}
 

--- a/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.geopackage/src/eu/esdihumboldt/hale/io/geopackage/GeopackageInstanceWriter.java
@@ -199,7 +199,10 @@ public class GeopackageInstanceWriter extends AbstractGeoInstanceWriter {
 					.as(Boolean.class, false);
 			if (file.exists() && (file.length() == 0L || overwriteTargetFile)) {
 				// overwrite empty existing file or if requested via setting
-				file.delete();
+				if (!file.delete()) {
+					throw new IOException("Cannot overwrite existing GeoPackage file (file may be in use): "
+							+ file.getAbsolutePath());
+				}
 			}
 			if (!file.exists()) {
 				GeoPackageManager.create(file);


### PR DESCRIPTION
## Summary

Fixes #1201

When the **Overwrite target file if it exists** option is enabled but the target .gpkg file cannot be deleted (e.g. it is locked by QGIS or another process on Windows), File.delete() returns False silently. The writer then opens the existing file and **appends** data instead of overwriting it — resulting in duplicated records with no error reported to the user.

### Root cause

In GeopackageInstanceWriter.java (around line 202), the return value of File.delete() was not checked:

```java
// before fix
file.delete();  // silently returns false if file is locked
```

### Fix

Check the return value and throw IOException if deletion fails:

```java
if (!file.delete()) {
    throw new IOException("Cannot overwrite existing GeoPackage file (file may be in use): "
            + file.getAbsolutePath());
}
```

The exception is caught by the surrounding 	ry/catch in execute(), which marks the report as failed and records the error — so the user sees a clear error message instead of silently corrupted output.

### Test

Added 	estOverwriteFailsWhenFileInUse() to GeopackageInstanceWriterTest:
- Writes a GeoPackage file
- Simulates "file in use" by holding an open RandomAccessFile handle (mirrors Windows file locking behaviour, e.g. when QGIS has the file open)
- Asserts that the writer reports failure and records an error

---

Submitted by: **The Wroclaw Institute of Spatial Information and Artificial Intelligence**
(WIZIPISI — Wrocławski Instytut Zastosowań Informacji Przestrzennej i Sztucznej Inteligencji)