### PR TITLE
Fix classification file export omitting empty target values

### DIFF
--- a/common/plugins/eu.esdihumboldt.hale.common.lookup/src/eu/esdihumboldt/hale/common/lookup/impl/LookupTableImpl.java
+++ b/common/plugins/eu.esdihumboldt.hale.common.lookup/src/eu/esdihumboldt/hale/common/lookup/impl/LookupTableImpl.java
@@ -23,10 +23,8 @@ import java.util.Set;
 
 import net.jcip.annotations.Immutable;
 
-import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Maps;
 
 import eu.esdihumboldt.hale.common.core.io.Value;
 import eu.esdihumboldt.hale.common.lookup.LookupTable;
@@ -48,8 +46,7 @@ public class LookupTableImpl implements LookupTable {
 	 */
 	public LookupTableImpl(Map<Value, Value> table) {
 		super();
-		// ignore null values, so their entries don't show up in any methods
-		this.table = new LinkedHashMap<Value, Value>(Maps.filterValues(table, Predicates.notNull()));
+		this.table = new LinkedHashMap<Value, Value>(table);
 	}
 
 	@Override
@@ -67,7 +64,9 @@ public class LookupTableImpl implements LookupTable {
 		ListMultimap<Value, Value> result = ArrayListMultimap.create();
 
 		for (Entry<Value, Value> entry : table.entrySet()) {
-			result.put(entry.getValue(), entry.getKey());
+			if (entry.getValue() != null) {
+				result.put(entry.getValue(), entry.getKey());
+			}
 		}
 
 		return result;

--- a/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/internal/CSVLookupWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.csv/src/eu/esdihumboldt/hale/io/csv/writer/internal/CSVLookupWriter.java
@@ -66,7 +66,9 @@ public class CSVLookupWriter extends AbstractLookupExport {
 		writer.writeNext(values);
 
 		for (Value key : table.keySet()) {
-			values = new String[] { key.as(String.class), table.get(key).as(String.class) };
+			Value targetValue = table.get(key);
+			String targetStr = (targetValue != null) ? targetValue.as(String.class) : "";
+			values = new String[] { key.as(String.class), targetStr };
 			writer.writeNext(values);
 		}
 		writer.close();

--- a/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSLookupTableWriter.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xls/src/eu/esdihumboldt/hale/io/xls/writer/XLSLookupTableWriter.java
@@ -133,7 +133,7 @@ public class XLSLookupTableWriter extends AbstractLookupExport {
 
 			Value entry = table.get(key);
 			cell = row.createCell(1);
-			cell.setCellValue(entry.as(String.class));
+			cell.setCellValue((entry != null) ? entry.as(String.class) : "");
 			cell.setCellStyle(rowStyle);
 			rownum++;
 		}


### PR DESCRIPTION
## Summary

When using "Fill source values with enumeration" in the classification mapping, the resulting CSV/XLS export silently dropped all rows where the target value was not yet mapped. This made it impossible to send a partially-filled classification to an expert for completion.

**Root cause:** LookupTableImpl constructor filtered out all 
ull target values via Predicates.notNull(), so they never reached the export writers.

**Fix:**
- Remove the 
otNull() filter in LookupTableImpl so entries with null target values are preserved in the table.
- Guard 
everse() to skip null values (ArrayListMultimap does not accept null keys).
- Update CSVLookupWriter and XLSLookupTableWriter to write an empty string instead of calling .as(String.class) on a null Value.

Fixes #959
Submitted by: The Wroclaw Institute of Spatial Information and Artificial Intelligence
(WIZIPISI — Wrocławski Instytut Zastosowań Informacji Przestrzennej i Sztucznej Inteligencji)