### PR TITLE
Reduce log level for noisy XML schema import messages

### DIFF
--- a/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/XmlSchemaReader.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/XmlSchemaReader.java
@@ -1111,8 +1111,7 @@ public class XmlSchemaReader extends AbstractSchemaReader {
 		}
 		else if (particle instanceof XmlSchemaAny) {
 			// XXX ignore for now
-			reporter.info(new IOMessageImpl("Particle that allows any element is not supported.",
-					null, particle.getLineNumber(), particle.getLinePosition()));
+			_log.debug("Particle that allows any element is not supported.");
 		}
 		else {
 			reporter.error(new IOMessageImpl(

--- a/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/internal/XmlTypeUtil.java
+++ b/io/plugins/eu.esdihumboldt.hale.io.xsd/src/eu/esdihumboldt/hale/io/xsd/reader/internal/XmlTypeUtil.java
@@ -28,6 +28,9 @@ import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 
+import de.fhg.igd.slf4jplus.ALogger;
+import de.fhg.igd.slf4jplus.ALoggerFactory;
+
 import org.apache.ws.commons.schema.XmlSchemaEnumerationFacet;
 import org.apache.ws.commons.schema.XmlSchemaFacet;
 import org.apache.ws.commons.schema.XmlSchemaFractionDigitsFacet;
@@ -93,7 +96,7 @@ import eu.esdihumboldt.util.validator.Validator;
  */
 public abstract class XmlTypeUtil {
 
-//	private static final ALogger log = ALoggerFactory.getLogger(TypeUtil.class);
+	private static final ALogger log = ALoggerFactory.getLogger(XmlTypeUtil.class);
 //	
 //	private static final AGroup TYPE_RESOLVE = AGroupFactory.getGroup(Messages.getString("TypeUtil.0")); //$NON-NLS-1$
 
@@ -414,8 +417,7 @@ public abstract class XmlTypeUtil {
 						Integer.parseInt(facet.getValue().toString())));
 			}
 			else if (facet instanceof XmlSchemaWhiteSpaceFacet) {
-				reporter.info(new IOMessageImpl("White space facet not supported", null,
-						facet.getLineNumber(), facet.getLinePosition()));
+				log.debug("White space facet not supported");
 				// Nothing to validate according to w3.
 				// Values should be processed according to rule?
 			}


### PR DESCRIPTION
## Summary

Two log messages during XML schema import were emitted at INFO level, causing excessive noise in the log for valid schema constructs that the reader simply skips:

- Unsupported white space facet ? reduced to DEBUG
- Unsupported XmlSchemaAny particle ? reduced to DEBUG

These messages appear for every occurrence and provide no actionable information for most users; debug level is more appropriate.

Fixes #965
Submitted by: The Wroclaw Institute of Spatial Information and Artificial Intelligence
(WIZIPISI — Wrocławski Instytut Zastosowań Informacji Przestrzennej i Sztucznej Inteligencji)